### PR TITLE
Strip colors in log files

### DIFF
--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -5,7 +5,7 @@
             <PatternLayout pattern="%cyan{%d{HH:mm:ss}} [%yellow{%t}] [%style{%highlight{%level}}] %minecraftFormatting{%msg}%n"/>
         </TerminalConsole>
         <RollingRandomAccessFile name="File" fileName="logs/server.log" filePattern="logs/%d{yyyy-MM-dd}-%i.log.gz">
-            <PatternLayout pattern="%d{yyy-MM-dd HH:mm:ss.SSS} [%t] %level - %minecraftFormatting{%msg}%n"/>
+            <PatternLayout pattern="%d{yyy-MM-dd HH:mm:ss.SSS} [%t] %level - %minecraftFormatting{%msg}{strip}%n"/>
             <Policies>
                 <TimeBasedTriggeringPolicy/>
                 <OnStartupTriggeringPolicy/>


### PR DESCRIPTION
# Before
![image](https://github.com/user-attachments/assets/12786b97-9b31-4f72-8071-94daafe355c8)
# After
![image](https://github.com/user-attachments/assets/7edf95ba-77f1-46fd-a023-cbc65908f171)

(color codes will only be removed in .log files, not in the console)