### PR TITLE
Blocklantern

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockCauldron.java
+++ b/src/main/java/cn/nukkit/block/BlockCauldron.java
@@ -388,7 +388,7 @@ public class BlockCauldron extends BlockSolidMeta implements BlockEntityHolder<B
     private void consumePotion(Item item, Player player) {
         if (player.isSurvival() || player.isAdventure()) {
             if (item.getCount() == 1) {
-                player.getInventory().setItemInHand(new ItemBlock(new BlockAir()));
+                player.getInventory().setItemInHand(Item.get(ItemID.GLASS_BOTTLE));
             } else if (item.getCount() > 1) {
                 item.setCount(item.getCount() - 1);
                 player.getInventory().setItemInHand(item);

--- a/src/main/java/cn/nukkit/block/BlockLantern.java
+++ b/src/main/java/cn/nukkit/block/BlockLantern.java
@@ -109,22 +109,17 @@ public class BlockLantern extends BlockFlowable {
 
     @Override
     public double getResistance() {
-        return 17.5;
+        return 3.5;
     }
 
     @Override
     public double getHardness() {
-        return 5.0;
+        return 3.5;
     }
 
     @Override
     public boolean canHarvestWithHand() {
         return false;
-    }
-
-    @Override
-    public int getToolType() {
-        return ItemTool.TYPE_PICKAXE;
     }
 
     @Override
@@ -155,11 +150,6 @@ public class BlockLantern extends BlockFlowable {
     @Override
     public double getMaxZ() {
         return z + (11.0/16);
-    }
-
-    @Override
-    public int getToolTier() {
-        return ItemTool.TIER_WOODEN;
     }
 
     @Override


### PR DESCRIPTION
修复灯笼悬空不掉落物品，貌似以及不能被空手破坏，挖掘进度与挖掘贴图不一致(未修复)