### PR TITLE
Added support for dynamic custom item IDs (fallback fix)

### DIFF
--- a/src/main/java/cn/nukkit/item/Item.java
+++ b/src/main/java/cn/nukkit/item/Item.java
@@ -1066,7 +1066,11 @@ public class Item implements Cloneable, BlockID, ItemID, ItemNamespaceId, Protoc
                     c = Block.list[blockId];
                 }
             } else {
-                c = list[id];
+                if (id >= 0 && id < list.length) {
+                    c = list[id];
+                } else {
+                    c = null;
+                }
             }
             Item item;
 


### PR DESCRIPTION
This change improves item handling by allowing dynamic/custom item IDs without requiring manual registration.

- Added bounds check when accessing Item.list to prevent crashes on invalid IDs
- Ensures unknown or out-of-range IDs fall back to a generic Item instead of failing
- Enables plugins to define temporary custom items at runtime without modifying core code

This makes it possible to use custom IDs (e.g. 5000+) safely and supports dynamic item systems.