### PR TITLE
fix: frosted ice should not melt immediately on neighbor update

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockIceFrosted.java
+++ b/src/main/java/cn/nukkit/block/BlockIceFrosted.java
@@ -70,8 +70,10 @@ public class BlockIceFrosted extends BlockTransparentMeta {
                 level.scheduleUpdate(this, Utils.random.nextInt(20, 40));
             }
         } else if (type == Level.BLOCK_UPDATE_NORMAL) {
+            // Like vanilla: don't melt immediately on neighbor update
+            // Instead, schedule a delayed check to allow Frost Walker ice to stabilize
             if (countNeighbors() < 2) {
-                level.setBlock(this, get(WATER), true);
+                level.scheduleUpdate(this, Utils.random.nextInt(20, 40));
             }
         } else if (type == Level.BLOCK_UPDATE_RANDOM) {
             if ((this.getLevel().getBlockLightAt((int) this.x, (int) this.y, (int) this.z) >= 12 || (level.getTime() % Level.TIME_FULL < 13184 || level.getTime() % Level.TIME_FULL > 22800)) && (Utils.random.nextInt(3) == 0 || countNeighbors() < 4)) {


### PR DESCRIPTION
## Problem
When water is placed from a bucket while wearing Frost Walker boots, the water converts to frosted ice but immediately reverts to water.

## Cause
`BLOCK_UPDATE_NORMAL` triggered instant melting when `countNeighbors() < 2`, not giving Frost Walker ice a chance to stabilize.

## Fix
Changed behavior to match vanilla Minecraft:
- On neighbor update, schedule a delayed check instead of instant melt
- Ice will still melt through the normal `BLOCK_UPDATE_SCHEDULED` tick mechanism
- Allows Frost Walker ice to function properly

## Testing
1. Equip boots with Frost Walker enchantment
2. Place water from a bucket near your feet
3. Water should convert to frosted ice and stay as ice (not instantly revert to water)
4. Ice will eventually melt through normal aging process