### PR TITLE
Fix the inability to override commands (Backport of https://github.com/CloudburstMC/Nukkit/pull/2196)

### DIFF
--- a/src/main/java/cn/nukkit/command/Command.java
+++ b/src/main/java/cn/nukkit/command/Command.java
@@ -2,12 +2,7 @@ package cn.nukkit.command;
 
 import cn.nukkit.Player;
 import cn.nukkit.Server;
-import cn.nukkit.command.data.CommandData;
-import cn.nukkit.command.data.CommandDataVersions;
-import cn.nukkit.command.data.CommandEnum;
-import cn.nukkit.command.data.CommandOverload;
-import cn.nukkit.command.data.CommandParamType;
-import cn.nukkit.command.data.CommandParameter;
+import cn.nukkit.command.data.*;
 import cn.nukkit.command.tree.ParamList;
 import cn.nukkit.command.tree.ParamTree;
 import cn.nukkit.command.utils.CommandLogger;
@@ -20,13 +15,7 @@ import cn.nukkit.plugin.PluginBase;
 import cn.nukkit.utils.TextFormat;
 import io.netty.util.internal.EmptyArrays;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -239,7 +228,7 @@ public abstract class Command {
     }
 
     public boolean register(CommandMap commandMap) {
-        if (this.allowChangesFrom(commandMap)) {
+        if (commandMap != null && this.allowChangesFrom(commandMap)) {
             this.commandMap = commandMap;
             return true;
         }

--- a/src/main/java/cn/nukkit/command/Command.java
+++ b/src/main/java/cn/nukkit/command/Command.java
@@ -257,7 +257,7 @@ public abstract class Command {
     }
 
     public boolean allowChangesFrom(CommandMap commandMap) {
-        return commandMap != null && !commandMap.equals(this.commandMap);
+        return this.commandMap == null || this.commandMap.equals(commandMap);
     }
 
     public boolean isRegistered() {


### PR DESCRIPTION
This PR backports from upstream pull https://github.com/CloudburstMC/Nukkit/pull/2196

tl;dr fixes command overriding which is not possible without this changes
sample code:
```java
public static boolean unregisterCommand(Command command){
    command.setLabel(command.getName() + "__unregistered");
    return command.unregister(Server.getInstance().getCommandMap());
}
```