### PR TITLE
fix: JsonSyntaxException

### DIFF
--- a/src/main/java/cn/nukkit/form/window/FormWindowCustom.java
+++ b/src/main/java/cn/nukkit/form/window/FormWindowCustom.java
@@ -1,8 +1,10 @@
 package cn.nukkit.form.window;
 
+import cn.nukkit.Server;
 import cn.nukkit.form.element.*;
 import cn.nukkit.form.response.FormResponseCustom;
 import cn.nukkit.form.response.FormResponseData;
+import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
 
 import java.util.ArrayList;
@@ -75,7 +77,13 @@ public class FormWindowCustom extends FormWindow {
             return;
         }
 
-        List<String> elementResponses = GSON.fromJson(data, new ListTypeToken().getType());
+        List<String> elementResponses;
+        try {
+            elementResponses = GSON.fromJson(data, new ListTypeToken().getType());
+        } catch (JsonSyntaxException e) {
+            Server.getInstance().getLogger().error("An error occurred while deserializing the form");
+            return;
+        }
 
         int i = 0;
 


### PR DESCRIPTION
This could have caused an error and shutdown the RakNetInterface:
`com.google.gson.JsonSyntaxException: java.lang.IllegalStateException: Expected BEGIN_ARRAY but was NUMBER at line 1 column 2 path $`