### PR TITLE
feat: Plugin Annotation

### DIFF
--- a/src/main/java/cn/nukkit/plugin/annotation/AnnotationProcessor.java
+++ b/src/main/java/cn/nukkit/plugin/annotation/AnnotationProcessor.java
@@ -3,6 +3,7 @@ package cn.nukkit.plugin.annotation;
 import cn.nukkit.plugin.PluginLoadOrder;
 
 import javax.annotation.processing.*;
+import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.TypeElement;
@@ -147,5 +148,10 @@ public class AnnotationProcessor extends AbstractProcessor {
         }
         TypeMirror erasedSuper = types.erasure(superType.asType());
         return types.isAssignable(types.erasure(type.asType()), erasedSuper);
+    }
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latestSupported();
     }
 }

--- a/src/main/java/cn/nukkit/plugin/annotation/AnnotationProcessor.java
+++ b/src/main/java/cn/nukkit/plugin/annotation/AnnotationProcessor.java
@@ -1,0 +1,151 @@
+package cn.nukkit.plugin.annotation;
+
+import cn.nukkit.plugin.PluginLoadOrder;
+
+import javax.annotation.processing.*;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Elements;
+import javax.lang.model.util.Types;
+import javax.tools.Diagnostic;
+import javax.tools.FileObject;
+import javax.tools.StandardLocation;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Arrays;
+import java.util.Set;
+
+@SupportedAnnotationTypes({"cn.nukkit.plugin.annotation.PluginMeta"})
+public class AnnotationProcessor extends AbstractProcessor {
+    private Elements elements;
+    private Types types;
+    private Messager messager;
+    private Filer filer;
+
+    private boolean generated = false;
+
+    @Override
+    public synchronized void init(ProcessingEnvironment env) {
+        super.init(env);
+        this.elements = env.getElementUtils();
+        this.types = env.getTypeUtils();
+        this.messager = env.getMessager();
+        this.filer = env.getFiler();
+    }
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        if (roundEnv.processingOver()) {
+            return false;
+        }
+
+        Set<? extends Element> metas = roundEnv.getElementsAnnotatedWith(PluginMeta.class);
+        if (metas.isEmpty() || generated) {
+            return false;
+        }
+        if (metas.size() > 1) {
+            for (Element m : metas) {
+                error(m, "Only one type may be annotated with @PluginMeta per project; found " + metas.size() + ".");
+            }
+            return false;
+        }
+
+        TypeElement main = (TypeElement) metas.iterator().next();
+        if (!validateMain(main)) {
+            return false;
+        }
+
+        generated = true;
+        generate(main);
+        return false;
+    }
+
+    private void generate(TypeElement main) {
+        String mainBinary = elements.getBinaryName(main).toString();
+        writeDescriptor(main, mainBinary);
+    }
+
+    private void writeDescriptor(TypeElement main, String mainBinary) {
+        PluginMeta meta = main.getAnnotation(PluginMeta.class);
+        StringBuilder y = new StringBuilder();
+        scalar(y, "name", meta.name());
+        scalar(y, "main", mainBinary);
+        scalar(y, "version", meta.version());
+        list(y, "api", meta.api());
+        if (meta.authors().length > 0) {
+            list(y, "authors", meta.authors());
+        }
+        if (!meta.description().isEmpty()) {
+            scalar(y, "description", meta.description());
+        }
+        if (!meta.website().isEmpty()) {
+            scalar(y, "website", meta.website());
+        }
+        scalar(y, "prefix", meta.prefix().isEmpty() ? meta.name() : meta.prefix());
+        if (meta.order() != PluginLoadOrder.POSTWORLD) {
+            y.append("load: ").append(meta.order().name()).append('\n');
+        }
+        String[] depend = Arrays.stream(meta.depend()).map(Dependency::name).toArray(String[]::new);
+        String[] softDepend = Arrays.stream(meta.softDepend()).map(Dependency::name).toArray(String[]::new);
+        if (meta.depend().length > 0) {
+            list(y, "depend", depend);
+        }
+        if (meta.softDepend().length > 0) {
+            list(y, "softdepend", softDepend);
+        }
+        if (meta.loadBefore().length > 0) {
+            list(y, "loadbefore", meta.loadBefore());
+        }
+
+        try {
+            FileObject yml = filer.createResource(StandardLocation.CLASS_OUTPUT, "", "plugin.yml", main);
+            try (Writer w = yml.openWriter()) {
+                w.write(y.toString());
+            }
+        } catch (IOException ex) {
+            error(main, "Failed to generate plugin.yml: " + ex.getMessage());
+        }
+    }
+
+    private static void scalar(StringBuilder y, String key, String value) {
+        y.append(key).append(": ").append(quote(value)).append('\n');
+    }
+
+    private static void list(StringBuilder y, String key, String[] values) {
+        y.append(key).append(":\n");
+        for (String v : values) {
+            y.append("  - ").append(quote(v)).append('\n');
+        }
+    }
+
+    private static String quote(String s) {
+        return '"' + s.replace("\\", "\\\\").replace("\"", "\\\"") + '"';
+    }
+
+    private boolean validateMain(TypeElement main) {
+        if (main.getKind() != ElementKind.CLASS) {
+            error(main, "@PluginMeta may only be placed on a class.");
+            return false;
+        }
+        if (!isAssignableTo(main, "cn.nukkit.plugin.PluginBase")) {
+            error(main, "@PluginMeta class must extend cn.nukkit.plugin.PluginBase.");
+            return false;
+        }
+        return true;
+    }
+
+    private void error(Element e, String message) {
+        messager.printMessage(Diagnostic.Kind.ERROR, message, e);
+    }
+
+    private boolean isAssignableTo(TypeElement type, String superFqn) {
+        TypeElement superType = elements.getTypeElement(superFqn);
+        if (superType == null) {
+            return false;
+        }
+        TypeMirror erasedSuper = types.erasure(superType.asType());
+        return types.isAssignable(types.erasure(type.asType()), erasedSuper);
+    }
+}

--- a/src/main/java/cn/nukkit/plugin/annotation/Dependency.java
+++ b/src/main/java/cn/nukkit/plugin/annotation/Dependency.java
@@ -1,0 +1,17 @@
+package cn.nukkit.plugin.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Dependency {
+
+    String name();
+
+    String version() default "";
+
+    boolean optional() default false;
+}

--- a/src/main/java/cn/nukkit/plugin/annotation/PluginMeta.java
+++ b/src/main/java/cn/nukkit/plugin/annotation/PluginMeta.java
@@ -1,0 +1,69 @@
+package cn.nukkit.plugin.annotation;
+
+import cn.nukkit.plugin.PluginLoadOrder;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PluginMeta {
+
+    /**
+     * The plugin name.
+     */
+    String name();
+
+    /**
+     * The plugin version.
+     */
+    String version();
+
+    /**
+     * The compatible API versions.
+     */
+    String[] api();
+
+    /**
+     * Description of the plugin.
+     */
+    String description() default "";
+
+    /**
+     * The plugin website.
+     */
+    String website() default "";
+
+    /**
+     * The plugin authors.
+     */
+    String[] authors() default {};
+
+    /**
+     * The log prefix used by this plugin. Optional.
+     */
+    String prefix() default "";
+
+    /**
+     * Plugins that must be loaded after this one.
+     */
+    String[] loadBefore() default {};
+
+    /**
+     * The load order. Defaults to {@link PluginLoadOrder#POSTWORLD}; the default
+     * is omitted from the generated descriptor.
+     */
+    PluginLoadOrder order() default PluginLoadOrder.POSTWORLD;
+
+    /**
+     * Hard dependencies: plugins that must be present and loaded first. Optional.
+     */
+    Dependency[] depend() default {};
+
+    /**
+     * Soft dependencies: plugins loaded first when present, but not required. Optional.
+     */
+    Dependency[] softDepend() default {};
+}

--- a/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+cn.nukkit.plugin.annotation.AnnotationProcessor


### PR DESCRIPTION
# Plugin Annotation

Add an annotation processor for @PluginMeta that automatically generates plugin.yml during compilation.

## Feature
`@PluginMeta`
```java
@PluginMeta(
        name = "ExamplePlugin",
        version = "1.0.0",
        api = {"1.0.0"},
        authors = {"NotMe"},
        description = "An example plugin using @PluginMeta.",
        website = "https://trustmebro.com",
        prefix = "Example",
        order = PluginLoadOrder.POSTWORLD,
        depend = {@Dependency(name = "SomeOtherPlugin")},
        softDepend = {@Dependency(name = "SomeOtherPlugin")},
        loadBefore = {"SomeOtherPlugin"}
)
public class ExamplePlugin extends PluginBase {
    public void onEnable() {
    }
}
```