### PR TITLE
fix: player fake death with health_boost effect

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -6120,6 +6120,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
 
             this.extinguish();
             this.health = 0;
+            this.removeAllEffects(EntityPotionEffectEvent.Cause.DEATH);
             this.scheduleUpdate();
             this.timeSinceRest = 0;
 


### PR DESCRIPTION
Fixes #693

## Problem

When a player with `HEALTH_BOOST` effect dies (e.g., via `/kill @s`), the client receives attribute updates with boosted max_health. During `respawn()`, the effect is removed and max_health changes back to the base value. This max_health inconsistency while the player is in the death screen can cause the client to enter an unrecoverable "fake death" state.

## Fix

Move `removeAllEffects(EntityPotionEffectEvent.Cause.DEATH)` into `Player.kill()` so that effects (including HEALTH_BOOST) are removed before any death/respawn packets are sent. This ensures the client always receives consistent max_health values (base value, not boosted) throughout the entire death sequence.

The `removeAllEffects()` in `respawn()` is kept as-is since it's idempotent and handles any effects that may have been applied between death and respawn.