### PR TITLE
Bad level tick

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -4997,7 +4997,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
             this.perm = null;
         }
 
-        this.inventory = null;
+        this.inventory = new PlayerInventory(null);
         this.chunk = null;
 
         this.server.removePlayer(this);


### PR DESCRIPTION
[main] ERROR - Could not tick level "survival": java.lang.NullPointerException: Cannot invoke "cn.nukkit.inventory.PlayerInventory.getItemInHandFast()" because the return value of "cn.nukkit.Player.getInventory()" is null
	at cn.nukkit.entity.passive.EntityRabbit.targetOption(EntityRabbit.java:61)
	at cn.nukkit.entity.EntityJumping.checkTarget(EntityJumping.java:42)
	at cn.nukkit.entity.EntityJumping.updateMove(EntityJumping.java:143)
	at cn.nukkit.entity.passive.EntityJumpingAnimal.onUpdate(EntityJumpingAnimal.java:28)
	at cn.nukkit.level.Level.doTick(Level.java:1012)
	at cn.nukkit.Server.checkTickUpdates(Server.java:1343)
	at cn.nukkit.Server.tick(Server.java:1419)
	at cn.nukkit.Server.tickProcessor(Server.java:1139)
	at cn.nukkit.Server.start(Server.java:1107)
	at cn.nukkit.Server.<init>(Server.java:821)
	at cn.nukkit.Nukkit.main(Nukkit.java:87)