### PR TITLE
Fix an error of Item.fromString()

### DIFF
--- a/src/main/java/cn/nukkit/item/Item.java
+++ b/src/main/java/cn/nukkit/item/Item.java
@@ -1079,7 +1079,10 @@ public class Item implements Cloneable, BlockID, ItemID, ProtocolInfo {
                 try {
                     Item item = constructor.get();
                     if (meta.isPresent()) {
-                        item.setDamage(meta.getAsInt());
+                        int metaValue = meta.getAsInt();
+                        if (metaValue != 0) {
+                            item.setDamage(metaValue);
+                        }
                     }
                     // Avoid the upcoming changes to the original item object
                     return item.clone();


### PR DESCRIPTION
If you use Item.fromString() with "minecraft:water_bucket:0", then you will get a empty bucket.

如果你使用Item.fromString("minecraft:water_bucket:0")获取物品，你将获得到一个空桶。
此PR对空特殊值做相应的调整处理。