### PR TITLE
fix: illegal capacity

### DIFF
--- a/src/main/java/cn/nukkit/entity/Entity.java
+++ b/src/main/java/cn/nukkit/entity/Entity.java
@@ -2736,7 +2736,15 @@ public abstract class Entity extends Location implements Metadatable {
             int maxY = Math.min(NukkitMath.ceilDouble(bb.getMaxY()), this.level.getMaxBlockY());
             int maxZ = NukkitMath.ceilDouble(bb.getMaxZ());
 
-            this.blocksAround = new ArrayList<>((maxX - minX + 1) * (maxY - minY + 1) * (maxZ - minZ + 1));
+            int sizeX = maxX - minX + 1;
+            int sizeY = maxY - minY + 1;
+            int sizeZ = maxZ - minZ + 1;
+
+            if (sizeX <= 0 || sizeY <= 0 || sizeZ <= 0) {
+                return new ArrayList<>();
+            }
+
+            this.blocksAround = new ArrayList<>(sizeX * sizeY * sizeZ);
 
             try {
                 if (!this.level.isYInRange(minY) && !this.level.isYInRange(maxY)) {
@@ -2798,7 +2806,15 @@ public abstract class Entity extends Location implements Metadatable {
         int maxY = Math.min(NukkitMath.ceilDouble(bb.getMaxY()), this.level.getMaxBlockY());
         int maxZ = NukkitMath.ceilDouble(bb.getMaxZ());
 
-        List<Block> blocks = new ArrayList<>((maxX - minX + 1) * (maxY - minY + 1) * (maxZ - minZ + 1));
+        int sizeX = maxX - minX + 1;
+        int sizeY = maxY - minY + 1;
+        int sizeZ = maxZ - minZ + 1;
+
+        if (sizeX <= 0 || sizeY <= 0 || sizeZ <= 0) {
+            return new ArrayList<>();
+        }
+
+        List<Block> blocks = new ArrayList<>(sizeX * sizeY * sizeZ);
         for (int x = minX; x <= maxX; x++) {
             for (int y = minY; y <= maxY; y++) {
                 for (int z = minZ; z <= maxZ; z++) {


### PR DESCRIPTION
After some tests

```
16:59:10 [main] [ERROR] Could not tick level "world": java.lang.IllegalArgumentException: Illegal Capacity: -456
        at java.base/java.util.ArrayList.<init>(ArrayList.java:160)
        at cn.nukkit.entity.Entity.getBlocksInBoundingBox(Entity.java:2801)
        at cn.nukkit.entity.Entity.getCollisionBlocks(Entity.java:2770)
        at cn.nukkit.entity.Entity.checkBlockCollision(Entity.java:2831)
        at cn.nukkit.entity.item.EntityItem.entityBaseTick(EntityItem.java:362)
        at cn.nukkit.entity.item.EntityItem.onUpdate(EntityItem.java:179)
        at cn.nukkit.level.Level.doTick(Level.java:1099)
        at cn.nukkit.Server.checkTickUpdates(Server.java:1432)
        at cn.nukkit.Server.tick(Server.java:1508)
        at cn.nukkit.Server.tickProcessor(Server.java:1260)
        at cn.nukkit.Server.start(Server.java:1222)
        at cn.nukkit.Server.<init>(Server.java:944)
        at cn.nukkit.Nukkit.main(Nukkit.java:88)
```