### PR TITLE
Fix the wrong parsing of FormResponseCustom below 1.21.70

### DIFF
--- a/src/main/java/cn/nukkit/form/window/FormWindow.java
+++ b/src/main/java/cn/nukkit/form/window/FormWindow.java
@@ -35,7 +35,7 @@ public abstract class FormWindow {
         return FormWindow.GSON.toJson(this);
     }
 
-    public abstract void setResponse(String data);
+    public abstract void setResponse(int protocol, String data);
 
     public abstract FormResponse getResponse();
 

--- a/src/main/java/cn/nukkit/form/window/FormWindow.java
+++ b/src/main/java/cn/nukkit/form/window/FormWindow.java
@@ -35,6 +35,10 @@ public abstract class FormWindow {
         return FormWindow.GSON.toJson(this);
     }
 
+    public void setResponse(String data) {
+        this.setResponse(ProtocolInfo.CURRENT_PROTOCOL, data);
+    }
+
     public abstract void setResponse(int protocol, String data);
 
     public abstract FormResponse getResponse();

--- a/src/main/java/cn/nukkit/form/window/FormWindow.java
+++ b/src/main/java/cn/nukkit/form/window/FormWindow.java
@@ -39,7 +39,9 @@ public abstract class FormWindow {
         this.setResponse(ProtocolInfo.CURRENT_PROTOCOL, data);
     }
 
-    public abstract void setResponse(int protocol, String data);
+    public void setResponse(int protocol, String data) {
+        // no-op
+    }
 
     public abstract FormResponse getResponse();
 

--- a/src/main/java/cn/nukkit/form/window/FormWindowCustom.java
+++ b/src/main/java/cn/nukkit/form/window/FormWindowCustom.java
@@ -71,7 +71,7 @@ public class FormWindowCustom extends FormWindow {
     }
 
     @Override
-    public void setResponse(String data) {
+    public void setResponse(int playerProtocol, String data) {
         if (data.equals("null")) {
             this.closed = true;
             return;
@@ -96,6 +96,10 @@ public class FormWindowCustom extends FormWindow {
             if (e instanceof ElementLabel) {
                 labelResponses.put(i, ((ElementLabel) e).getText());
                 responses.put(i, ((ElementLabel) e).getText());
+                if (playerProtocol < 786) {
+                    // to be compatible with the older response before 1.21.70
+                    responseIndex++;
+                }
             } else if (e instanceof ElementDropdown elementDropdown) {
                 int index = Integer.parseInt(elementData);
                 String answer = elementDropdown.getOptions().get(index);

--- a/src/main/java/cn/nukkit/form/window/FormWindowCustom.java
+++ b/src/main/java/cn/nukkit/form/window/FormWindowCustom.java
@@ -3,6 +3,7 @@ package cn.nukkit.form.window;
 import cn.nukkit.form.element.*;
 import cn.nukkit.form.response.FormResponseCustom;
 import cn.nukkit.form.response.FormResponseData;
+import cn.nukkit.network.protocol.ProtocolInfo;
 import com.google.gson.reflect.TypeToken;
 
 import java.util.ArrayList;
@@ -96,7 +97,7 @@ public class FormWindowCustom extends FormWindow {
             if (e instanceof ElementLabel) {
                 labelResponses.put(i, ((ElementLabel) e).getText());
                 responses.put(i, ((ElementLabel) e).getText());
-                if (playerProtocol < 786) {
+                if (playerProtocol < ProtocolInfo.v1_21_70_25) {
                     // to be compatible with the older response before 1.21.70
                     responseIndex++;
                 }

--- a/src/main/java/cn/nukkit/form/window/FormWindowCustom.java
+++ b/src/main/java/cn/nukkit/form/window/FormWindowCustom.java
@@ -72,7 +72,7 @@ public class FormWindowCustom extends FormWindow {
     }
 
     @Override
-    public void setResponse(int playerProtocol, String data) {
+    public void setResponse(int protocol, String data) {
         if (data.equals("null")) {
             this.closed = true;
             return;
@@ -97,7 +97,7 @@ public class FormWindowCustom extends FormWindow {
             if (e instanceof ElementLabel) {
                 labelResponses.put(i, ((ElementLabel) e).getText());
                 responses.put(i, ((ElementLabel) e).getText());
-                if (playerProtocol < ProtocolInfo.v1_21_70_25) {
+                if (protocol < ProtocolInfo.v1_21_70_25) {
                     // to be compatible with the older response before 1.21.70
                     responseIndex++;
                 }

--- a/src/main/java/cn/nukkit/form/window/FormWindowModal.java
+++ b/src/main/java/cn/nukkit/form/window/FormWindowModal.java
@@ -58,7 +58,7 @@ public class FormWindowModal extends FormWindow {
     }
 
     @Override
-    public void setResponse(String data) {
+    public void setResponse(int protocol, String data) {
         if (data.equals("null")) {
             closed = true;
             return;

--- a/src/main/java/cn/nukkit/form/window/FormWindowSimple.java
+++ b/src/main/java/cn/nukkit/form/window/FormWindowSimple.java
@@ -78,7 +78,7 @@ public class FormWindowSimple extends FormWindow {
     }
 
     @Override
-    public void setResponse(String data) {
+    public void setResponse(int protocol, String data) {
         if (data.equals("null")) {
             this.closed = true;
             return;

--- a/src/main/java/cn/nukkit/network/PacketPool.java
+++ b/src/main/java/cn/nukkit/network/PacketPool.java
@@ -38,7 +38,7 @@ public class PacketPool {
     }
 
     public DataPacket getPacket(int id) {
-        if (id > packetsById.length) {
+        if (id >= packetsById.length) {
             Server.getInstance().getLogger().debug("Packet exceeds limits, id: " + id);
             return null;
         }

--- a/src/main/java/cn/nukkit/network/process/processor/common/ModalFormResponseProcessor.java
+++ b/src/main/java/cn/nukkit/network/process/processor/common/ModalFormResponseProcessor.java
@@ -35,7 +35,7 @@ public class ModalFormResponseProcessor extends DataPacketProcessor<ModalFormRes
 
         if (playerHandle.getFormWindows().containsKey(pk.formId)) {
             FormWindow window = playerHandle.getFormWindows().remove(pk.formId);
-            window.setResponse(pk.data.trim());
+            window.setResponse(player.protocol, pk.data.trim());
 
             for (FormResponseHandler handler : window.getHandlers()) {
                 handler.handle(player, pk.formId);
@@ -44,7 +44,7 @@ public class ModalFormResponseProcessor extends DataPacketProcessor<ModalFormRes
             new PlayerFormRespondedEvent(player, pk.formId, window).call();
         } else if (playerHandle.getServerSettings().containsKey(pk.formId)) {
             FormWindow window = playerHandle.getServerSettings().get(pk.formId);
-            window.setResponse(pk.data.trim());
+            window.setResponse(player.protocol, pk.data.trim());
 
             for (FormResponseHandler handler : window.getHandlers()) {
                 handler.handle(player, pk.formId);


### PR DESCRIPTION
FormResponseCustom cannot properly parse the modal form response from clients below 1.21.70 because of different index sequencing