### PR TITLE
fix: StringIndexOutOfBoundsException when input starts with {

### DIFF
--- a/src/main/java/cn/nukkit/command/SimpleCommandMap.java
+++ b/src/main/java/cn/nukkit/command/SimpleCommandMap.java
@@ -270,7 +270,7 @@ public class SimpleCommandMap implements CommandMap {
         int start = 0;
 
         for (int i = 0; i < sb.length(); i++) {
-            if ((sb.charAt(i) == '{' && curlyBraceCount >= 1) || (sb.charAt(i) == '{' && sb.charAt(i - 1) == ' ' && curlyBraceCount == 0)) {
+            if ((sb.charAt(i) == '{' && curlyBraceCount >= 1) || (sb.charAt(i) == '{' && (i == 0 || sb.charAt(i - 1) == ' ') && curlyBraceCount == 0)) {
                 curlyBraceCount++;
             } else if (sb.charAt(i) == '}' && curlyBraceCount > 0) {
                 curlyBraceCount--;


### PR DESCRIPTION
Fixes #691

## Problem

In Java 25, `StringBuilder.charAt()` with a negative index throws `StringIndexOutOfBoundsException` via `jdk.internal.util.Preconditions.checkIndex`, which is stricter than previous Java versions.

When the first character of the command line is `{` (`i == 0`), `sb.charAt(i - 1)` accesses index `-1`, causing a fatal crash. This can be triggered by any player typing `{` or `/{` in-game, effectively acting as a DoS vulnerability.

## Fix

Added an `i == 0` guard in `SimpleCommandMap.parseArguments()` so that `{` at position 0 is treated as the start of a curly brace block without checking the previous character.

```diff
- if ((sb.charAt(i) == '{' && curlyBraceCount >= 1) || (sb.charAt(i) == '{' && sb.charAt(i - 1) == ' ' && curlyBraceCount == 0)) {
+ if ((sb.charAt(i) == '{' && curlyBraceCount >= 1) || (sb.charAt(i) == '{' && (i == 0 || sb.charAt(i - 1) == ' ') && curlyBraceCount == 0)) {
```