### PR TITLE
fix: handle out-of-bounds enum values in SetPlayerInventoryOptionsPacket (#703)

### DIFF
--- a/src/main/java/cn/nukkit/network/protocol/SetPlayerInventoryOptionsPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/SetPlayerInventoryOptionsPacket.java
@@ -4,7 +4,9 @@ import cn.nukkit.network.protocol.types.inventory.InventoryLayout;
 import cn.nukkit.network.protocol.types.inventory.InventoryTabLeft;
 import cn.nukkit.network.protocol.types.inventory.InventoryTabRight;
 import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @ToString
 public class SetPlayerInventoryOptionsPacket extends DataPacket {
 
@@ -28,11 +30,11 @@ public class SetPlayerInventoryOptionsPacket extends DataPacket {
 
     @Override
     public void decode() {
-        this.leftTab = InventoryTabLeft.VALUES[this.getVarInt()];
-        this.rightTab = InventoryTabRight.VALUES[this.getVarInt()];
+        this.leftTab = getEnumValue(InventoryTabLeft.VALUES, this.getVarInt());
+        this.rightTab = getEnumValue(InventoryTabRight.VALUES, this.getVarInt());
         this.filtering = this.getBoolean();
-        this.layout = InventoryLayout.VALUES[this.getVarInt()];
-        this.craftingLayout = InventoryLayout.VALUES[this.getVarInt()];
+        this.layout = getEnumValue(InventoryLayout.VALUES, this.getVarInt());
+        this.craftingLayout = getEnumValue(InventoryLayout.VALUES, this.getVarInt());
     }
 
     @Override
@@ -43,5 +45,13 @@ public class SetPlayerInventoryOptionsPacket extends DataPacket {
         this.putBoolean(this.filtering);
         this.putVarInt(this.layout.ordinal());
         this.putVarInt(this.craftingLayout.ordinal());
+    }
+
+    private static <T extends Enum<T>> T getEnumValue(T[] values, int ordinal) {
+        if (ordinal >= 0 && ordinal < values.length) {
+            return values[ordinal];
+        }
+        log.warn("Received unknown enum ordinal {} (max {}), falling back to default", ordinal, values.length - 1);
+        return values[0];
     }
 }

--- a/src/test/java/cn/nukkit/network/protocol/regression/decode/MiscDecodeRegressionTest.java
+++ b/src/test/java/cn/nukkit/network/protocol/regression/decode/MiscDecodeRegressionTest.java
@@ -590,6 +590,75 @@ public class MiscDecodeRegressionTest extends AbstractPacketRegressionTest {
         assertEquals(InventoryLayout.NONE, nk.craftingLayout);
     }
 
+    @ParameterizedTest(name = "SetPlayerInventoryOptionsPacket all left tabs v{0}")
+    @MethodSource("versionsFrom630")
+    void setPlayerInventoryOptionsAllLeftTabs(int protocol) {
+        for (var leftTab : InventoryTabLeft.VALUES) {
+            var cb = new org.cloudburstmc.protocol.bedrock.packet.SetPlayerInventoryOptionsPacket();
+            cb.setLeftTab(org.cloudburstmc.protocol.bedrock.data.inventory.InventoryTabLeft.VALUES[leftTab.ordinal()]);
+            cb.setRightTab(org.cloudburstmc.protocol.bedrock.data.inventory.InventoryTabRight.NONE);
+            cb.setFiltering(false);
+            cb.setLayout(org.cloudburstmc.protocol.bedrock.data.inventory.InventoryLayout.NONE);
+            cb.setCraftingLayout(org.cloudburstmc.protocol.bedrock.data.inventory.InventoryLayout.NONE);
+
+            SetPlayerInventoryOptionsPacket nk = crossEncode(cb, SetPlayerInventoryOptionsPacket::new, protocol);
+            assertEquals(leftTab, nk.leftTab, "LeftTab mismatch for ordinal " + leftTab.ordinal());
+        }
+    }
+
+    @ParameterizedTest(name = "SetPlayerInventoryOptionsPacket all right tabs v{0}")
+    @MethodSource("versionsFrom630")
+    void setPlayerInventoryOptionsAllRightTabs(int protocol) {
+        for (var rightTab : InventoryTabRight.VALUES) {
+            var cb = new org.cloudburstmc.protocol.bedrock.packet.SetPlayerInventoryOptionsPacket();
+            cb.setLeftTab(org.cloudburstmc.protocol.bedrock.data.inventory.InventoryTabLeft.NONE);
+            cb.setRightTab(org.cloudburstmc.protocol.bedrock.data.inventory.InventoryTabRight.VALUES[rightTab.ordinal()]);
+            cb.setFiltering(false);
+            cb.setLayout(org.cloudburstmc.protocol.bedrock.data.inventory.InventoryLayout.NONE);
+            cb.setCraftingLayout(org.cloudburstmc.protocol.bedrock.data.inventory.InventoryLayout.NONE);
+
+            SetPlayerInventoryOptionsPacket nk = crossEncode(cb, SetPlayerInventoryOptionsPacket::new, protocol);
+            assertEquals(rightTab, nk.rightTab, "RightTab mismatch for ordinal " + rightTab.ordinal());
+        }
+    }
+
+    @ParameterizedTest(name = "SetPlayerInventoryOptionsPacket all layouts v{0}")
+    @MethodSource("versionsFrom630")
+    void setPlayerInventoryOptionsAllLayouts(int protocol) {
+        for (var layout : InventoryLayout.VALUES) {
+            var cb = new org.cloudburstmc.protocol.bedrock.packet.SetPlayerInventoryOptionsPacket();
+            cb.setLeftTab(org.cloudburstmc.protocol.bedrock.data.inventory.InventoryTabLeft.NONE);
+            cb.setRightTab(org.cloudburstmc.protocol.bedrock.data.inventory.InventoryTabRight.NONE);
+            cb.setFiltering(false);
+            cb.setLayout(org.cloudburstmc.protocol.bedrock.data.inventory.InventoryLayout.VALUES[layout.ordinal()]);
+            cb.setCraftingLayout(org.cloudburstmc.protocol.bedrock.data.inventory.InventoryLayout.VALUES[layout.ordinal()]);
+
+            SetPlayerInventoryOptionsPacket nk = crossEncode(cb, SetPlayerInventoryOptionsPacket::new, protocol);
+            assertEquals(layout, nk.layout, "Layout mismatch for ordinal " + layout.ordinal());
+            assertEquals(layout, nk.craftingLayout, "CraftingLayout mismatch for ordinal " + layout.ordinal());
+        }
+    }
+
+    @ParameterizedTest(name = "SetPlayerInventoryOptionsPacket creative search v{0}")
+    @MethodSource("versionsFrom630")
+    void setPlayerInventoryOptionsCreativeSearch(int protocol) {
+        // This is the exact scenario from issue #703: Creative mode search
+        var cb = new org.cloudburstmc.protocol.bedrock.packet.SetPlayerInventoryOptionsPacket();
+        cb.setLeftTab(org.cloudburstmc.protocol.bedrock.data.inventory.InventoryTabLeft.RECIPE_SEARCH);
+        cb.setRightTab(org.cloudburstmc.protocol.bedrock.data.inventory.InventoryTabRight.FULL_SCREEN);
+        cb.setFiltering(true);
+        cb.setLayout(org.cloudburstmc.protocol.bedrock.data.inventory.InventoryLayout.RECIPE_BOOK_ONLY);
+        cb.setCraftingLayout(org.cloudburstmc.protocol.bedrock.data.inventory.InventoryLayout.NONE);
+
+        SetPlayerInventoryOptionsPacket nk = crossEncode(cb, SetPlayerInventoryOptionsPacket::new, protocol);
+
+        assertEquals(InventoryTabLeft.RECIPE_SEARCH, nk.leftTab);
+        assertEquals(InventoryTabRight.FULL_SCREEN, nk.rightTab);
+        assertTrue(nk.filtering);
+        assertEquals(InventoryLayout.CREATIVE, nk.layout);
+        assertEquals(InventoryLayout.NONE, nk.craftingLayout);
+    }
+
     // ==================== ServerboundDiagnosticsPacket ====================
 
     @ParameterizedTest(name = "ServerboundDiagnosticsPacket v{0}")


### PR DESCRIPTION
## Summary

Fixes #703

### Problem
Game crashes (Protocol Version 630 / 1.20.50) when opening search in Creative mode. The `SetPlayerInventoryOptionsPacket.decode()` method uses direct array indexing without bounds checking, causing `ArrayIndexOutOfBoundsException` when the client sends an enum ordinal that exceeds the server's enum array length.

### Root Cause
```java
// Before: no bounds checking
this.leftTab = InventoryTabLeft.VALUES[this.getVarInt()];
```
When a 1.20.50 client opens Creative mode search, it sends a `SetPlayerInventoryOptionsPacket` with enum values that may not exist in the server's enum definitions, causing a crash.

### Fix
- Added `getEnumValue()` helper method with bounds checking
- Falls back to the first enum value (index 0) when an unknown ordinal is received
- Logs a warning when an out-of-bounds value is encountered
- No longer crashes on unknown client values

### Tests Added
- **All left tabs**: Tests every `InventoryTabLeft` enum value (including `RECIPE_SEARCH` from issue #703)
- **All right tabs**: Tests every `InventoryTabRight` enum value
- **All layouts**: Tests every `InventoryLayout` enum value
- **Creative search scenario**: Reproduces the exact scenario from issue #703

### Changes
- `SetPlayerInventoryOptionsPacket.java`: Added bounds checking in `decode()` method
- `MiscDecodeRegressionTest.java`: Added 4 new parameterized test methods covering all enum values
