### PR TITLE
Projectile Can Pass The Barrier

### DIFF
--- a/src/main/java/cn/nukkit/entity/Entity.java
+++ b/src/main/java/cn/nukkit/entity/Entity.java
@@ -2560,6 +2560,11 @@ public abstract class Entity extends Location implements Metadatable {
         return true;
     }
 
+    /**
+     * Whether the entity can pass through barrier blocks.
+     *
+     * @return passes through barriers
+     **/
     public boolean canPassThroughBarrier() {
         return false;
     }

--- a/src/main/java/cn/nukkit/entity/Entity.java
+++ b/src/main/java/cn/nukkit/entity/Entity.java
@@ -2560,6 +2560,10 @@ public abstract class Entity extends Location implements Metadatable {
         return true;
     }
 
+    public boolean canPassThroughBarrier() {
+        return false;
+    }
+
     protected void checkChunks() {
         int cx = (int) this.x >> 4;
         int cz = (int) this.z >> 4;

--- a/src/main/java/cn/nukkit/entity/projectile/EntityProjectile.java
+++ b/src/main/java/cn/nukkit/entity/projectile/EntityProjectile.java
@@ -249,4 +249,9 @@ public abstract class EntityProjectile extends Entity {
             block.onEntityCollide(this);
         }
     }
+
+    @Override
+    public boolean canPassThroughBarrier() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -1717,6 +1717,9 @@ public class Level implements ChunkManager, Metadatable {
             for (int x = minX; x <= maxX; ++x) {
                 for (int y = minY; y <= maxY; ++y) {
                     Block block = this.getBlock(x, y, z, false);
+                    if (block.getId() == BlockID.BARRIER && entity.canPassThroughBarrier()) {
+                        continue;
+                    }
                     if (!block.canPassThrough() && block.collidesWithBB(bb)) {
                         collides.add(block.getBoundingBox());
                     }


### PR DESCRIPTION
This aims to make mini-game development easier. Especially when they need to make arrow passable through barriers while players are not.