### PR TITLE
Fixed a vulnerability in TextPacket

### DIFF
--- a/src/main/java/cn/nukkit/network/protocol/TextPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/TextPacket.java
@@ -64,6 +64,9 @@ public class TextPacket extends DataPacket {
             case TYPE_JUKEBOX_POPUP:
                 this.message = this.getString();
                 int count = (int) this.getUnsignedVarInt();
+                if (count > 10) {
+                    break;
+                }
                 this.parameters = new String[Math.min(count, 128)];
                 for (int i = 0; i < this.parameters.length; i++) {
                     this.parameters[i] = this.getString();


### PR DESCRIPTION
If a proxy client or bot sends too many Jukebox popups, the server may crash.