### PR TITLE
Handle SIGTERM signal

### DIFF
--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -832,6 +832,8 @@ public class Server {
             }
         });
 
+        Runtime.getRuntime().addShutdownHook(new Thread(this::forceShutdown));
+
         this.start();
     }
 


### PR DESCRIPTION
Currently the only way to shut MOT down gracefully is to write "stop" in console, but it becomes very uncomfortable when running MOT inside docker container. This commit implements SIGTERM handling which is used by OS to request graceful shutdown. 
![image](https://github.com/MemoriesOfTime/Nukkit-MOT/assets/78866820/e55986bf-e298-4c38-9a57-4e846c722d68)
