### PR TITLE
fix(ddui): resolve instant-close when navigating to second-level menu

### DIFF
--- a/src/main/java/cn/nukkit/ddui/DataDrivenScreen.java
+++ b/src/main/java/cn/nukkit/ddui/DataDrivenScreen.java
@@ -10,18 +10,22 @@ import cn.nukkit.network.protocol.ClientboundDataStorePacket;
 import cn.nukkit.network.protocol.types.datastore.DataStoreChange;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Abstract base for all data-driven UI screens.
  */
 public abstract class DataDrivenScreen extends ObjectProperty<Object> {
 
-    private static final Map<Player, DataDrivenScreen> ACTIVE_SCREENS =
+    private static final AtomicInteger DDUI_FORM_ID_COUNTER = new AtomicInteger(0);
+
+    private static final Map<Player, Map<Integer, DataDrivenScreen>> PLAYER_DDUI_SCREENS =
             new ConcurrentHashMap<>();
 
     public abstract String getIdentifier();
@@ -29,6 +33,8 @@ public abstract class DataDrivenScreen extends ObjectProperty<Object> {
     public abstract String getProperty();
 
     private final Set<Player> viewers = new CopyOnWriteArraySet<>();
+
+    private final Map<Player, Integer> playerFormIds = new ConcurrentHashMap<>();
 
     protected final LayoutElement layout;
 
@@ -39,6 +45,15 @@ public abstract class DataDrivenScreen extends ObjectProperty<Object> {
     }
 
     public void show(Player player) {
+        // Close any existing DDUI screen for this player first
+        DataDrivenScreen current = getActiveScreen(player);
+        if (current != null) {
+            current.close(player);
+        }
+
+        // Allocate a new unique formId for this screen on this player
+        int formId = DDUI_FORM_ID_COUNTER.updateAndGet(v -> (v == Integer.MAX_VALUE) ? 0 : v + 1);
+
         String dataStore = getIdentifier().split(":")[0];
         DataStoreChange change = new DataStoreChange();
         change.setDataStoreName(dataStore);
@@ -51,20 +66,27 @@ public abstract class DataDrivenScreen extends ObjectProperty<Object> {
 
         ClientboundDataDrivenUIShowScreenPacket show = new ClientboundDataDrivenUIShowScreenPacket();
         show.screenId = getIdentifier();
-        show.formId = 0;
+        show.formId = formId;
         player.dataPacket(data);
         player.dataPacket(show);
 
         viewers.add(player);
-        ACTIVE_SCREENS.put(player, this);
+        playerFormIds.put(player, formId);
+        PLAYER_DDUI_SCREENS
+                .computeIfAbsent(player, k -> new ConcurrentHashMap<>())
+                .put(formId, this);
     }
 
     public void close(Player player) {
+        Integer formId = playerFormIds.get(player);
+        if (formId == null) return;
+
+        PLAYER_DDUI_SCREENS.getOrDefault(player, Collections.emptyMap()).remove(formId);
+        playerFormIds.remove(player);
         viewers.remove(player);
-        ACTIVE_SCREENS.remove(player);
 
         ClientboundDataDrivenUICloseScreenPacket packet = new ClientboundDataDrivenUICloseScreenPacket();
-        packet.formId = 0;
+        packet.formId = formId;
         player.dataPacket(packet);
     }
 
@@ -73,25 +95,28 @@ public abstract class DataDrivenScreen extends ObjectProperty<Object> {
     }
 
     public static DataDrivenScreen getActiveScreen(Player player) {
-        return ACTIVE_SCREENS.get(player);
+        Map<Integer, DataDrivenScreen> screens = PLAYER_DDUI_SCREENS.get(player);
+        if (screens == null || screens.isEmpty()) return null;
+        return screens.values().iterator().next();
     }
 
-    /**
-     * Removes a player from this screen's viewer set and the global active screen map.
-     * Called when the client closes the screen or the player disconnects.
-     */
+    public static DataDrivenScreen getScreenByFormId(Player player, int formId) {
+        return PLAYER_DDUI_SCREENS.getOrDefault(player, Collections.emptyMap()).get(formId);
+    }
+
     public void removeViewer(Player player) {
+        Integer formId = playerFormIds.get(player);
+        if (formId != null) {
+            PLAYER_DDUI_SCREENS.getOrDefault(player, Collections.emptyMap()).remove(formId);
+            playerFormIds.remove(player);
+        }
         viewers.remove(player);
-        ACTIVE_SCREENS.remove(player, this);
     }
 
-    /**
-     * Removes the player's active screen entry. Called during player disconnect cleanup.
-     */
     public static void removeActiveScreen(Player player) {
-        DataDrivenScreen screen = ACTIVE_SCREENS.remove(player);
+        DataDrivenScreen screen = getActiveScreen(player);
         if (screen != null) {
-            screen.viewers.remove(player);
+            screen.close(player);
         }
     }
 

--- a/src/main/java/cn/nukkit/ddui/DataDrivenScreen.java
+++ b/src/main/java/cn/nukkit/ddui/DataDrivenScreen.java
@@ -81,7 +81,13 @@ public abstract class DataDrivenScreen extends ObjectProperty<Object> {
         Integer formId = playerFormIds.get(player);
         if (formId == null) return;
 
-        PLAYER_DDUI_SCREENS.getOrDefault(player, Collections.emptyMap()).remove(formId);
+        Map<Integer, DataDrivenScreen> screens = PLAYER_DDUI_SCREENS.get(player);
+        if (screens != null) {
+            screens.remove(formId);
+            if (screens.isEmpty()) {
+                PLAYER_DDUI_SCREENS.remove(player);
+            }
+        }
         playerFormIds.remove(player);
         viewers.remove(player);
 
@@ -97,7 +103,10 @@ public abstract class DataDrivenScreen extends ObjectProperty<Object> {
     public static DataDrivenScreen getActiveScreen(Player player) {
         Map<Integer, DataDrivenScreen> screens = PLAYER_DDUI_SCREENS.get(player);
         if (screens == null || screens.isEmpty()) return null;
-        return screens.values().iterator().next();
+        return screens.entrySet().stream()
+                .max(Map.Entry.comparingByKey())
+                .map(Map.Entry::getValue)
+                .orElse(null);
     }
 
     public static DataDrivenScreen getScreenByFormId(Player player, int formId) {
@@ -107,7 +116,13 @@ public abstract class DataDrivenScreen extends ObjectProperty<Object> {
     public void removeViewer(Player player) {
         Integer formId = playerFormIds.get(player);
         if (formId != null) {
-            PLAYER_DDUI_SCREENS.getOrDefault(player, Collections.emptyMap()).remove(formId);
+            Map<Integer, DataDrivenScreen> screens = PLAYER_DDUI_SCREENS.get(player);
+            if (screens != null) {
+                screens.remove(formId);
+                if (screens.isEmpty()) {
+                    PLAYER_DDUI_SCREENS.remove(player);
+                }
+            }
             playerFormIds.remove(player);
         }
         viewers.remove(player);

--- a/src/main/java/cn/nukkit/ddui/DataDrivenScreen.java
+++ b/src/main/java/cn/nukkit/ddui/DataDrivenScreen.java
@@ -1,6 +1,7 @@
 package cn.nukkit.ddui;
 
 import cn.nukkit.Player;
+import cn.nukkit.Server;
 import cn.nukkit.ddui.element.LayoutElement;
 import cn.nukkit.ddui.properties.DataDrivenProperty;
 import cn.nukkit.ddui.properties.ObjectProperty;
@@ -8,14 +9,15 @@ import cn.nukkit.network.protocol.ClientboundDataDrivenUICloseScreenPacket;
 import cn.nukkit.network.protocol.ClientboundDataDrivenUIShowScreenPacket;
 import cn.nukkit.network.protocol.ClientboundDataStorePacket;
 import cn.nukkit.network.protocol.types.datastore.DataStoreChange;
+import cn.nukkit.plugin.InternalPlugin;
+import cn.nukkit.scheduler.TaskHandler;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -27,6 +29,10 @@ public abstract class DataDrivenScreen extends ObjectProperty<Object> {
 
     private static final Map<Player, Map<Integer, DataDrivenScreen>> PLAYER_DDUI_SCREENS =
             new ConcurrentHashMap<>();
+
+    private static final Cache<Player, TaskHandler> PENDING_SHOW_TASKS = Caffeine.newBuilder()
+            .expireAfterWrite(30, TimeUnit.SECONDS)
+            .build();
 
     public abstract String getIdentifier();
 
@@ -45,11 +51,40 @@ public abstract class DataDrivenScreen extends ObjectProperty<Object> {
     }
 
     public void show(Player player) {
-        // Close any existing DDUI screen for this player first
-        DataDrivenScreen current = getActiveScreen(player);
-        if (current != null) {
-            current.close(player);
+        // Cancel any pending delayed show for this player
+        TaskHandler pending = PENDING_SHOW_TASKS.asMap().remove(player);
+        if (pending != null) {
+            pending.cancel();
         }
+
+        Map<Integer, DataDrivenScreen> oldScreens = PLAYER_DDUI_SCREENS.remove(player);
+        boolean hasExistingScreen = oldScreens != null && !oldScreens.isEmpty();
+
+        if (hasExistingScreen) {
+            for (DataDrivenScreen screen : oldScreens.values()) {
+                Integer oldFormId = screen.playerFormIds.remove(player);
+                if (oldFormId != null) {
+                    ClientboundDataDrivenUICloseScreenPacket closePacket = new ClientboundDataDrivenUICloseScreenPacket();
+                    closePacket.formId = oldFormId;
+                    player.dataPacket(closePacket);
+                }
+                screen.viewers.remove(player);
+            }
+            // Delay the new screen to allow the client to fully process the close.
+            // The Bedrock client rejects ShowScreen with USER_BUSY if it arrives
+            // too soon after closing a DDUI screen.
+            TaskHandler task = Server.getInstance().getScheduler().scheduleDelayedTask(InternalPlugin.INSTANCE, () -> {
+                PENDING_SHOW_TASKS.invalidate(player);
+                doShow(player);
+            }, 20);
+            PENDING_SHOW_TASKS.put(player, task);
+        } else {
+            doShow(player);
+        }
+    }
+
+    private void doShow(Player player) {
+        if (!player.isConnected()) return;
 
         // Allocate a new unique formId for this screen on this player
         int formId = DDUI_FORM_ID_COUNTER.updateAndGet(v -> (v == Integer.MAX_VALUE) ? 0 : v + 1);
@@ -67,9 +102,12 @@ public abstract class DataDrivenScreen extends ObjectProperty<Object> {
         ClientboundDataDrivenUIShowScreenPacket show = new ClientboundDataDrivenUIShowScreenPacket();
         show.screenId = getIdentifier();
         show.formId = formId;
+
+        // Send new screen packets
         player.dataPacket(data);
         player.dataPacket(show);
 
+        // Update server-side tracking
         viewers.add(player);
         playerFormIds.put(player, formId);
         PLAYER_DDUI_SCREENS
@@ -81,15 +119,7 @@ public abstract class DataDrivenScreen extends ObjectProperty<Object> {
         Integer formId = playerFormIds.get(player);
         if (formId == null) return;
 
-        Map<Integer, DataDrivenScreen> screens = PLAYER_DDUI_SCREENS.get(player);
-        if (screens != null) {
-            screens.remove(formId);
-            if (screens.isEmpty()) {
-                PLAYER_DDUI_SCREENS.remove(player);
-            }
-        }
-        playerFormIds.remove(player);
-        viewers.remove(player);
+        removeViewer(player);
 
         ClientboundDataDrivenUICloseScreenPacket packet = new ClientboundDataDrivenUICloseScreenPacket();
         packet.formId = formId;
@@ -129,6 +159,10 @@ public abstract class DataDrivenScreen extends ObjectProperty<Object> {
     }
 
     public static void removeActiveScreen(Player player) {
+        TaskHandler pending = PENDING_SHOW_TASKS.asMap().remove(player);
+        if (pending != null) {
+            pending.cancel();
+        }
         DataDrivenScreen screen = getActiveScreen(player);
         if (screen != null) {
             screen.close(player);

--- a/src/main/java/cn/nukkit/ddui/element/MessageBoxButtonElement.java
+++ b/src/main/java/cn/nukkit/ddui/element/MessageBoxButtonElement.java
@@ -1,6 +1,7 @@
 package cn.nukkit.ddui.element;
 
 import cn.nukkit.Player;
+import cn.nukkit.ddui.DataDrivenScreen;
 import cn.nukkit.ddui.Observable;
 import cn.nukkit.ddui.properties.ObjectProperty;
 import cn.nukkit.ddui.properties.StringProperty;
@@ -31,7 +32,15 @@ public class MessageBoxButtonElement extends Element<Long> {
 
         ButtonClickElement clickElement = new ButtonClickElement(this);
         setProperty(clickElement);
-        clickElement.addListener((player, data) -> triggerListeners(player, data));
+        clickElement.addListener(this::triggerListeners);
+        // Auto-close the screen after user-defined listeners complete,
+        // matching vanilla Bedrock behavior where MessageBox dismisses on button click.
+        clickElement.addListener((player, data) -> {
+            DataDrivenScreen screen = DataDrivenScreen.getActiveScreen(player);
+            if (screen != null) {
+                screen.close(player);
+            }
+        });
     }
 
     public void addListener(Consumer<Player> listener) {

--- a/src/main/java/cn/nukkit/network/process/processor/ServerboundDataDrivenScreenClosedProcessor.java
+++ b/src/main/java/cn/nukkit/network/process/processor/ServerboundDataDrivenScreenClosedProcessor.java
@@ -14,14 +14,19 @@ public class ServerboundDataDrivenScreenClosedProcessor extends DataPacketProces
 
     @Override
     public void handle(@NotNull PlayerHandle playerHandle, @NotNull ServerboundDataDrivenScreenClosedPacket pk) {
-        DataDrivenScreen screen = DataDrivenScreen.getActiveScreen(playerHandle.player);
-        if (screen != null) {
-            screen.removeViewer(playerHandle.player);
-
-            ClientboundDataDrivenUICloseScreenPacket closePacket = new ClientboundDataDrivenUICloseScreenPacket();
-            closePacket.formId = pk.formId;
-            playerHandle.player.dataPacket(closePacket);
+        // Look up the screen by formId from the close packet, NOT by active screen
+        DataDrivenScreen screen = DataDrivenScreen.getScreenByFormId(playerHandle.player, pk.formId);
+        if (screen == null) {
+            // Screen already closed or invalid formId, ignore
+            return;
         }
+
+        screen.removeViewer(playerHandle.player);
+
+        // Send close confirmation packet with the formId from the client's close request
+        ClientboundDataDrivenUICloseScreenPacket closePacket = new ClientboundDataDrivenUICloseScreenPacket();
+        closePacket.formId = pk.formId;
+        playerHandle.player.dataPacket(closePacket);
     }
 
     @Override


### PR DESCRIPTION
## Summary

**Bug:** Clicking a button/dropdown in a DDUI CustomForm that opens a child screen causes the child screen to instantly close.

**Root Cause:** `DataDrivenScreen.show()` overwrote the static `ACTIVE_SCREENS` map without closing the old screen. The client auto-closes the old screen upon receiving `ShowScreenPacket` and sends a `ServerboundDataDrivenScreenClosedPacket` with `formId=0`. The processor then looked up `getActiveScreen(player)` (which returned the **new child**) and removed it instead of the old parent.

## Changes (Option B - unique formId per screen per player)

### DataDrivenScreen.java
- Replace single `ACTIVE_SCREENS` map with `PLAYER_DDUI_SCREENS: Map<Player, Map<Integer, DataDrivenScreen>>` for formId-based routing
- Add `DDUI_FORM_ID_COUNTER` (AtomicInteger) for unique formId allocation  
- `show()` now closes any existing screen before showing new one, and uses the allocated formId (not 0) in `ShowScreenPacket`
- `close()` sends close packet with actual formId and cleans up routing table
- Add `getScreenByFormId(player, formId)` for precise close-packet routing

### ServerboundDataDrivenScreenClosedProcessor.java
- Now routes by `formId` from the close packet (via `getScreenByFormId`) instead of by active screen
- Fixes the bug where the new child screen was incorrectly removed

This enables proper parent-child navigation where clicking a button in a parent menu opens a child menu without instantly closing it.
