### PR TITLE
CraftingGrid clear on cancel PlayerDropItemEvent

### DIFF
--- a/src/main/java/cn/nukkit/inventory/transaction/action/DropItemAction.java
+++ b/src/main/java/cn/nukkit/inventory/transaction/action/DropItemAction.java
@@ -27,6 +27,7 @@ public class DropItemAction extends InventoryAction {
         source.getServer().getPluginManager().callEvent(ev = new PlayerDropItemEvent(source, this.targetItem));
 
         if(ev.isCancelled()) {
+            source.getUIInventory().clearAll();
             source.stopAction();
         }
 

--- a/src/main/java/cn/nukkit/network/process/processor/v113/DropItemProcessor_v113.java
+++ b/src/main/java/cn/nukkit/network/process/processor/v113/DropItemProcessor_v113.java
@@ -35,6 +35,7 @@ public class DropItemProcessor_v113 extends DataPacketProcessor<DropItemPacketV1
         PlayerDropItemEvent dropItemEvent = new PlayerDropItemEvent(player, item);
         Server.getInstance().getPluginManager().callEvent(dropItemEvent);
         if (dropItemEvent.isCancelled()) {
+            player.getUIInventory().clearAll();
             inventory.sendContents(player);
             return;
         }


### PR DESCRIPTION
If the inventory is full, they drop when the event is canceled, they remain in the inventory in this field, when switching to another mode, they also remain there