### PR TITLE
Fix: Player in creative mode cannot use smithing table to upgrade tools

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -3955,7 +3955,6 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                 }
 
                 InventoryTransactionPacket transactionPacket = (InventoryTransactionPacket) packet;
-                System.out.println(transactionPacket);
                 // Nasty hack because the client won't change the right packet in survival when creating netherite stuff,
                 // so we are emulating what Mojang should be sending
                 if (getWindowById(SMITHING_WINDOW_ID) instanceof SmithingInventory smithingInventory) {

--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -3958,9 +3958,9 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
 
                 // Nasty hack because the client won't change the right packet in survival when creating netherite stuff
                 // so we are emulating what Mojang should be sending
-                if(getWindowById(SMITHING_WINDOW_ID) instanceof SmithingInventory smithingInventory){
+                if (getWindowById(SMITHING_WINDOW_ID) instanceof SmithingInventory smithingInventory) {
                     if (transactionPacket.transactionType == InventoryTransactionPacket.TYPE_MISMATCH
-                            || transactionPacket.transactionType == InventoryTransactionPacket.TYPE_NORMAL){
+                            || transactionPacket.transactionType == InventoryTransactionPacket.TYPE_NORMAL) {
                         if (!smithingInventory.getResult().isNull()) {
                             InventoryTransactionPacket fixedPacket = new InventoryTransactionPacket();
                             fixedPacket.isRepairItemPart = true;

--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -3955,12 +3955,16 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                 }
 
                 InventoryTransactionPacket transactionPacket = (InventoryTransactionPacket) packet;
-
-                // Nasty hack because the client won't change the right packet in survival when creating netherite stuff
+                System.out.println(transactionPacket);
+                // Nasty hack because the client won't change the right packet in survival when creating netherite stuff,
                 // so we are emulating what Mojang should be sending
                 if (getWindowById(SMITHING_WINDOW_ID) instanceof SmithingInventory smithingInventory) {
-                    if (transactionPacket.transactionType == InventoryTransactionPacket.TYPE_MISMATCH
-                            || transactionPacket.transactionType == InventoryTransactionPacket.TYPE_NORMAL) {
+                    // When players in creative mode are about to see the result, a fixed packet can help.
+                    // It's so weird that players in survival will receive a mismatch-type packet, while players in creative won't.
+                    // Instead, sending a normal packet upon getting result item.
+                    boolean creativeSmithingAboutToGetResult = this.isCreative() && (transactionPacket.transactionType == InventoryTransactionPacket.TYPE_NORMAL)
+                            && !smithingInventory.getEquipment().isNull() && !smithingInventory.getIngredient().isNull() && !smithingInventory.getResult().isNull();
+                    if ((transactionPacket.transactionType == InventoryTransactionPacket.TYPE_MISMATCH) || creativeSmithingAboutToGetResult) {
                         if (!smithingInventory.getResult().isNull()) {
                             InventoryTransactionPacket fixedPacket = new InventoryTransactionPacket();
                             fixedPacket.isRepairItemPart = true;

--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -3959,10 +3959,9 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                 // so we are emulating what Mojang should be sending
                 if (getWindowById(SMITHING_WINDOW_ID) instanceof SmithingInventory smithingInventory) {
                     // When players in creative mode are about to see the result, a fixed packet can help.
-                    // It's so weird that players in survival will receive a mismatch-type packet, while players in creative won't.
-                    // Instead, sending a normal packet upon getting result item.
-                    boolean creativeSmithingAboutToGetResult = this.isCreative() && (transactionPacket.transactionType == InventoryTransactionPacket.TYPE_NORMAL)
-                            && !smithingInventory.getEquipment().isNull() && !smithingInventory.getIngredient().isNull() && !smithingInventory.getResult().isNull();
+                    // One of those actions in the inventory transaction packet contains to-do sourceType,
+                    // which can serve as a symbol to detect whether player is upgrading an item or not.
+                    boolean creativeSmithingAboutToGetResult = this.isCreative() && (transactionPacket.transactionType == InventoryTransactionPacket.TYPE_NORMAL) && Arrays.stream(transactionPacket.actions).anyMatch(action -> action.sourceType == NetworkInventoryAction.SOURCE_TODO);
                     if ((transactionPacket.transactionType == InventoryTransactionPacket.TYPE_MISMATCH) || creativeSmithingAboutToGetResult) {
                         if (!smithingInventory.getResult().isNull()) {
                             InventoryTransactionPacket fixedPacket = new InventoryTransactionPacket();

--- a/src/main/java/cn/nukkit/inventory/SmithingInventory.java
+++ b/src/main/java/cn/nukkit/inventory/SmithingInventory.java
@@ -111,6 +111,7 @@ public class SmithingInventory extends FakeBlockUIComponent {
 
         this.clear(EQUIPMENT);
         this.clear(INGREDIENT);
+        this.getHolder().getInventory().clear(50);
     }
 
     public Item getCurrentResult() {

--- a/src/main/java/cn/nukkit/inventory/SmithingInventory.java
+++ b/src/main/java/cn/nukkit/inventory/SmithingInventory.java
@@ -111,7 +111,7 @@ public class SmithingInventory extends FakeBlockUIComponent {
 
         this.clear(EQUIPMENT);
         this.clear(INGREDIENT);
-        this.getHolder().getInventory().clear(50);
+        this.getHolder().getInventory().clear(CREATED_ITEM_OUTPUT_UI_SLOT);
     }
 
     public Item getCurrentResult() {


### PR DESCRIPTION
## Problem
Related to the issule [#90](https://github.com/MemoriesOfTime/NukkitPetteriM1Edition/issues/90)

> If players **in creative mode** try to **upgrade an item in smithing table**, then **a black screen appears**.

## Previous
https://github.com/MemoriesOfTime/Nukkit-MOT/assets/61799945/ba05d6b6-461a-4323-92b7-c5f92d31c07c

## Now(After fix)
https://github.com/MemoriesOfTime/Nukkit-MOT/assets/61799945/7f5002ef-ce01-4e84-a008-501962ab824f
