### PR TITLE
fix: boolean flip, release byteBuf.

### DIFF
--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -3108,7 +3108,7 @@ public class Server {
         }
 
         this.levelDbCache = this.getPropertyInt("leveldb-cache-mb", 80);
-        this.useNativeLevelDB = this.getPropertyBoolean("use-native-leveldb", false);
+        this.useNativeLevelDB = this.getPropertyBoolean("use-native-leveldb", true);
         this.enableRawOres = this.getPropertyBoolean("enable-raw-ores", true);
     }
 
@@ -3253,7 +3253,7 @@ public class Server {
             put("hastebin-token", "");
 
             put("leveldb-cache-mb", 80);
-            put("use-native-leveldb", false);
+            put("use-native-leveldb", true);
             put("enable-raw-ores", true);
         }
     }

--- a/src/main/java/cn/nukkit/level/format/leveldb/LevelDBProvider.java
+++ b/src/main/java/cn/nukkit/level/format/leveldb/LevelDBProvider.java
@@ -169,7 +169,7 @@ public class LevelDBProvider implements LevelProvider {
                 .compressionType(CompressionType.ZLIB_RAW)
                 .cacheSize(1024L * 1024L * Server.getInstance().levelDbCache)
                 .blockSize(64 * 1024);
-        return Server.getInstance().useNativeLevelDB ? LevelDB.PROVIDER.open(dir, options) : JAVA_LDB_PROVIDER.open(dir, options);
+        return Server.getInstance().useNativeLevelDB ? JAVA_LDB_PROVIDER.open(dir, options) : LevelDB.PROVIDER.open(dir, options);
     }
 
     public static void updateLevelData(CompoundTag levelData) {
@@ -534,6 +534,7 @@ public class LevelDBProvider implements LevelProvider {
                     NBTOutputStream outputStream = NbtUtils.createWriterLE(new ByteBufOutputStream(byteBuf));
                     outputStream.writeTag(ticks);
                     writeBatch.put(pendingScheduledTicksKey, Utils.convertByteBuf2Array(byteBuf));
+                    byteBuf.release();
                 } else {
                     writeBatch.delete(pendingScheduledTicksKey);
                 }

--- a/src/main/java/cn/nukkit/level/format/leveldb/LevelDBProvider.java
+++ b/src/main/java/cn/nukkit/level/format/leveldb/LevelDBProvider.java
@@ -169,7 +169,7 @@ public class LevelDBProvider implements LevelProvider {
                 .compressionType(CompressionType.ZLIB_RAW)
                 .cacheSize(1024L * 1024L * Server.getInstance().levelDbCache)
                 .blockSize(64 * 1024);
-        return Server.getInstance().useNativeLevelDB ? JAVA_LDB_PROVIDER.open(dir, options) : LevelDB.PROVIDER.open(dir, options);
+        return Server.getInstance().useNativeLevelDB ? LevelDB.PROVIDER.open(dir, options) : JAVA_LDB_PROVIDER.open(dir, options);
     }
 
     public static void updateLevelData(CompoundTag levelData) {


### PR DESCRIPTION
https://www.nukkit-mot.com/docs/server-config/server-properties#use-native-leveldb

需尽快合并此 pr 以防 leveldb 磁盘空间泄露造成更严重的影响