### PR TITLE
fix: early return in `ZippedResourcePackLoader`

### DIFF
--- a/src/main/java/cn/nukkit/resourcepacks/loader/ZippedResourcePackLoader.java
+++ b/src/main/java/cn/nukkit/resourcepacks/loader/ZippedResourcePackLoader.java
@@ -133,7 +133,7 @@ public class ZippedResourcePackLoader implements ResourcePackLoader {
         }
         for (File file : getFiles) {
             if (file.isDirectory()) {
-                return getDirectoryFiles(file);
+                files.addAll(getDirectoryFiles(file));
             } else {
                 files.add(file);
             }


### PR DESCRIPTION
Fixes a bug in `ZippedResourcePackLoader` where encountering a directory caused an early return, preventing subsequent files from being processed. Replace the premature return with `files.addAll(getDirectoryFiles(file))` so directory contents are accumulated and the loop continues to collect all files.