### PR TITLE
feat: some settings are useful for servers

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -2836,19 +2836,12 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
         this.forceMovement = this.teleportPosition = this.getPosition();
 
         ResourcePacksInfoPacket infoPacket = new ResourcePacksInfoPacket();
-        var mvResourcePacks = Server.mvResourcePacks;
 
-        infoPacket.resourcePackEntries = mvResourcePacks.isEmpty() ? this.server.getResourcePackManager().getResourceStack() :
-            mvResourcePacks.entrySet().stream()
-        .filter(entry -> entry.getValue() <= protocol)
-        .max(Entry.comparingByValue())
-        .map(Entry::getKey)
-        .flatMap(id -> Arrays.stream(this.server.getResourcePackManager().getResourceStack())
-                .filter(pack -> id.equals(pack.getPackId()))
-                .findFirst()
-        )
-        .map(pack -> new ResourcePack[]{pack})
-        .orElse(ResourcePack.EMPTY_ARRAY);
+        infoPacket.resourcePackEntries = Arrays.stream(this.server.getResourcePackManager().getResourceStack())
+                .filter(pack -> pack.getPackProtocol() <= protocol)
+                .max(Comparator.comparingInt(ResourcePack::getPackProtocol))
+                .map(pack -> new ResourcePack[]{pack})
+                .orElse(ResourcePack.EMPTY_ARRAY);
 
         infoPacket.mustAccept = this.server.getForceResources();
         this.dataPacket(infoPacket);

--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -2838,10 +2838,15 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
         ResourcePacksInfoPacket infoPacket = new ResourcePacksInfoPacket();
 
         infoPacket.resourcePackEntries = Arrays.stream(this.server.getResourcePackManager().getResourceStack())
-                .filter(pack -> pack.getPackProtocol() <= protocol)
-                .max(Comparator.comparingInt(ResourcePack::getPackProtocol))
-                .map(pack -> new ResourcePack[]{pack})
-                .orElse(ResourcePack.EMPTY_ARRAY);
+        .filter(pack -> pack.getPackProtocol() <= protocol)
+        .collect(Collectors.collectingAndThen(
+                Collectors.groupingBy(
+                        ResourcePack::getPackProtocol,
+                        TreeMap::new,
+                        Collectors.toList()
+                ),
+                map -> map.isEmpty() ? ResourcePack.EMPTY_ARRAY : map.lastEntry().getValue().toArray(ResourcePack[]::new)
+        ));
 
         infoPacket.mustAccept = this.server.getForceResources();
         this.dataPacket(infoPacket);

--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -3282,8 +3282,6 @@ public class Server {
             put("multi-nether-worlds", "");
             put("anti-xray-worlds", "");
 
-            put("multi-version-packs", "");
-
             put("do-not-tick-worlds", "");
             put("worlds-entity-spawning-disabled", "");
             put("load-all-worlds", true);

--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -423,10 +423,10 @@ public class Server {
      */
     public boolean opInGame;
     /**
-     * Action mode if there is a space in the nickname.
-        0 - disabled (kick player on login)
-        1 - ignore [default]
-        2 - replace (replacing the space with an underscore)
+     * Handling player names with spaces.
+        [0] "disabled" - Players with names containing spaces are prohibited from entering the server.
+        [1] "ignore" - Ignore names with spaces (default).
+        [2] "replacing" - Replace spaces in player names with "_".
      */
     public int spaceMode;
     /**
@@ -466,7 +466,7 @@ public class Server {
      */
     public boolean vanillaPortals;
     /**
-     * Ticks before activating the portal.
+     * Ticks required for the player to trigger the portal.
      */
     public int portalTicks;
     /**

--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -215,12 +215,6 @@ public class Server {
     public static final List<String> multiNetherWorlds = new ArrayList<>();
     public static final List<String> antiXrayWorlds = new ArrayList<>();
     /**
-     * Multi-version settings for resource packs.
-     * The resource pack will be sent only from the specified protocol.
-     * Format: protocol:UUIDv4
-     */
-    public static final HashMap<UUID, Integer> mvResourcePacks = new HashMap<>();
-    /**
      * Worlds where random block ticking is disabled.
      */
     public static final List<String> noTickingWorlds = new ArrayList<>();
@@ -3074,37 +3068,6 @@ public class Server {
             StringTokenizer tokenizer = new StringTokenizer(antiXrayWorldsString, ", ");
             while (tokenizer.hasMoreTokens()) {
                 antiXrayWorlds.add(tokenizer.nextToken());
-            }
-        }
-
-        mvResourcePacks.clear();
-        String mvResourcePacksString = this.getPropertyString("multi-version-packs");
-        if (mvResourcePacksString != null && !mvResourcePacksString.trim().isEmpty()) {
-            String[] pairs = mvResourcePacksString.split("\\s*,\\s*");
-            for (String pair : pairs) {
-                String[] parts = pair.split(":");
-                if (parts.length == 2) {
-                    try {
-                        int protocol = Integer.parseInt(parts[0].trim());
-                        boolean isSupported = false;
-                        for (int supported : ProtocolInfo.SUPPORTED_PROTOCOLS) {
-                            if (supported == protocol) {
-                                isSupported = true;
-                                break;
-                            }
-                        }
-                        if (isSupported) {
-                            try {
-                                UUID uuid = UUID.fromString(parts[1].trim());
-                                mvResourcePacks.put(uuid, protocol);
-                            } catch (IllegalArgumentException e) {
-                                this.getLogger().error("Invalid UUID for mvResourcePacks: " + parts[1]);
-                            }
-                        }
-                    } catch (NumberFormatException e) {
-                        this.getLogger().error("Invalid protocol for mvResourcePacks: " + parts[0]);
-                    }
-                }
             }
         }
 

--- a/src/main/java/cn/nukkit/resourcepacks/AbstractResourcePack.java
+++ b/src/main/java/cn/nukkit/resourcepacks/AbstractResourcePack.java
@@ -10,8 +10,7 @@ public abstract class AbstractResourcePack implements ResourcePack {
 
     protected JsonObject manifest;
     private UUID id = null;
-
-    private Integer protocol = null;
+    private int protocol = 0;
 
     protected boolean verifyManifest() {
         if (this.manifest.has("format_version") && this.manifest.has("header") && this.manifest.has("modules")) {
@@ -41,8 +40,8 @@ public abstract class AbstractResourcePack implements ResourcePack {
     }
 
     @Override
-    public Integer getPackProtocol() {
-        if (protocol == null) {
+    public int getPackProtocol() {
+        if (protocol == 0) {
             var header = this.manifest.getAsJsonObject("header");
             protocol = header.has("protocol") ? header.get("protocol").getAsInt() : ProtocolInfo.SUPPORTED_PROTOCOLS.get(0);
         }

--- a/src/main/java/cn/nukkit/resourcepacks/AbstractResourcePack.java
+++ b/src/main/java/cn/nukkit/resourcepacks/AbstractResourcePack.java
@@ -1,5 +1,6 @@
 package cn.nukkit.resourcepacks;
 
+import cn.nukkit.network.protocol.ProtocolInfo;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
@@ -9,6 +10,8 @@ public abstract class AbstractResourcePack implements ResourcePack {
 
     protected JsonObject manifest;
     private UUID id = null;
+
+    private Integer protocol = null;
 
     protected boolean verifyManifest() {
         if (this.manifest.has("format_version") && this.manifest.has("header") && this.manifest.has("modules")) {
@@ -35,6 +38,15 @@ public abstract class AbstractResourcePack implements ResourcePack {
             id = UUID.fromString(this.manifest.getAsJsonObject("header").get("uuid").getAsString());
         }
         return id;
+    }
+
+    @Override
+    public Integer getPackProtocol() {
+        if (protocol == null) {
+            var header = this.manifest.getAsJsonObject("header");
+            protocol = header.has("protocol") ? header.get("protocol").getAsInt() : ProtocolInfo.SUPPORTED_PROTOCOLS.get(0);
+        }
+        return protocol;
     }
 
     @Override

--- a/src/main/java/cn/nukkit/resourcepacks/AbstractResourcePack.java
+++ b/src/main/java/cn/nukkit/resourcepacks/AbstractResourcePack.java
@@ -1,10 +1,11 @@
 package cn.nukkit.resourcepacks;
 
-import cn.nukkit.network.protocol.ProtocolInfo;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
 import java.util.UUID;
+
+import cn.nukkit.network.protocol.ProtocolInfo;
 
 public abstract class AbstractResourcePack implements ResourcePack {
 
@@ -43,7 +44,9 @@ public abstract class AbstractResourcePack implements ResourcePack {
     public int getPackProtocol() {
         if (protocol == 0) {
             var header = this.manifest.getAsJsonObject("header");
-            protocol = header.has("protocol") ? header.get("protocol").getAsInt() : ProtocolInfo.SUPPORTED_PROTOCOLS.get(0);
+            protocol = header.has("min_engine_version") ?
+                    ResourcePackManager.ProtocolConverter.convertToProtocol(header.get("min_engine_version").getAsJsonArray())
+                    : ProtocolInfo.SUPPORTED_PROTOCOLS.get(0);
         }
         return protocol;
     }

--- a/src/main/java/cn/nukkit/resourcepacks/ResourcePack.java
+++ b/src/main/java/cn/nukkit/resourcepacks/ResourcePack.java
@@ -10,7 +10,7 @@ public interface ResourcePack {
 
     UUID getPackId();
 
-    Integer getPackProtocol();
+    int getPackProtocol();
 
     String getPackVersion();
 

--- a/src/main/java/cn/nukkit/resourcepacks/ResourcePack.java
+++ b/src/main/java/cn/nukkit/resourcepacks/ResourcePack.java
@@ -10,6 +10,8 @@ public interface ResourcePack {
 
     UUID getPackId();
 
+    Integer getPackProtocol();
+
     String getPackVersion();
 
     int getPackSize();

--- a/src/main/java/cn/nukkit/resourcepacks/ResourcePack.java
+++ b/src/main/java/cn/nukkit/resourcepacks/ResourcePack.java
@@ -10,7 +10,9 @@ public interface ResourcePack {
 
     UUID getPackId();
 
-    int getPackProtocol();
+    default int getPackProtocol() {
+        return 0;
+    }
 
     String getPackVersion();
 

--- a/src/main/java/cn/nukkit/resourcepacks/ResourcePackManager.java
+++ b/src/main/java/cn/nukkit/resourcepacks/ResourcePackManager.java
@@ -1,13 +1,20 @@
 package cn.nukkit.resourcepacks;
 
 import cn.nukkit.Server;
+import cn.nukkit.network.protocol.ProtocolInfo;
 import cn.nukkit.resourcepacks.loader.ResourcePackLoader;
 import cn.nukkit.resourcepacks.loader.ZippedResourcePackLoader;
+
 import com.google.common.collect.Sets;
+import com.google.gson.JsonArray;
+
 import lombok.extern.log4j.Log4j2;
 
 import java.io.File;
+import java.lang.reflect.Field;
 import java.util.*;
+
+import static cn.nukkit.network.protocol.ProtocolInfo.SUPPORTED_PROTOCOLS;
 
 @Log4j2
 public class ResourcePackManager {
@@ -51,5 +58,75 @@ public class ResourcePackManager {
         });
 
         log.info(Server.getInstance().getLanguage().translateString("nukkit.resources.success", String.valueOf(this.resourcePacks.size())));
+    }
+
+    protected static class ProtocolConverter {
+        private static final Map<String, Integer> PROTOCOL_MAP = new HashMap<>();
+
+        static {
+            Field[] fields = ProtocolInfo.class.getDeclaredFields();
+
+            for (Field field : fields) {
+                String fieldName = field.getName();
+                if (fieldName.startsWith("v") && SUPPORTED_PROTOCOLS.contains(getFieldValue(field))) {
+                    try {
+                        String versionKey = fieldName.substring(1).replace("_", ".");
+                        PROTOCOL_MAP.put(versionKey, (Integer) field.get(null));
+                    } catch (IllegalAccessException e) {
+                        System.err.println("Error accessing field " + fieldName + ": " + e.getMessage());
+                    }
+                }
+            }
+        }
+
+        private static int getFieldValue(Field field) {
+            try {
+                return field.getInt(null);
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException("Failed to get field value: " + field.getName(), e);
+            }
+        }
+
+        public static int convertToProtocol(JsonArray minEngineVersion) {
+            if (minEngineVersion == null || minEngineVersion.size() < 3) {
+                throw new IllegalArgumentException("Invalid minEngineVersion array");
+            }
+
+            int major = minEngineVersion.get(0).getAsInt();
+            int minor = minEngineVersion.get(1).getAsInt();
+            int patch = minEngineVersion.get(2).getAsInt();
+
+            String baseKey = major + "." + minor + "." + patch;
+
+            if (minEngineVersion.size() >= 4) {
+                int extra = minEngineVersion.get(3).getAsInt();
+                String fullKey = baseKey + "." + extra;
+                if (PROTOCOL_MAP.containsKey(fullKey)) {
+                    return PROTOCOL_MAP.get(fullKey);
+                }
+            }
+
+            if (PROTOCOL_MAP.containsKey(baseKey)) {
+                return PROTOCOL_MAP.get(baseKey);
+            }
+
+            return findClosestProtocol(major, minor, patch);
+        }
+
+        private static int findClosestProtocol(int major, int minor, int patch) {
+            for (int p = patch; p >= 0; p--) {
+                String key = major + "." + minor + "." + p;
+                if (PROTOCOL_MAP.containsKey(key)) {
+                    return PROTOCOL_MAP.get(key);
+                }
+            }
+
+            String minorKey = major + "." + minor + ".0";
+            if (PROTOCOL_MAP.containsKey(minorKey)) {
+                return PROTOCOL_MAP.get(minorKey);
+            }
+
+            return SUPPORTED_PROTOCOLS.get(0);
+        }
     }
 }


### PR DESCRIPTION
Adding useful settings for servers

`min_engine_version` in manifest.json
> default: loading all resource packs

Allows you to configure supported resource packs on specific protocols, so that there are no conflicts, you can configure a resource pack for each protocol

**Official parameter on wiki bedrock**

![image](https://github.com/user-attachments/assets/dfec1974-95fd-450a-a20c-e25060de638d)

`space-name-mode`
> default: ignore (allow spaces completely)

The space check mode in nicknames will help to avoid errors with space checks if the `replacing` mode is set

`portal-ticks`
> default: 80

If the value of `vanilla-portals` is false, it allows you to set custom ticks before activating the portal