### PR TITLE
feat: 支持Legacy模式自定义物品以兼容老版本客户端

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -3039,12 +3039,13 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                                 for (Entry<String, CustomItemDefinition> entry : itemDefinitions) {
                                     try {
                                         Item item = Item.fromString(entry.getKey());
+                                        CustomItemDefinition def = entry.getValue();
                                         entries.add(new ItemComponentPacket.ItemDefinition(
                                                 entry.getKey(),
                                                 item.getNetworkId(this.protocol),
-                                                true,
-                                                1,
-                                                entry.getValue().getNbt(this.protocol)
+                                                def.isComponentBased(),
+                                                def.getVersion(),
+                                                def.getNbt(this.protocol)
                                         ));
                                     } catch (Exception e) {
                                         log.error("ItemComponentPacket encoding error", e);
@@ -3060,12 +3061,13 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                                 for (var entry : itemDefinition.entrySet()) {
                                     try {
                                         Item item = Item.fromString(entry.getKey());
+                                        CustomItemDefinition def = entry.getValue();
                                         entries.add(new ItemComponentPacket.ItemDefinition(
                                                 entry.getKey(),
                                                 item.getNetworkId(this.protocol),
-                                                true,
-                                                1,
-                                                entry.getValue().getNbt(this.protocol).putShort("minecraft:identifier", i)
+                                                def.isComponentBased(),
+                                                def.getVersion(),
+                                                def.getNbt(this.protocol).putShort("minecraft:identifier", i)
                                         ));
                                         i++;
                                     } catch (Exception e) {

--- a/src/main/java/cn/nukkit/item/RuntimeItemMapping.java
+++ b/src/main/java/cn/nukkit/item/RuntimeItemMapping.java
@@ -275,7 +275,8 @@ public class RuntimeItemMapping {
                 if (Server.getInstance().enableExperimentMode && protocolId >= ProtocolInfo.v1_16_100) {
                     paletteBuffer.putString(entry.getIdentifier());
                     paletteBuffer.putLShort(entry.getRuntimeId());
-                    paletteBuffer.putBoolean(true); // Component item
+                    var def = Item.getCustomItemDefinition().get(entry.getIdentifier());
+                    paletteBuffer.putBoolean(def != null && def.isComponentBased());
                 }
             } else {
                 paletteBuffer.putString(entry.getIdentifier());


### PR DESCRIPTION
## 背景

当前CustomItemDefinition只支持Component-based模式（version=1），这是基岩版较新版本的物品注册方式。但存在以下问题：

1. **老版本客户端不兼容**：远古版本如基岩版1.10使用的是Legacy模式（version=0）
2. **中国版（网易版）无法支持**：中国版一直使用1.10这个远古版本，并且有自己独有的组件扩展
3. **强制使用新版协议**：服务端必须通过NBT完全定义物品，无法利用客户端资源包

## 解决方案

实现双模式注册系统，兼容新老版本客户端：

### Legacy模式 (version=0)
- 兼容老版本基岩版（如1.10）
- 支持中国版（网易版）及其独有组件
- 服务端只注册物品标识符，贴图和组件由客户端资源包提供

### Component-based模式 (version=1)
- 保持现有方式，兼容新版客户端
- 服务端完全控制物品定义

## 核心实现

### 1. 新增注册模式枚举 (`ItemRegistrationMode`)
- `LEGACY`: 老版本注册方式，用于1.10等远古版本
- `COMPONENT_BASED`: 新版本注册方式

### 2. 新增Builder类

**LegacyItemBuilder**: 通用Legacy物品构建器
- `maxStackSize()`: 设置堆叠数量
- `component()`: 添加自定义组件（支持网易版独有组件）
- `customNBT()`: 自定义NBT处理

**LegacyFoodBuilder**: Legacy食物构建器
- `foodProperties()`: 设置食物属性
- `useDuration()`: 使用时长
- `usingConvertsTo()`: 消耗后转换物品

### 3. 网络层适配
- `ItemComponentPacket`: 根据注册模式发送正确的version字段（0或1）
- `RuntimeItemMapping`: 在ItemPalette中正确标记component item

## 使用示例

```java
// Legacy模式 - 兼容1.10等老版本
CustomItemDefinition legacyDef = CustomItemDefinition
    .legacyBuilder(myItem)
    .maxStackSize(64)
    .build();

// Legacy模式 - 食物（兼容中国版）
CustomItemDefinition foodDef = CustomItemDefinition
    .legacyFoodBuilder(myFoodItem)
    .foodProperties(4, 0.6f, false)
    .useDuration(32)
    .usingConvertsTo("glass_bottle")
    .build();

// Legacy模式 - 自定义组件（支持网易版独有组件）
CustomItemDefinition customDef = CustomItemDefinition
    .legacyBuilder(myItem)
    .component("minecraft:fuel", new CompoundTag().putFloat("duration", 0.5f))
    .component("netease:custom_component", customTag) // 网易版独有组件
    .build();

// Component-based模式（现有方式，完全兼容）
CustomItemDefinition componentDef = CustomItemDefinition
    .simpleBuilder(myItem, CreativeItemCategory.ITEMS)
    .foil(true)
    .build();
```

## 向后兼容性

✅ 完全向后兼容，现有代码无需任何修改
✅ SimpleBuilder等现有Builder默认使用Component-based模式
✅ 新功能作为可选增强特性

## 适用场景

- 支持基岩版1.10等老版本客户端
- 支持中国版（网易版）客户端及其独有组件
- 减少网络传输，利用客户端资源包
- 需要客户端自定义贴图和行为的场景

## 修改的文件

- `CustomItemDefinition.java`: 新增注册模式、Builder类和完整文档
- `Player.java`: 网络层集成，正确发送version字段
- `RuntimeItemMapping.java`: 根据注册模式标记component item
