### PR TITLE
Add Tooltip Options To Some Form Elements

### DIFF
--- a/src/main/java/cn/nukkit/form/element/ElementDropdown.java
+++ b/src/main/java/cn/nukkit/form/element/ElementDropdown.java
@@ -13,6 +13,10 @@ public class ElementDropdown extends Element {
     private List<String> options;
     @SerializedName("default")
     private int defaultOptionIndex = 0;
+    /**
+     * This option will show an exclamation icon that will display a tooltip if it is hovered.
+     */
+    private String tooltip = "";
 
     public ElementDropdown(String text) {
         this(text, new ArrayList<>());
@@ -56,5 +60,13 @@ public class ElementDropdown extends Element {
     public void addOption(String option, boolean isDefault) {
         options.add(option);
         if (isDefault) this.defaultOptionIndex = options.size() - 1;
+    }
+
+    public String getTooltip() {
+        return tooltip;
+    }
+
+    public void setTooltip(String tooltip) {
+        this.tooltip = tooltip;
     }
 }

--- a/src/main/java/cn/nukkit/form/element/ElementInput.java
+++ b/src/main/java/cn/nukkit/form/element/ElementInput.java
@@ -10,6 +10,10 @@ public class ElementInput extends Element {
     private String placeholder = "";
     @SerializedName("default")
     private String defaultText = "";
+    /**
+     * This option will show an exclamation icon that will display a tooltip if it is hovered.
+     */
+    private String tooltip = "";
 
     public ElementInput(String text) {
         this(text, "");
@@ -47,5 +51,13 @@ public class ElementInput extends Element {
 
     public void setDefaultText(String defaultText) {
         this.defaultText = defaultText;
+    }
+
+    public String getTooltip() {
+        return tooltip;
+    }
+
+    public void setTooltip(String tooltip) {
+        this.tooltip = tooltip;
     }
 }

--- a/src/main/java/cn/nukkit/form/element/ElementLabel.java
+++ b/src/main/java/cn/nukkit/form/element/ElementLabel.java
@@ -5,6 +5,10 @@ public class ElementLabel extends Element implements SimpleElement {
     @SuppressWarnings("unused")
     private final String type = "label"; //This variable is used for JSON import operations. Do NOT delete :) -- @Snake1999
     private String text = "";
+    /**
+     * This option will show an exclamation icon that will display a tooltip if it is hovered.
+     */
+    private String tooltip = "";
 
     public ElementLabel(String text) {
         this.text = text;
@@ -16,5 +20,13 @@ public class ElementLabel extends Element implements SimpleElement {
 
     public void setText(String text) {
         this.text = text;
+    }
+
+    public String getTooltip() {
+        return tooltip;
+    }
+
+    public void setTooltip(String tooltip) {
+        this.tooltip = tooltip;
     }
 }

--- a/src/main/java/cn/nukkit/form/element/ElementSlider.java
+++ b/src/main/java/cn/nukkit/form/element/ElementSlider.java
@@ -12,6 +12,10 @@ public class ElementSlider extends Element {
     private int step;
     @SerializedName("default")
     private float defaultValue;
+    /**
+     * This option will show an exclamation icon that will display a tooltip if it is hovered.
+     */
+    private String tooltip = "";
 
     public ElementSlider(String text, float min, float max) {
         this(text, min, max, -1);
@@ -67,5 +71,13 @@ public class ElementSlider extends Element {
 
     public void setDefaultValue(float defaultValue) {
         this.defaultValue = defaultValue;
+    }
+
+    public String getTooltip() {
+        return tooltip;
+    }
+
+    public void setTooltip(String tooltip) {
+        this.tooltip = tooltip;
     }
 }


### PR DESCRIPTION
This allows some elements decorated with exclamation sign. When the element's exclaimation is hovered, it will display a text field as a warning, etc.

![QQ20250620-094053](https://github.com/user-attachments/assets/452acb80-f73e-4f71-9f50-39229f2b0d89)

# Ref
`@minecraft/server-ui 2.0.0
@minecraft/server-ui 2.0.0 is now released, 2.1.0-beta is the new beta version for @minecraft/server-ui
Fixed bug where sliders move super fast when using gamepad. Added a timeout to avoid this problem
Moved ModalFormDataDropdownOptions from beta to 2.0.0.
Moved ModalFormDataSliderOptions from beta to 2.0.0.
Moved ModalFormDataTextFieldOptions from beta to 2.0.0.
Moved ModalFormDataToggleOptions from beta to 2.0.0.`