### PR TITLE
fix: `execute` command slash_command type, soft enum correct.

### DIFF
--- a/src/main/java/cn/nukkit/command/Command.java
+++ b/src/main/java/cn/nukkit/command/Command.java
@@ -3,6 +3,7 @@ package cn.nukkit.command;
 import cn.nukkit.Player;
 import cn.nukkit.Server;
 import cn.nukkit.command.data.*;
+import cn.nukkit.command.defaults.ExecuteCommand;
 import cn.nukkit.command.tree.ParamList;
 import cn.nukkit.command.tree.ParamTree;
 import cn.nukkit.command.utils.CommandLogger;
@@ -140,6 +141,9 @@ public abstract class Command {
         this.commandParameters.forEach((key, params) -> {
             CommandOverload overload = new CommandOverload();
             overload.input.parameters = params;
+            if (this instanceof ExecuteCommand) {
+                overload.chaining = true;
+            }
             customData.overloads.put(key, overload);
         });
 

--- a/src/main/java/cn/nukkit/command/Command.java
+++ b/src/main/java/cn/nukkit/command/Command.java
@@ -74,7 +74,9 @@ public abstract class Command {
         this.usageMessage = usageMessage == null ? "/" + name : usageMessage;
         this.aliases = aliases;
         this.activeAliases = aliases;
-        this.commandParameters.put("default", new CommandParameter[]{CommandParameter.newType("args", true, CommandParamType.RAWTEXT)});
+        this.commandParameters.put("default", new CommandParameter[]{
+                CommandParameter.newType("args", true, CommandParamType.RAWTEXT)
+        });
     }
 
     /**

--- a/src/main/java/cn/nukkit/command/data/CommandEnum.java
+++ b/src/main/java/cn/nukkit/command/data/CommandEnum.java
@@ -116,6 +116,14 @@ public class CommandEnum {
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CommandEnum that = (CommandEnum) o;
+        return name.equals(that.name);
+    }
+
+    @Override
     public int hashCode() {
         return name.hashCode();
     }

--- a/src/main/java/cn/nukkit/command/data/GenericParameter.java
+++ b/src/main/java/cn/nukkit/command/data/GenericParameter.java
@@ -10,7 +10,7 @@ public interface GenericParameter {
     CommandParameterSupplier<CommandParameter> OBJECTIVES = (optional) -> CommandParameter.newEnum("objective", optional, CommandEnum.SCOREBOARD_OBJECTIVES);
     CommandParameterSupplier<CommandParameter> TARGET_OBJECTIVES = (optional) -> CommandParameter.newEnum("targetObjective", optional, CommandEnum.SCOREBOARD_OBJECTIVES);
     CommandParameterSupplier<CommandParameter> ITEM_NAME = (optional) -> CommandParameter.newEnum("itemName", optional, CommandEnum.ENUM_ITEM, new ItemNode());
-    CommandParameterSupplier<CommandParameter> CHAINED_COMMAND = (optional) -> CommandParameter.newEnum("chainedCommand", optional, CommandEnum.CHAINED_COMMAND_ENUM, new ChainedCommandNode(), CommandParamOption.ENUM_AS_CHAINED_COMMAND);
+    CommandParameterSupplier<CommandParameter> CHAINED_COMMAND = (optional) -> CommandParameter.newEnum("chainedCommand", optional, CommandEnum.CHAINED_COMMAND_ENUM, new ChainedCommandNode());// , CommandParamOption.ENUM_AS_CHAINED_COMMAND
     CommandParameterSupplier<CommandParameter> ORIGIN = (optional) -> CommandParameter.newType("origin", optional, CommandParamType.TARGET);
 
     @FunctionalInterface

--- a/src/main/java/cn/nukkit/command/tree/node/EnumNode.java
+++ b/src/main/java/cn/nukkit/command/tree/node/EnumNode.java
@@ -31,7 +31,7 @@ public class EnumNode extends ParamNode<String> {
     public IParamNode<String> init(ParamList parent, String name, boolean optional, CommandParamType type, CommandEnum enumData, String postFix) {
         this.paramList = parent;
         this.commandEnum = enumData;
-        this.enums = Sets.newHashSet(this.commandEnum.getValues());
+        this.enums = enumData == null ? Sets.newHashSet() : Sets.newHashSet(this.commandEnum.getValues());
         this.optional = optional;
         return this;
     }

--- a/src/main/java/cn/nukkit/network/protocol/AvailableCommandsPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/AvailableCommandsPacket.java
@@ -381,8 +381,8 @@ public class AvailableCommandsPacket extends DataPacket {
         this.reset();
 
         if (this.protocol < ProtocolInfo.v1_2_0) {
-            putString(new Gson().toJson(this.commands));
-            putString("");
+            this.putString(new Gson().toJson(this.commands));
+            this.putString("");
             return;
         }
 
@@ -430,6 +430,7 @@ public class AvailableCommandsPacket extends DataPacket {
             }
 
             for (CommandOverload overload : cmdData.overloads.values()) {
+
                 for (CommandParameter parameter : overload.input.parameters) {
                     if (parameter.enumData != null) {
                         if (parameter.enumData.isSoft()) {
@@ -454,17 +455,17 @@ public class AvailableCommandsPacket extends DataPacket {
 
         // refer: https://github.com/Sandertv/gophertunnel/blob/master/minecraft/protocol/packet/available_commands.go
         // EnumValues
-        putUnsignedVarInt(enumValues.size());
+        this.putUnsignedVarInt(enumValues.size());
         enumValues.forEach(this::putString);
 
         // ChainedSubcommandValues
         if (this.protocol >= ProtocolInfo.v1_20_10_21) {
-            putUnsignedVarInt(subCommandValues.size());
+            this.putUnsignedVarInt(subCommandValues.size());
             subCommandValues.forEach(this::putString);
         }
 
         // Suffixes
-        putUnsignedVarInt(postFixes.size());
+        this.putUnsignedVarInt(postFixes.size());
         postFixes.forEach(this::putString);
 
         ObjIntConsumer<BinaryStream> indexWriter;
@@ -477,12 +478,12 @@ public class AvailableCommandsPacket extends DataPacket {
         }
 
         // Enums
-        putUnsignedVarInt(enums.size());
+        this.putUnsignedVarInt(enums.size());
         enums.forEach((cmdEnum) -> {
-            putString(cmdEnum.getName());
+            this.putString(cmdEnum.getName());
 
             List<String> values = cmdEnum.getValues();
-            putUnsignedVarInt(values.size());
+            this.putUnsignedVarInt(values.size());
 
             for (String val : values) {
                 int i = enumValues.indexOf(val);
@@ -497,10 +498,10 @@ public class AvailableCommandsPacket extends DataPacket {
 
         // ChainedSubcommands
         if (this.protocol >= ProtocolInfo.v1_20_10_21) {
-            putUnsignedVarInt(subCommandData.size());
+            this.putUnsignedVarInt(subCommandData.size());
             for (ChainedSubCommandData chainedSubCommandData : subCommandData) {
-                putString(chainedSubCommandData.getName());
-                putUnsignedVarInt(chainedSubCommandData.getValues().size());
+                this.putString(chainedSubCommandData.getName());
+                this.putUnsignedVarInt(chainedSubCommandData.getValues().size());
                 for (ChainedSubCommandData.Value value : chainedSubCommandData.getValues()) {
                     int first = subCommandValues.indexOf(value.getFirst());
                     checkArgument(first > -1, "Invalid enum value detected: " + value.getFirst());
@@ -514,55 +515,55 @@ public class AvailableCommandsPacket extends DataPacket {
                         second = -1;
                     }
 
-                    putLShort(first);
-                    putLShort(second);
+                    this.putLShort(first);
+                    this.putLShort(second);
                 }
             }
         }
 
 
         // Commands
-        putUnsignedVarInt(commands.size());
+        this.putUnsignedVarInt(commands.size());
         commands.forEach((name, cmdData) -> {
             CommandData data = cmdData.versions.get(0);
 
-            putString(name);
-            putString(data.description);
+            this.putString(name);
+            this.putString(data.description);
             // Commands\Flags
             if (protocol >= ProtocolInfo.v1_17_10) {
-                putLShort(data.flags);
+                this.putLShort(data.flags);
             } else {
-                putByte((byte) data.flags);
+                this.putByte((byte) data.flags);
             }
             // Commands\PermissionLevel
-            putByte((byte) data.permission);
+            this.putByte((byte) data.permission);
 
             // Commands\AliasesOffset
-            putLInt(data.aliases == null ? -1 : enums.indexOf(data.aliases));
+            this.putLInt(data.aliases == null ? -1 : enums.indexOf(data.aliases));
 
             // Commands\ChainedSubcommandOffsets
             if (this.protocol >= ProtocolInfo.v1_20_10_21) {
-                putUnsignedVarInt(data.subcommands.size());
+                this.putUnsignedVarInt(data.subcommands.size());
                 for (ChainedSubCommandData subcommand : data.subcommands) {
                     int index = subCommandData.indexOf(subcommand);
                     checkArgument(index > -1, "Invalid subcommand index: " + subcommand);
-                    putLShort(index);
+                    this.putLShort(index);
                 }
             }
 
             // Commands\Overloads
-            putUnsignedVarInt(data.overloads.size());
+            this.putUnsignedVarInt(data.overloads.size());
             for (CommandOverload overload : data.overloads.values()) {
                 if (this.protocol >= ProtocolInfo.v1_20_10_21) {
-                    putBoolean(overload.chaining);
+                    this.putBoolean(overload.chaining);
                 }
-                putUnsignedVarInt(overload.input.parameters.length);
+                this.putUnsignedVarInt(overload.input.parameters.length);
 
                 for (CommandParameter parameter : overload.input.parameters) {
-                    putString(parameter.name);
+                    this.putString(parameter.name);
 
-                    putLInt(computeOverloadOffset(parameter, postFixes, softEnums, enums, name, protocol));
-                    putBoolean(parameter.optional);
+                    this.putLInt(computeOverloadOffset(parameter, postFixes, softEnums, enums, name, protocol));
+                    this.putBoolean(parameter.optional);
                     if (protocol >= 340) {
                         byte options = 0;
                         if (parameter.paramOptions != null) {
@@ -572,7 +573,7 @@ public class AvailableCommandsPacket extends DataPacket {
                         } else {
                             options = parameter.options;
                         }
-                        putByte(options);
+                        this.putByte(options);
                     }
                 }
             }
@@ -580,18 +581,18 @@ public class AvailableCommandsPacket extends DataPacket {
 
         // DynamicEnums
         if (protocol > 274) {
-            putUnsignedVarInt(softEnums.size());
+            this.putUnsignedVarInt(softEnums.size());
 
             softEnums.forEach((enumValue) -> {
-                putString(enumValue.getName());
-                putUnsignedVarInt(enumValue.getValues().size());
+                this.putString(enumValue.getName());
+                this.putUnsignedVarInt(enumValue.getValues().size());
                 enumValue.getValues().forEach(this::putString);
             });
         }
 
         // Constraints
         if (protocol >= 407) {
-            putUnsignedVarInt(0); //enumConstraints
+            this.putUnsignedVarInt(0); //enumConstraints
         }
     }
 

--- a/src/main/java/cn/nukkit/network/protocol/AvailableCommandsPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/AvailableCommandsPacket.java
@@ -561,7 +561,7 @@ public class AvailableCommandsPacket extends DataPacket {
                 for (CommandParameter parameter : overload.input.parameters) {
                     putString(parameter.name);
 
-                    putLInt(computeOffset(parameter, postFixes, softEnums, enums, name, protocol));
+                    putLInt(computeOverloadOffset(parameter, postFixes, softEnums, enums, name, protocol));
                     putBoolean(parameter.optional);
                     if (protocol >= 340) {
                         byte options = 0;
@@ -595,8 +595,8 @@ public class AvailableCommandsPacket extends DataPacket {
         }
     }
 
-    private Integer computeOffset(CommandParameter parameter, List<String> postFixes, List<CommandEnum> softEnums,
-            List<CommandEnum> enums, String name, int protocol) {
+    private Integer computeOverloadOffset(CommandParameter parameter, List<String> postFixes, List<CommandEnum> softEnums,
+                                          List<CommandEnum> enums, String name, int protocol) {
         int type = 0;
         if (parameter.postFix != null) {
             int i = postFixes.indexOf(parameter.postFix);

--- a/src/main/java/cn/nukkit/network/protocol/AvailableCommandsPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/AvailableCommandsPacket.java
@@ -167,10 +167,10 @@ public class AvailableCommandsPacket extends DataPacket {
             .insert(36, CommandParam.PERMISSION_ELEMENTS)
             .build();
     private static final TypeMap<CommandParam> COMMAND_PARAMS_594 = COMMAND_PARAMS_582.toBuilder()
-            //TODO solve memory usage problem
-            //.insert(134217728, CommandParam.CHAINED_COMMAND)
+            .insert(134217728, CommandParam.CHAINED_COMMAND)
             .build();
     private static final TypeMap<CommandParam> COMMAND_PARAMS_662 = COMMAND_PARAMS_594.toBuilder()
+            .remove(134217728)//remove CommandParam.CHAINED_COMMAND
             .shift(24, 4)
             .insert(24, CommandParam.RATIONAL_RANGE_VAL)
             .insert(25, CommandParam.RATIONAL_RANGE_POST_VAL)
@@ -185,13 +185,15 @@ public class AvailableCommandsPacket extends DataPacket {
             .insert(53, CommandParam.HAS_PROPERTY_ELEMENT)
             .insert(54, CommandParam.HAS_PROPERTY_ELEMENTS)
             .insert(55, CommandParam.HAS_PROPERTY_SELECTOR)
+            .insert(134217728, CommandParam.CHAINED_COMMAND)//reinsert, avoid shift
             .build();
     private static final TypeMap<CommandParam> COMMAND_PARAMS_685 = COMMAND_PARAMS_662.toBuilder()
-            .shift(86, 4)
-            .insert(86, CommandParam.CODE_BUILDER_ARG)
-            .insert(87, CommandParam.CODE_BUILDER_ARGS)
-            .insert(88, CommandParam.CODE_BUILDER_SELECT_PARAM)
-            .insert(89, CommandParam.CODE_BUILDER_SELECTOR)
+            .remove(134217728)//remove CommandParam.CHAINED_COMMAND
+            .insert(88, CommandParam.CODE_BUILDER_ARG)
+            .insert(89, CommandParam.CODE_BUILDER_ARGS)
+            .insert(90, CommandParam.CODE_BUILDER_SELECT_PARAM)
+            .insert(91, CommandParam.CODE_BUILDER_SELECTOR)
+            .insert(134217728, CommandParam.CHAINED_COMMAND)//reinsert, avoid shift
             .build();
 
     //TODO Multiversion 保持最新版
@@ -220,7 +222,7 @@ public class AvailableCommandsPacket extends DataPacket {
     public static final int ARG_TYPE_COMMAND = COMMAND_PARAMS.getId(CommandParam.COMMAND);
 
     public Map<String, CommandDataVersions> commands;
-    public final Map<String, List<String>> softEnums = new HashMap<>();
+//    public final Map<String, List<String>> softEnums = new HashMap<>();
 
     public static TypeMap<CommandParam> getCommandParams(int protocol) {
         //TODO Multiversion
@@ -379,8 +381,8 @@ public class AvailableCommandsPacket extends DataPacket {
         this.reset();
 
         if (this.protocol < ProtocolInfo.v1_2_0) {
-            this.putString(new Gson().toJson(this.commands));
-            this.putString("");
+            putString(new Gson().toJson(this.commands));
+            putString("");
             return;
         }
 
@@ -389,6 +391,7 @@ public class AvailableCommandsPacket extends DataPacket {
         LinkedHashSet<String> postFixesSet = new LinkedHashSet<>();
         SequencedHashSet<ChainedSubCommandData> subCommandData = new SequencedHashSet<>();
         LinkedHashSet<CommandEnum> enumsSet = new LinkedHashSet<>();
+        LinkedHashSet<CommandEnum> softEnumsSet = new LinkedHashSet<>();
 
         commands.forEach((name, data) -> {
             CommandData cmdData = data.versions.get(0);
@@ -398,6 +401,16 @@ public class AvailableCommandsPacket extends DataPacket {
 
                 enumValuesSet.addAll(cmdData.aliases.getValues());
             }
+            if ("execute".equals(name) && cmdData.subcommands.isEmpty()) {// Hook
+                String[] keywords = {
+                        "as", "at", "in", "positioned", "rotated", "facing", "align", "anchored", "if", "unless", "run"
+                };
+                ChainedSubCommandData chainedSubCommand = new ChainedSubCommandData("ExecuteChainedOption_0");
+                for (String keyword : keywords) {
+                    chainedSubCommand.getValues().add(new ChainedSubCommandData.Value(keyword, null));
+                }
+                cmdData.subcommands.add(chainedSubCommand);
+            }
 
             for (ChainedSubCommandData subcommand : cmdData.subcommands) {
                 if (subCommandData.contains(subcommand)) {
@@ -406,11 +419,11 @@ public class AvailableCommandsPacket extends DataPacket {
 
                 subCommandData.add(subcommand);
                 for (ChainedSubCommandData.Value value : subcommand.getValues()) {
-                    if (subCommandValues.contains(value.getFirst())) {
+                    if (value.getFirst() != null && !subCommandValues.contains(value.getFirst())) {
                         subCommandValues.add(value.getFirst());
                     }
 
-                    if (subCommandValues.contains(value.getSecond())) {
+                    if (value.getSecond() != null && !subCommandValues.contains(value.getSecond())) {
                         subCommandValues.add(value.getSecond());
                     }
                 }
@@ -419,9 +432,12 @@ public class AvailableCommandsPacket extends DataPacket {
             for (CommandOverload overload : cmdData.overloads.values()) {
                 for (CommandParameter parameter : overload.input.parameters) {
                     if (parameter.enumData != null) {
-                        enumsSet.add(parameter.enumData);
-
-                        enumValuesSet.addAll(parameter.enumData.getValues());
+                        if (parameter.enumData.isSoft()) {
+                            softEnumsSet.add(parameter.enumData);
+                        } else {
+                            enumsSet.add(parameter.enumData);
+                            enumValuesSet.addAll(parameter.enumData.getValues());
+                        }
                     }
 
                     if (parameter.postFix != null) {
@@ -432,18 +448,23 @@ public class AvailableCommandsPacket extends DataPacket {
         });
 
         List<String> enumValues = new ArrayList<>(enumValuesSet);
-        List<CommandEnum> enums = new ArrayList<>(enumsSet);
         List<String> postFixes = new ArrayList<>(postFixesSet);
+        List<CommandEnum> enums = new ArrayList<>(enumsSet);
+        List<CommandEnum> softEnums = new ArrayList<>(softEnumsSet);
 
-        this.putUnsignedVarInt(enumValues.size());
+        // refer: https://github.com/Sandertv/gophertunnel/blob/master/minecraft/protocol/packet/available_commands.go
+        // EnumValues
+        putUnsignedVarInt(enumValues.size());
         enumValues.forEach(this::putString);
 
+        // ChainedSubcommandValues
         if (this.protocol >= ProtocolInfo.v1_20_10_21) {
-            this.putUnsignedVarInt(subCommandValues.size());
+            putUnsignedVarInt(subCommandValues.size());
             subCommandValues.forEach(this::putString);
         }
 
-        this.putUnsignedVarInt(postFixes.size());
+        // Suffixes
+        putUnsignedVarInt(postFixes.size());
         postFixes.forEach(this::putString);
 
         ObjIntConsumer<BinaryStream> indexWriter;
@@ -455,7 +476,8 @@ public class AvailableCommandsPacket extends DataPacket {
             indexWriter = WRITE_INT;
         }
 
-        this.putUnsignedVarInt(enums.size());
+        // Enums
+        putUnsignedVarInt(enums.size());
         enums.forEach((cmdEnum) -> {
             putString(cmdEnum.getName());
 
@@ -473,83 +495,73 @@ public class AvailableCommandsPacket extends DataPacket {
             }
         });
 
+        // ChainedSubcommands
         if (this.protocol >= ProtocolInfo.v1_20_10_21) {
-            this.putUnsignedVarInt(subCommandData.size());
+            putUnsignedVarInt(subCommandData.size());
             for (ChainedSubCommandData chainedSubCommandData : subCommandData) {
-                this.putString(chainedSubCommandData.getName());
-                this.putUnsignedVarInt(chainedSubCommandData.getValues().size());
+                putString(chainedSubCommandData.getName());
+                putUnsignedVarInt(chainedSubCommandData.getValues().size());
                 for (ChainedSubCommandData.Value value : chainedSubCommandData.getValues()) {
                     int first = subCommandValues.indexOf(value.getFirst());
                     checkArgument(first > -1, "Invalid enum value detected: " + value.getFirst());
+                    if (value.getFirst() == null) {
+                        first = -1;
+                    }
 
                     int second = subCommandValues.indexOf(value.getSecond());
                     checkArgument(second > -1, "Invalid enum value detected: " + value.getSecond());
+                    if (value.getSecond() == null) {
+                        second = -1;
+                    }
 
-                    this.putLShort(first);
-                    this.putLShort(second);
+                    putLShort(first);
+                    putLShort(second);
                 }
             }
         }
 
-        putUnsignedVarInt(commands.size());
 
+        // Commands
+        putUnsignedVarInt(commands.size());
         commands.forEach((name, cmdData) -> {
             CommandData data = cmdData.versions.get(0);
 
             putString(name);
             putString(data.description);
+            // Commands\Flags
             if (protocol >= ProtocolInfo.v1_17_10) {
                 putLShort(data.flags);
             } else {
                 putByte((byte) data.flags);
             }
+            // Commands\PermissionLevel
             putByte((byte) data.permission);
 
+            // Commands\AliasesOffset
             putLInt(data.aliases == null ? -1 : enums.indexOf(data.aliases));
 
+            // Commands\ChainedSubcommandOffsets
             if (this.protocol >= ProtocolInfo.v1_20_10_21) {
-                this.putUnsignedVarInt(data.subcommands.size());
+                putUnsignedVarInt(data.subcommands.size());
                 for (ChainedSubCommandData subcommand : data.subcommands) {
                     int index = subCommandData.indexOf(subcommand);
                     checkArgument(index > -1, "Invalid subcommand index: " + subcommand);
-                    this.putLShort(index);
+                    putLShort(index);
                 }
             }
 
+            // Commands\Overloads
             putUnsignedVarInt(data.overloads.size());
             for (CommandOverload overload : data.overloads.values()) {
                 if (this.protocol >= ProtocolInfo.v1_20_10_21) {
-                    this.putBoolean(overload.chaining);
+                    putBoolean(overload.chaining);
                 }
                 putUnsignedVarInt(overload.input.parameters.length);
 
                 for (CommandParameter parameter : overload.input.parameters) {
                     putString(parameter.name);
 
-                    int type = 0;
-                    if (parameter.postFix != null) {
-                        int i = postFixes.indexOf(parameter.postFix);
-                        if (i < 0) {
-                            throw new IllegalStateException(
-                                    "Postfix '" + parameter.postFix + "' isn't in postfix array");
-                        }
-                        type = ARG_FLAG_POSTFIX | i;
-                    } else {
-                        type |= ARG_FLAG_VALID;
-                        if (parameter.enumData != null) {
-                            type |= ARG_FLAG_ENUM | enums.indexOf(parameter.enumData);
-                        } else {
-                            CommandParam commandParam = COMMAND_PARAMS.getType(parameter.type.getId()); //正常来说应该传入最新版的数字id
-                            try {
-                                int id = getCommandParams(protocol).getId(commandParam);
-                                type |= id;
-                            } catch (IllegalArgumentException e) {
-                                type |= getCommandParams(protocol).getId(CommandParam.STRING);
-                            }
-                        }
-                    }
-
-                    putLInt(type);
+                    putLInt(computeOffset(parameter, postFixes, softEnums, enums, name, protocol));
                     putBoolean(parameter.optional);
                     if (protocol >= 340) {
                         byte options = 0;
@@ -560,24 +572,64 @@ public class AvailableCommandsPacket extends DataPacket {
                         } else {
                             options = parameter.options;
                         }
-                        this.putByte(options);
+                        putByte(options);
                     }
                 }
             }
         });
 
+        // DynamicEnums
         if (protocol > 274) {
-            this.putUnsignedVarInt(softEnums.size());
+            putUnsignedVarInt(softEnums.size());
 
-            softEnums.forEach((name, values) -> {
-                this.putString(name);
-                this.putUnsignedVarInt(values.size());
-                values.forEach(this::putString);
+            softEnums.forEach((enumValue) -> {
+                putString(enumValue.getName());
+                putUnsignedVarInt(enumValue.getValues().size());
+                enumValue.getValues().forEach(this::putString);
             });
         }
 
+        // Constraints
         if (protocol >= 407) {
-            this.putUnsignedVarInt(0); //enumConstraints
+            putUnsignedVarInt(0); //enumConstraints
         }
+    }
+
+    private Integer computeOffset(CommandParameter parameter, List<String> postFixes, List<CommandEnum> softEnums,
+            List<CommandEnum> enums, String name, int protocol) {
+        int type = 0;
+        if (parameter.postFix != null) {
+            int i = postFixes.indexOf(parameter.postFix);
+            if (i < 0) {
+                throw new IllegalStateException(
+                        "Postfix '" + parameter.postFix + "' isn't in postfix array");
+            }
+            type = ARG_FLAG_POSTFIX | i;
+        } else {
+            type |= ARG_FLAG_VALID;
+            if (parameter.enumData != null) {
+                if (parameter.enumData.isSoft()) {
+                    type = softEnums.indexOf(parameter.enumData) | ARG_FLAG_SOFT_ENUM | ARG_FLAG_VALID;
+                } else {
+                    type = enums.indexOf(parameter.enumData) | ARG_FLAG_ENUM | ARG_FLAG_VALID;
+                }
+            } else {
+                CommandParam commandParam = COMMAND_PARAMS.getType(parameter.type.getId()); //正常来说应该传入最新版的数字id
+
+                if ("execute".equals(name)) {// Hook
+                    if ("command".equals(parameter.name) && protocol >= 575) {
+                        commandParam = CommandParam.SLASH_COMMAND;
+                    }
+                }
+
+                try {
+                    int id = getCommandParams(protocol).getId(commandParam);
+                    type |= id;
+                } catch (IllegalArgumentException e) {
+                    type |= getCommandParams(protocol).getId(CommandParam.STRING);
+                }
+            }
+        }
+        return type;
     }
 }


### PR DESCRIPTION
- Fixed the issue causing the `/execute` command to crash.

> Temporary fix: removed `ENUM_AS_CHAINED_COMMAND`

- Excluded duplicate values in CommandEnum

> Solved by overriding the hashCode and equals methods of the CommandEnum class

- Fixed command completion for `/execute run <command>`

> Since protocol 575, replaced `CommandParam.COMMAND` with `CommandParam.SLASH_COMMAND`
> The hook method still needs improvement.

- AvailableCommandsPacket will correctly send `softEnums`

> Source: [PowerNukkitX#AvailableCommandsPacket](https://github.com/PowerNukkitX/PowerNukkitX/blob/master/src/main/java/cn/nukkit/network/protocol/AvailableCommandsPacket.java#L83)
