### PR TITLE
fix: projectile item rollback

### DIFF
--- a/src/main/java/cn/nukkit/item/ProjectileItem.java
+++ b/src/main/java/cn/nukkit/item/ProjectileItem.java
@@ -83,7 +83,24 @@ public abstract class ProjectileItem extends Item {
                 projectile.close();
             } else {
                 if (!player.isCreative()) {
-                    this.count--;
+                    // client bug patch (item rollback cause pitch > 18 and this.count--)
+                    if (player.getPitch() > 18.0) {
+                        Item handItem = player.getInventory().getItemInHand();
+                        if (handItem.getId() == this.getId() && handItem.getCount() > 0) {
+                            handItem.setCount(handItem.getCount() - 1);
+
+                            if (handItem.getCount() <= 0) {
+                                player.getInventory().setItemInHand(Item.get(Item.AIR));
+                            } else {
+                                player.getInventory().setItemInHand(handItem);
+                            }
+
+                            player.getInventory().sendSlot(player.getInventory().getHeldItemIndex(), player);
+                        }
+                    } else {
+                        // but only this method works for pitch < 18
+                        this.count--;
+                    }
                 }
                 if (projectile instanceof EntityEnderPearl || projectile instanceof EntityEnderEye) {
                     player.onThrowEnderPearl();


### PR DESCRIPTION
There is a bug that if the player's pitch is >18, then the method `this.count--` causes the item to roll back, but if it is issued in a different way, it works fine. This also happens in reverse for pitch <18

It is possible that the bug is somewhere deeper in the packet processing, but this patch currently fixes it

The review from Ai and debug showed that there are no problems with the ProjectileItem itself. This may be due to the fact that the client considers the below throw to be invalid and does not process the item properly

## Steps to Reproduce 
1. Take an Exp Bottle in your hand, for example
2. Try to throw it up/down slowly, not quickly
3. Watch the slot, the amount will first be subtracted and then rollback to the previous