### PR TITLE
Fix Multi Recipe & Wind Charge

### DIFF
--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -2950,6 +2950,8 @@ public class Server {
         Entity.registerEntity("Human", EntityHuman.class, true);
         Entity.registerEntity("Lightning", EntityLightning.class);
         Entity.registerEntity("AreaEffectCloud", EntityAreaEffectCloud.class);
+
+        Entity.registerEntity("WindCharge", EntityWindCharge.class);
     }
 
     /**

--- a/src/main/java/cn/nukkit/entity/projectile/EntityWindCharge.java
+++ b/src/main/java/cn/nukkit/entity/projectile/EntityWindCharge.java
@@ -1,0 +1,138 @@
+package cn.nukkit.entity.projectile;
+
+import cn.nukkit.entity.Entity;
+import cn.nukkit.entity.EntityLiving;
+import cn.nukkit.event.entity.EntityDamageByEntityEvent;
+import cn.nukkit.event.entity.EntityDamageEvent;
+import cn.nukkit.level.format.FullChunk;
+import cn.nukkit.level.particle.GenericParticle;
+import cn.nukkit.level.particle.Particle;
+import cn.nukkit.math.Vector3;
+import cn.nukkit.nbt.tag.CompoundTag;
+import cn.nukkit.network.protocol.LevelSoundEventPacket;
+
+/**
+ * @author glorydark
+ */
+public class EntityWindCharge extends EntityProjectile {
+
+    public static final int NETWORK_ID = 143;
+
+    public Entity directionChanged;
+
+    public EntityWindCharge(FullChunk chunk, CompoundTag nbt) {
+        this(chunk, nbt, null);
+    }
+
+    public EntityWindCharge(FullChunk chunk, CompoundTag nbt, Entity shootingEntity) {
+        super(chunk, nbt, shootingEntity);
+    }
+
+    @Override
+    public int getNetworkId() {
+        return NETWORK_ID;
+    }
+
+    @Override
+    public void onCollideWithEntity(Entity entity) {
+        if (directionChanged != null) {
+            if(directionChanged == entity) return;
+        }
+        entity.attack(new EntityDamageByEntityEvent(this, entity, EntityDamageEvent.DamageCause.PROJECTILE, 1f));
+        level.addLevelSoundEvent(entity.getPosition().add(0, 1), LevelSoundEventPacket.SOUND_WIND_CHARGE_BURST);
+        knockBack(entity);
+        this.kill();
+    }
+
+    @Override
+    public void onHit() {
+        for (Entity entity : level.getEntities()) {
+            if (entity instanceof EntityLiving entityLiving) {
+                if (entityLiving.distance(this) < getBurstRadius()) {
+                    this.knockBack(entityLiving);
+                }
+            }
+        }
+        level.addLevelSoundEvent(this.add(0, 1), LevelSoundEventPacket.SOUND_WIND_CHARGE_BURST);
+        this.kill();
+
+        this.level.addParticle(new GenericParticle(this, Particle.TYPE_WIND_EXPLOSION));
+    }
+
+    @Override
+    public boolean attack(EntityDamageEvent source) {
+        if (this.directionChanged == null && source instanceof EntityDamageByEntityEvent event) {
+            this.directionChanged = event.getDamager();
+            this.setMotion(event.getDamager().getDirectionVector());
+            this.level.addParticle(new GenericParticle(event.getDamager(), Particle.TYPE_WIND_EXPLOSION));
+        }
+        return true;
+    }
+
+    @Override
+    public boolean onUpdate(int currentTick) {
+        if (this.closed) {
+            return false;
+        }
+
+        boolean hasUpdate = super.onUpdate(currentTick);
+
+        if (this.age > 1200 || this.isCollided) {
+            this.kill();
+            hasUpdate = true;
+        }
+
+        return hasUpdate;
+    }
+
+
+    @Override
+    public float getWidth() {
+        return 0.3125f;
+    }
+
+    @Override
+    public float getLength() {
+        return 0.3125f;
+    }
+
+    @Override
+    public float getHeight() {
+        return 0.3125f;
+    }
+
+    @Override
+    protected float getGravity() {
+        return 0.00f;
+    }
+
+    @Override
+    protected float getDrag() {
+        return 0.01f;
+    }
+
+    public double getBurstRadius() {
+        return 2f;
+    }
+
+    public double getKnockbackStrength() {
+        return 0.2f;
+    }
+
+    protected void knockBack(Entity entity) {
+        Vector3 knockback = new Vector3(entity.motionX, entity.motionY, entity.motionZ);
+        knockback.x /= 2d;
+        knockback.y /= 2d;
+        knockback.z /= 2d;
+        knockback.x -= (this.getX() - entity.getX()) * getKnockbackStrength();
+        knockback.y += 1.0f;
+        knockback.z -= (this.getZ() - entity.getZ()) * getKnockbackStrength();
+
+        entity.setMotion(knockback);
+    }
+
+    @Override
+    public String getName() {
+        return "Wind Charge Projectile";
+    }
+}

--- a/src/main/java/cn/nukkit/inventory/CraftingManager.java
+++ b/src/main/java/cn/nukkit/inventory/CraftingManager.java
@@ -301,6 +301,7 @@ public class CraftingManager {
                         break;
                     case 4:
                         String uuid = (String) recipe.get("uuid");
+                        // TODO: when cartography is supported, this should be removed and add relevant checks like MapCloningRecipe.class.
                         if (MultiRecipe.unsupportedRecipes.contains(uuid)) {
                             this.registerRecipe(new UncheckedMultiRecipe(uuid));
                         }

--- a/src/main/java/cn/nukkit/inventory/CraftingManager.java
+++ b/src/main/java/cn/nukkit/inventory/CraftingManager.java
@@ -2,6 +2,9 @@ package cn.nukkit.inventory;
 
 import cn.nukkit.Player;
 import cn.nukkit.Server;
+import cn.nukkit.inventory.special.BookCloningRecipe;
+import cn.nukkit.inventory.special.MapCloningRecipe;
+import cn.nukkit.inventory.special.UncheckedMultiRecipe;
 import cn.nukkit.inventory.special.RepairItemRecipe;
 import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemFirework;
@@ -130,6 +133,8 @@ public class CraftingManager {
     public CraftingManager() {
         MainLogger.getLogger().debug("Loading recipes...");
         this.registerMultiRecipe(new RepairItemRecipe());
+        this.registerMultiRecipe(new BookCloningRecipe());
+        this.registerMultiRecipe(new MapCloningRecipe());
 
         ConfigSection recipes_649_config = new Config(Config.YAML).loadFromStream(Server.class.getClassLoader().getResourceAsStream("recipes649.json")).getRootSection();
         ConfigSection recipes_419_config = new Config(Config.YAML).loadFromStream(Server.class.getClassLoader().getResourceAsStream("recipes419.json")).getRootSection();
@@ -291,9 +296,12 @@ public class CraftingManager {
                                 break;
                         }
                         break;
-                    /*case 4:
-                        this.registerRecipe(new MultiRecipe(UUID.fromString((String) recipe.get("uuid"))));
-                        break;*/
+                    case 4:
+                        String uuid = (String) recipe.get("uuid");
+                        if (MultiRecipe.unsupportedRecipes.contains(uuid)) {
+                            this.registerRecipe(new UncheckedMultiRecipe(uuid));
+                        }
+                        break;
                     default:
                         break;
                 }

--- a/src/main/java/cn/nukkit/inventory/CraftingManager.java
+++ b/src/main/java/cn/nukkit/inventory/CraftingManager.java
@@ -2,10 +2,7 @@ package cn.nukkit.inventory;
 
 import cn.nukkit.Player;
 import cn.nukkit.Server;
-import cn.nukkit.inventory.special.BookCloningRecipe;
-import cn.nukkit.inventory.special.MapCloningRecipe;
-import cn.nukkit.inventory.special.UncheckedMultiRecipe;
-import cn.nukkit.inventory.special.RepairItemRecipe;
+import cn.nukkit.inventory.special.*;
 import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemFirework;
 import cn.nukkit.item.ItemID;
@@ -135,6 +132,12 @@ public class CraftingManager {
         this.registerMultiRecipe(new RepairItemRecipe());
         this.registerMultiRecipe(new BookCloningRecipe());
         this.registerMultiRecipe(new MapCloningRecipe());
+        this.registerMultiRecipe(new MapUpgradingRecipe());
+        this.registerMultiRecipe(new MapExtendingRecipe());
+        this.registerMultiRecipe(new BannerAddPatternRecipe());
+        this.registerMultiRecipe(new BannerDuplicateRecipe());
+        this.registerMultiRecipe(new FireworkRecipe());
+        this.registerMultiRecipe(new DecoratedPotRecipe());
 
         ConfigSection recipes_649_config = new Config(Config.YAML).loadFromStream(Server.class.getClassLoader().getResourceAsStream("recipes649.json")).getRootSection();
         ConfigSection recipes_419_config = new Config(Config.YAML).loadFromStream(Server.class.getClassLoader().getResourceAsStream("recipes419.json")).getRootSection();

--- a/src/main/java/cn/nukkit/inventory/MultiRecipe.java
+++ b/src/main/java/cn/nukkit/inventory/MultiRecipe.java
@@ -29,6 +29,7 @@ public class MultiRecipe implements Recipe {
     public static final String TYPE_MAP_CLONING_CARTOGRAPHY = "442D85ED-8272-4543-A6F1-418F90DED05D";
     public static final String TYPE_MAP_LOCKING_CARTOGRAPHY = "602234E4-CAC1-4353-8BB7-B1EBFF70024B";
 
+    // TODO: when cartography is supported, this should be removed and add relevant checks like MapCloningRecipe.class.
     public static final List<String> unsupportedRecipes = new ArrayList<>() {
         {
             this.add(TYPE_MAP_EXTENDING_CARTOGRAPHY);

--- a/src/main/java/cn/nukkit/inventory/MultiRecipe.java
+++ b/src/main/java/cn/nukkit/inventory/MultiRecipe.java
@@ -1,9 +1,9 @@
 package cn.nukkit.inventory;
 
 import cn.nukkit.Player;
-import cn.nukkit.inventory.transaction.CraftingTransaction;
 import cn.nukkit.item.Item;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -28,6 +28,22 @@ public class MultiRecipe implements Recipe {
     public static final String TYPE_MAP_UPGRADING_CARTOGRAPHY = "98C84B38-1085-46BD-B1CE-DD38C159E6CC";
     public static final String TYPE_MAP_CLONING_CARTOGRAPHY = "442D85ED-8272-4543-A6F1-418F90DED05D";
     public static final String TYPE_MAP_LOCKING_CARTOGRAPHY = "602234E4-CAC1-4353-8BB7-B1EBFF70024B";
+
+    public static final List<String> unsupportedRecipes = new ArrayList<>() {
+        {
+            this.add(TYPE_MAP_EXTENDING);
+            this.add(TYPE_MAP_CLONING);
+            this.add(TYPE_MAP_UPGRADING);
+            this.add(TYPE_DECORATED_POT_RECIPE);
+            this.add(TYPE_BANNER_DUPLICATE);
+            this.add(TYPE_BANNER_ADD_PATTERN);
+            this.add(TYPE_FIREWORKS);
+            this.add(TYPE_MAP_EXTENDING_CARTOGRAPHY);
+            this.add(TYPE_MAP_UPGRADING_CARTOGRAPHY);
+            this.add(TYPE_MAP_CLONING_CARTOGRAPHY);
+            this.add(TYPE_MAP_LOCKING_CARTOGRAPHY);
+        }
+    };
 
     public MultiRecipe(UUID id) {
         this.id = id;

--- a/src/main/java/cn/nukkit/inventory/MultiRecipe.java
+++ b/src/main/java/cn/nukkit/inventory/MultiRecipe.java
@@ -31,13 +31,6 @@ public class MultiRecipe implements Recipe {
 
     public static final List<String> unsupportedRecipes = new ArrayList<>() {
         {
-            this.add(TYPE_MAP_EXTENDING);
-            this.add(TYPE_MAP_CLONING);
-            this.add(TYPE_MAP_UPGRADING);
-            this.add(TYPE_DECORATED_POT_RECIPE);
-            this.add(TYPE_BANNER_DUPLICATE);
-            this.add(TYPE_BANNER_ADD_PATTERN);
-            this.add(TYPE_FIREWORKS);
             this.add(TYPE_MAP_EXTENDING_CARTOGRAPHY);
             this.add(TYPE_MAP_UPGRADING_CARTOGRAPHY);
             this.add(TYPE_MAP_CLONING_CARTOGRAPHY);

--- a/src/main/java/cn/nukkit/inventory/special/BannerAddPatternRecipe.java
+++ b/src/main/java/cn/nukkit/inventory/special/BannerAddPatternRecipe.java
@@ -1,0 +1,34 @@
+package cn.nukkit.inventory.special;
+
+import cn.nukkit.Player;
+import cn.nukkit.inventory.MultiRecipe;
+import cn.nukkit.item.Item;
+import cn.nukkit.item.ItemDye;
+import cn.nukkit.item.ItemID;
+
+import java.util.List;
+import java.util.UUID;
+
+public class BannerAddPatternRecipe extends MultiRecipe {
+
+    public BannerAddPatternRecipe(){
+        super(UUID.fromString(TYPE_BANNER_ADD_PATTERN));
+    }
+
+    @Override
+    public boolean canExecute(Player player, Item outputItem, List<Item> inputs) {
+        if (outputItem.getId() != ItemID.BANNER) {
+            return false;
+        }
+        int dyeCount = 0;
+        for (Item input : inputs) {
+            if (input instanceof ItemDye) {
+                dyeCount += 1;
+            }
+        }
+        if (dyeCount < 3) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/cn/nukkit/inventory/special/BannerDuplicateRecipe.java
+++ b/src/main/java/cn/nukkit/inventory/special/BannerDuplicateRecipe.java
@@ -1,0 +1,35 @@
+package cn.nukkit.inventory.special;
+
+import cn.nukkit.Player;
+import cn.nukkit.inventory.MultiRecipe;
+import cn.nukkit.item.Item;
+import cn.nukkit.item.ItemID;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public class BannerDuplicateRecipe extends MultiRecipe {
+
+    public BannerDuplicateRecipe(){
+        super(UUID.fromString(TYPE_BANNER_DUPLICATE));
+    }
+
+    @Override
+    public boolean canExecute(Player player, Item outputItem, List<Item> inputs) {
+        int count = 0;
+        for (Item input : inputs) {
+            if (input.getId() != ItemID.BANNER) {
+                return false;
+            }
+            count += 1;
+        }
+        if (count < 2) {
+            return false;
+        }
+        if (outputItem.getId() == ItemID.BANNER) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/cn/nukkit/inventory/special/BookCloningRecipe.java
+++ b/src/main/java/cn/nukkit/inventory/special/BookCloningRecipe.java
@@ -1,0 +1,33 @@
+package cn.nukkit.inventory.special;
+
+import cn.nukkit.Player;
+import cn.nukkit.inventory.MultiRecipe;
+import cn.nukkit.inventory.Recipe;
+import cn.nukkit.item.Item;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * @author glorydark
+ * @date {2024/1/8} {16:04}
+ */
+public class BookCloningRecipe extends MultiRecipe {
+
+    public BookCloningRecipe(){
+        super(UUID.fromString(TYPE_BOOK_CLONING));
+    }
+
+    @Override
+    public boolean canExecute(Player player, Item outputItem, List<Item> inputs) {
+        // Processing the checks about the inputs and outputItem
+        if (inputs.size() == 2) {
+            Item item1 = inputs.get(0);
+            Item item2 = inputs.get(1);
+            if (item1.getId() == Item.WRITTEN_BOOK && item2.getId() == Item.BOOK_AND_QUILL) {
+                return true;
+            } else return item1.getId() == Item.BOOK_AND_QUILL && item2.getId() == Item.WRITTEN_BOOK;
+        }
+        return false;
+    }
+}

--- a/src/main/java/cn/nukkit/inventory/special/BookCloningRecipe.java
+++ b/src/main/java/cn/nukkit/inventory/special/BookCloningRecipe.java
@@ -8,10 +8,6 @@ import cn.nukkit.item.Item;
 import java.util.List;
 import java.util.UUID;
 
-/**
- * @author glorydark
- * @date {2024/1/8} {16:04}
- */
 public class BookCloningRecipe extends MultiRecipe {
 
     public BookCloningRecipe(){

--- a/src/main/java/cn/nukkit/inventory/special/DecoratedPotRecipe.java
+++ b/src/main/java/cn/nukkit/inventory/special/DecoratedPotRecipe.java
@@ -1,0 +1,38 @@
+package cn.nukkit.inventory.special;
+
+import cn.nukkit.Player;
+import cn.nukkit.inventory.MultiRecipe;
+import cn.nukkit.item.Item;
+import cn.nukkit.item.ItemID;
+import cn.nukkit.item.ItemPotterySherd;
+
+import java.util.List;
+import java.util.UUID;
+
+public class DecoratedPotRecipe extends MultiRecipe {
+
+    public DecoratedPotRecipe(){
+        super(UUID.fromString(TYPE_DECORATED_POT_RECIPE));
+    }
+
+    @Override
+    public boolean canExecute(Player player, Item outputItem, List<Item> inputs) {
+        if (outputItem.getId() != Item.DECORATED_POT) {
+            return false;
+        }
+        int brickCount = 0;
+        int sherdCount = 0;
+        for (Item input : inputs) {
+            if (input.getId() == ItemID.BRICK) {
+                brickCount += 1;
+            }
+            if (input instanceof ItemPotterySherd) {
+                sherdCount += 1;
+            }
+        }
+        if (sherdCount + brickCount < 4) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/cn/nukkit/inventory/special/FireworkRecipe.java
+++ b/src/main/java/cn/nukkit/inventory/special/FireworkRecipe.java
@@ -1,0 +1,39 @@
+package cn.nukkit.inventory.special;
+
+import cn.nukkit.Player;
+import cn.nukkit.inventory.MultiRecipe;
+import cn.nukkit.item.Item;
+import cn.nukkit.item.ItemID;
+
+import java.util.List;
+import java.util.UUID;
+
+public class FireworkRecipe extends MultiRecipe {
+
+    public FireworkRecipe(){
+        super(UUID.fromString(TYPE_FIREWORKS));
+    }
+
+    @Override
+    public boolean canExecute(Player player, Item outputItem, List<Item> inputs) {
+        if (outputItem.getId() == ItemID.FIREWORKS) {
+            boolean hasPaper = false;
+            int powder = 0;
+            for (Item input : inputs) {
+                if (input.getId() == ItemID.GUNPOWDER) {
+                    powder += 1;
+                } else if (input.getId() == ItemID.PAPER) {
+                    hasPaper = true;
+                }
+            }
+            if (!hasPaper) {
+                return false;
+            }
+            if (powder != outputItem.getCount()) {
+                return false;
+            }
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/cn/nukkit/inventory/special/MapCloningRecipe.java
+++ b/src/main/java/cn/nukkit/inventory/special/MapCloningRecipe.java
@@ -7,26 +7,32 @@ import cn.nukkit.item.Item;
 import java.util.List;
 import java.util.UUID;
 
-/**
- * @author glorydark
- * @date {2024/1/8} {16:04}
- */
 public class MapCloningRecipe extends MultiRecipe {
 
     public MapCloningRecipe(){
-        super(UUID.fromString(TYPE_BOOK_CLONING));
+        super(UUID.fromString(TYPE_MAP_CLONING));
     }
 
     @Override
     public boolean canExecute(Player player, Item outputItem, List<Item> inputs) {
-        // Processing the checks about the inputs and outputItem
-        if (inputs.size() == 2) {
-            Item item1 = inputs.get(0);
-            Item item2 = inputs.get(1);
-            if (item1.getId() == Item.MAP && item2.getId() == Item.EMPTY_MAP) {
-                return true;
-            } else return item1.getId() == Item.EMPTY_MAP && item2.getId() == Item.MAP;
+        if (outputItem.getId() != Item.MAP) {
+            return false;
         }
-        return false;
+        int filledMap = 0;
+        int emptyMap = 0;
+        for (Item input : inputs) {
+            if (input.getId() == Item.MAP) {
+                filledMap += input.getCount();
+            } else if (input.getId() == Item.EMPTY_MAP) {
+                emptyMap += input.getCount();
+            }
+        }
+        if (filledMap == 0 || emptyMap == 0) {
+            return false;
+        }
+        if (outputItem.getCount() - 1 != emptyMap) {
+            return false;
+        }
+        return true;
     }
 }

--- a/src/main/java/cn/nukkit/inventory/special/MapCloningRecipe.java
+++ b/src/main/java/cn/nukkit/inventory/special/MapCloningRecipe.java
@@ -1,0 +1,32 @@
+package cn.nukkit.inventory.special;
+
+import cn.nukkit.Player;
+import cn.nukkit.inventory.MultiRecipe;
+import cn.nukkit.item.Item;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * @author glorydark
+ * @date {2024/1/8} {16:04}
+ */
+public class MapCloningRecipe extends MultiRecipe {
+
+    public MapCloningRecipe(){
+        super(UUID.fromString(TYPE_BOOK_CLONING));
+    }
+
+    @Override
+    public boolean canExecute(Player player, Item outputItem, List<Item> inputs) {
+        // Processing the checks about the inputs and outputItem
+        if (inputs.size() == 2) {
+            Item item1 = inputs.get(0);
+            Item item2 = inputs.get(1);
+            if (item1.getId() == Item.MAP && item2.getId() == Item.EMPTY_MAP) {
+                return true;
+            } else return item1.getId() == Item.EMPTY_MAP && item2.getId() == Item.MAP;
+        }
+        return false;
+    }
+}

--- a/src/main/java/cn/nukkit/inventory/special/MapExtendingRecipe.java
+++ b/src/main/java/cn/nukkit/inventory/special/MapExtendingRecipe.java
@@ -1,0 +1,42 @@
+
+package cn.nukkit.inventory.special;
+
+import cn.nukkit.Player;
+import cn.nukkit.inventory.MultiRecipe;
+import cn.nukkit.item.Item;
+import cn.nukkit.item.ItemID;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public class MapExtendingRecipe extends MultiRecipe {
+
+    public MapExtendingRecipe(){
+        super(UUID.fromString(TYPE_MAP_EXTENDING));
+    }
+
+    @Override
+    public boolean canExecute(Player player, Item outputItem, List<Item> inputs) {
+        // todo: I guess this recipe is similar to MapUpgradingRecipe, but without certain ideas.
+        if (outputItem.getId() != ItemID.MAP && outputItem.getCount() != 1) {
+            return false;
+        }
+        int filledMap = 0;
+        int paper = 0;
+        for (Item input : inputs) {
+            if (input.getId() == ItemID.MAP) {
+                filledMap += 1;
+            } else if (input.getId() == ItemID.PAPER) {
+                paper += 1;
+            }
+        }
+        if (filledMap < 1) {
+            return false;
+        }
+        if (paper < 8) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/cn/nukkit/inventory/special/MapUpgradingRecipe.java
+++ b/src/main/java/cn/nukkit/inventory/special/MapUpgradingRecipe.java
@@ -1,0 +1,42 @@
+
+
+package cn.nukkit.inventory.special;
+
+import cn.nukkit.Player;
+import cn.nukkit.inventory.MultiRecipe;
+import cn.nukkit.item.Item;
+import cn.nukkit.item.ItemID;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public class MapUpgradingRecipe extends MultiRecipe {
+
+    public MapUpgradingRecipe(){
+        super(UUID.fromString(TYPE_MAP_UPGRADING));
+    }
+
+    @Override
+    public boolean canExecute(Player player, Item outputItem, List<Item> inputs) {
+        if (outputItem.getId() != ItemID.MAP && outputItem.getCount() != 1) {
+            return false;
+        }
+        int filledMap = 0;
+        int paper = 0;
+        for (Item input : inputs) {
+            if (input.getId() == ItemID.MAP) {
+                filledMap += 1;
+            } else if (input.getId() == ItemID.PAPER) {
+                paper += 1;
+            }
+        }
+        if (filledMap != 1) {
+            return false;
+        }
+        if (paper != 8) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/cn/nukkit/inventory/special/RepairItemRecipe.java
+++ b/src/main/java/cn/nukkit/inventory/special/RepairItemRecipe.java
@@ -7,10 +7,6 @@ import cn.nukkit.item.Item;
 import java.util.List;
 import java.util.UUID;
 
-/**
- * @author glorydark
- * @date {2024/1/8} {16:04}
- */
 public class RepairItemRecipe extends MultiRecipe {
 
     public RepairItemRecipe(){

--- a/src/main/java/cn/nukkit/inventory/special/UncheckedMultiRecipe.java
+++ b/src/main/java/cn/nukkit/inventory/special/UncheckedMultiRecipe.java
@@ -7,6 +7,9 @@ import cn.nukkit.item.Item;
 import java.util.List;
 import java.util.UUID;
 
+/*
+   TODO: when cartography is supported, this should be disused.
+ */
 public class UncheckedMultiRecipe extends MultiRecipe {
 
     public UncheckedMultiRecipe(String id){

--- a/src/main/java/cn/nukkit/inventory/special/UncheckedMultiRecipe.java
+++ b/src/main/java/cn/nukkit/inventory/special/UncheckedMultiRecipe.java
@@ -19,7 +19,6 @@ public class UncheckedMultiRecipe extends MultiRecipe {
 
     @Override
     public boolean canExecute(Player player, Item outputItem, List<Item> inputs) {
-        // Processing the checks about the inputs and outputItem
         return true;
     }
 }

--- a/src/main/java/cn/nukkit/inventory/special/UncheckedMultiRecipe.java
+++ b/src/main/java/cn/nukkit/inventory/special/UncheckedMultiRecipe.java
@@ -1,0 +1,25 @@
+package cn.nukkit.inventory.special;
+
+import cn.nukkit.Player;
+import cn.nukkit.inventory.MultiRecipe;
+import cn.nukkit.item.Item;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * @author glorydark
+ * @date {2024/1/8} {16:04}
+ */
+public class UncheckedMultiRecipe extends MultiRecipe {
+
+    public UncheckedMultiRecipe(String id){
+        super(UUID.fromString(id));
+    }
+
+    @Override
+    public boolean canExecute(Player player, Item outputItem, List<Item> inputs) {
+        // Processing the checks about the inputs and outputItem
+        return true;
+    }
+}

--- a/src/main/java/cn/nukkit/inventory/special/UncheckedMultiRecipe.java
+++ b/src/main/java/cn/nukkit/inventory/special/UncheckedMultiRecipe.java
@@ -7,10 +7,6 @@ import cn.nukkit.item.Item;
 import java.util.List;
 import java.util.UUID;
 
-/**
- * @author glorydark
- * @date {2024/1/8} {16:04}
- */
 public class UncheckedMultiRecipe extends MultiRecipe {
 
     public UncheckedMultiRecipe(String id){

--- a/src/main/java/cn/nukkit/item/ItemMap.java
+++ b/src/main/java/cn/nukkit/item/ItemMap.java
@@ -142,9 +142,4 @@ public class ItemMap extends Item {
     public boolean canBeActivated() {
         return true;
     }
-
-    @Override
-    public int getMaxStackSize() {
-        return 1;
-    }
 }

--- a/src/main/java/cn/nukkit/item/ItemWindCharge.java
+++ b/src/main/java/cn/nukkit/item/ItemWindCharge.java
@@ -6,7 +6,7 @@ import cn.nukkit.network.protocol.ProtocolInfo;
  * @author MagicDroidX
  * Nukkit Project
  */
-public class ItemWindCharge extends StringItemBase {
+public class ItemWindCharge extends StringItemProjectileBase {
 
     public ItemWindCharge() {
         super("minecraft:wind_charge", "Wind Charge");
@@ -15,5 +15,20 @@ public class ItemWindCharge extends StringItemBase {
     @Override
     public boolean isSupportedOn(int protocolId) {
         return protocolId >= ProtocolInfo.v1_21_0;
+    }
+
+    @Override
+    public int getMaxStackSize() {
+        return 16;
+    }
+
+    @Override
+    public String getProjectileEntityType() {
+        return "WindCharge";
+    }
+
+    @Override
+    public float getThrowForce() {
+        return 1.5f;
     }
 }

--- a/src/main/java/cn/nukkit/item/StringItemProjectileBase.java
+++ b/src/main/java/cn/nukkit/item/StringItemProjectileBase.java
@@ -1,0 +1,45 @@
+package cn.nukkit.item;
+
+import cn.nukkit.network.protocol.ProtocolInfo;
+import com.google.common.base.Preconditions;
+import org.jetbrains.annotations.NotNull;
+
+import javax.annotation.Nullable;
+
+public abstract class StringItemProjectileBase extends ProjectileItem implements StringItem {
+
+    private final String namespaceId;
+
+    public StringItemProjectileBase(@NotNull String namespaceId, @Nullable String name) {
+        super(STRING_IDENTIFIED_ITEM, 0, 1, StringItem.notEmpty(name));
+        Preconditions.checkNotNull(namespaceId, "id can't be null");
+        Preconditions.checkArgument(namespaceId.contains(":"), "The ID must be a namespaced ID, like minecraft:stone");
+        this.namespaceId = namespaceId;
+        clearNamedTag();
+    }
+
+    @Override
+    public String getNamespaceId() {
+        return this.namespaceId;
+    }
+
+    @Override
+    public String getNamespaceId(int protocolId) {
+        return this.getNamespaceId();
+    }
+
+    @Override
+    public final int getId() {
+        return StringItem.super.getId();
+    }
+
+    @Override
+    public StringItemProjectileBase clone() {
+        return (StringItemProjectileBase) super.clone();
+    }
+
+    @Override
+    public boolean isSupportedOn(int protocolId) {
+        return protocolId >= ProtocolInfo.v1_16_100;
+    }
+}


### PR DESCRIPTION
1. Multi Recipe: Now, it only checks three multi recipes (Book Cloning, Item Repairing, Map Cloning) while others are unchecked and controlled by clients. 
2. Wind Charge: Add initial implementation of wind charge