### PR TITLE
Add new skin size

### DIFF
--- a/src/main/java/cn/nukkit/entity/data/Skin.java
+++ b/src/main/java/cn/nukkit/entity/data/Skin.java
@@ -28,7 +28,7 @@ public class Skin {
 
     // Currently, Minecraft character creator's skin picture size is 256*256.
     // Therefore, we need this to make sure Binary#getSkin() and BinaryStream#setSkin() is available for Mojang's one.
-    public static final int SKIN_256_256_SIZE_MJ = 262144;
+    public static final int SKIN_256_256_SIZE = 262144;
 
     private static final int MAX_DATA_SIZE = 262144;
 

--- a/src/main/java/cn/nukkit/entity/data/Skin.java
+++ b/src/main/java/cn/nukkit/entity/data/Skin.java
@@ -26,6 +26,10 @@ public class Skin {
     public static final int SKIN_128_64_SIZE = 32768;
     public static final int SKIN_128_128_SIZE = 65536;
 
+    // Currently, Minecraft character creator's skin picture size is 256*256.
+    // Therefore, we need this to make sure Binary#getSkin() and BinaryStream#setSkin() is available for Mojang's one.
+    public static final int SKIN_256_256_SIZE_MJ = 262144;
+
     private static final int MAX_DATA_SIZE = 262144;
 
     public static final String GEOMETRY_CUSTOM = convertLegacyGeometryName("geometry.humanoid.custom");

--- a/src/main/java/cn/nukkit/utils/SerializedImage.java
+++ b/src/main/java/cn/nukkit/utils/SerializedImage.java
@@ -44,6 +44,8 @@ public class SerializedImage {
                 return new SerializedImage(128, 64, skinData);
             case SKIN_128_128_SIZE:
                 return new SerializedImage(128, 128, skinData);
+            case SKIN_256_256_SIZE_MJ:
+                return new SerializedImage(256, 256, skinData);
         }
         throw new IllegalArgumentException("Unknown legacy skin size");
     }

--- a/src/main/java/cn/nukkit/utils/SerializedImage.java
+++ b/src/main/java/cn/nukkit/utils/SerializedImage.java
@@ -44,7 +44,7 @@ public class SerializedImage {
                 return new SerializedImage(128, 64, skinData);
             case SKIN_128_128_SIZE:
                 return new SerializedImage(128, 128, skinData);
-            case SKIN_256_256_SIZE_MJ:
+            case SKIN_256_256_SIZE:
                 return new SerializedImage(256, 256, skinData);
         }
         throw new IllegalArgumentException("Unknown legacy skin size");


### PR DESCRIPTION
Mojang used a special skin size (256 * 256) in character creator skins. If we want to save this kind by BinaryStream#setSkin or read by BinaryStream#setSkin, this skin size should be supported.