### PR TITLE
feat: shulker box now can change color

### DIFF
--- a/src/main/java/cn/nukkit/inventory/CraftingManager.java
+++ b/src/main/java/cn/nukkit/inventory/CraftingManager.java
@@ -164,8 +164,8 @@ public class CraftingManager {
                         break;
                     case 4: // multi (hardcoded)
                         break;
-                    case 5: // shulker_box
-                        loadShapelessRecipe(itemMapping, recipe);
+                    case 5: // shulker_box (UserDataShapelessRecipe): shapeless 结构，但需保留输入 NBT
+                        loadUserDataShapelessRecipe(itemMapping, recipe);
                         break;
                 }
             } catch (Exception e) {
@@ -320,6 +320,42 @@ public class CraftingManager {
                 this.registerRecipe(new ShapelessRecipe(null, 0, outputItem, sorted));
             }
         }
+    }
+
+    /**
+     * Loads "shulker_box" (type 5) recipes, wrapped in {@link UserDataShapelessRecipe} to preserve input NBT.
+     */
+    @SuppressWarnings("unchecked")
+    private void loadUserDataShapelessRecipe(RuntimeItemMapping itemMapping, Map recipe) {
+        if (!"crafting_table".equals(recipe.get("block"))) {
+            return;
+        }
+
+        Map outputMap = (Map) ((List) recipe.get("output")).get(0);
+        Item outputItem = loadRecipeOutputItem(itemMapping, outputMap);
+        if (outputItem == null || outputItem.isNull()) {
+            log.trace("Unknown shulker_box recipe output: {}", recipe);
+            return;
+        }
+
+        List<Map> input = (List<Map>) recipe.get("input");
+        List<Item> sorted = new ArrayList<>();
+        for (Map<String, Object> ingredient : input) {
+            if (!"default".equals(ingredient.get("type"))) {
+                log.trace("Unsupported shulker_box ingredient type: {}", recipe);
+                return;
+            }
+            Item inputItem = loadRecipeIngredientItem(itemMapping, ingredient);
+            if (inputItem == null || inputItem.isNull()) {
+                log.trace("Unknown shulker_box input: {}", recipe);
+                return;
+            }
+            sorted.add(inputItem);
+        }
+        sorted.sort(recipeComparator);
+
+        int priority = (int) recipe.getOrDefault("priority", 0);
+        this.registerRecipe(new UserDataShapelessRecipe((String) recipe.get("id"), priority, outputItem, sorted));
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/cn/nukkit/inventory/CraftingManager.java
+++ b/src/main/java/cn/nukkit/inventory/CraftingManager.java
@@ -165,6 +165,7 @@ public class CraftingManager {
                     case 4: // multi (hardcoded)
                         break;
                     case 5: // shulker_box
+                        loadShapelessRecipe(itemMapping, recipe);
                         break;
                 }
             } catch (Exception e) {

--- a/src/main/java/cn/nukkit/inventory/UserDataShapelessRecipe.java
+++ b/src/main/java/cn/nukkit/inventory/UserDataShapelessRecipe.java
@@ -1,0 +1,28 @@
+package cn.nukkit.inventory;
+
+import cn.nukkit.item.Item;
+
+import java.util.Collection;
+
+/**
+ * "shulker_box" 型 (type 5) 无序合成配方：合成输出需继承输入物品携带的 NBT (如潜影盒/收纳袋内容)，避免染色时丢失。
+ * <p>
+ * Shapeless variant for "shulker_box" (type 5) recipes: crafting output inherits the input item's NBT (e.g. shulker box/bundle contents) so dyeing does not wipe them.
+ * <p>
+ * Adapted from PowerNukkitX (<a href="https://github.com/PowerNukkitX/PowerNukkitX">PowerNukkitX</a>)
+ */
+public class UserDataShapelessRecipe extends ShapelessRecipe {
+
+    public UserDataShapelessRecipe(Item result, Collection<Item> ingredients) {
+        super(result, ingredients);
+    }
+
+    public UserDataShapelessRecipe(String recipeId, int priority, Item result, Collection<Item> ingredients) {
+        super(recipeId, priority, result, ingredients);
+    }
+
+    @Override
+    public RecipeType getType() {
+        return RecipeType.SHULKER_BOX;
+    }
+}

--- a/src/main/java/cn/nukkit/inventory/request/CraftRecipeActionProcessor.java
+++ b/src/main/java/cn/nukkit/inventory/request/CraftRecipeActionProcessor.java
@@ -131,6 +131,9 @@ public class CraftRecipeActionProcessor implements ItemStackRequestActionProcess
         }
         Item output = recipeResult.clone();
         output.setCount(output.getCount() * times);
+        if (recipe instanceof UserDataShapelessRecipe) {
+            applyInputNbt(output, collectCraftingInputList(player));
+        }
         output.autoAssignStackNetworkId();
         player.getUIInventory().setItem(PlayerUIComponent.CREATED_ITEM_OUTPUT_UI_SLOT, output, false);
 
@@ -377,6 +380,18 @@ public class CraftRecipeActionProcessor implements ItemStackRequestActionProcess
             }
         }
         return items;
+    }
+
+    /**
+     * Copies the NBT of the first NBT-carrying input onto the output, so {@link UserDataShapelessRecipe} dyeing keeps container contents.
+     */
+    static void applyInputNbt(Item output, List<Item> inputs) {
+        for (Item inputItem : inputs) {
+            if (inputItem != null && !inputItem.isNull() && inputItem.hasCompoundTag()) {
+                output.setCompoundTag(inputItem.getCompoundTag());
+                return;
+            }
+        }
     }
 
     private static CraftingGrid getActiveCraftingGrid(Player player) {

--- a/src/main/java/cn/nukkit/inventory/request/CraftRecipeAutoProcessor.java
+++ b/src/main/java/cn/nukkit/inventory/request/CraftRecipeAutoProcessor.java
@@ -2,10 +2,7 @@ package cn.nukkit.inventory.request;
 
 import cn.nukkit.Player;
 import cn.nukkit.event.inventory.CraftItemEvent;
-import cn.nukkit.inventory.CraftingRecipe;
-import cn.nukkit.inventory.MultiRecipe;
-import cn.nukkit.inventory.PlayerUIComponent;
-import cn.nukkit.inventory.Recipe;
+import cn.nukkit.inventory.*;
 import cn.nukkit.item.Item;
 import cn.nukkit.network.protocol.types.inventory.ContainerSlotType;
 import cn.nukkit.network.protocol.types.inventory.FullContainerName;
@@ -106,6 +103,9 @@ public class CraftRecipeAutoProcessor implements ItemStackRequestActionProcessor
         }
         Item output = recipeResult.clone();
         output.setCount(output.getCount() * times);
+        if (recipe instanceof UserDataShapelessRecipe) {
+            CraftRecipeActionProcessor.applyInputNbt(output, consumedItems);
+        }
         output.autoAssignStackNetworkId();
         player.getUIInventory().setItem(PlayerUIComponent.CREATED_ITEM_OUTPUT_UI_SLOT, output, false);
 

--- a/src/main/java/cn/nukkit/network/protocol/CraftingDataPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/CraftingDataPacket.java
@@ -107,6 +107,7 @@ public class CraftingDataPacket extends DataPacket {
                 this.putVarInt(networkType.getNetworkType(protocol));
                 switch (recipe.getType()) {
                     case SHAPELESS:
+                    case SHULKER_BOX: // UserDataShapelessRecipe: same wire format as SHAPELESS
                         ShapelessRecipe shapeless = (ShapelessRecipe) recipe;
                         if (protocol >= 361) {
                             this.putString(shapeless.getRecipeId());

--- a/src/test/java/cn/nukkit/inventory/request/UserDataShapelessRecipeTest.java
+++ b/src/test/java/cn/nukkit/inventory/request/UserDataShapelessRecipeTest.java
@@ -1,0 +1,110 @@
+package cn.nukkit.inventory.request;
+
+import cn.nukkit.MockServer;
+import cn.nukkit.block.BlockID;
+import cn.nukkit.inventory.*;
+import cn.nukkit.item.Item;
+import cn.nukkit.item.ItemDye;
+import cn.nukkit.nbt.tag.CompoundTag;
+import cn.nukkit.nbt.tag.ListTag;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression tests for "shulker_box" (type 5) recipes: loading, NBT-tolerant matching, and NBT preservation.
+ */
+class UserDataShapelessRecipeTest {
+
+    private CraftingManager manager;
+
+    @BeforeAll
+    static void init() {
+        MockServer.init();
+    }
+
+    @BeforeEach
+    void setUp() {
+        manager = new CraftingManager();
+    }
+
+    @Test
+    void shulkerBoxRecipesAreLoadedAsUserDataShapeless() {
+        UserDataShapelessRecipe recipe = findShulkerBoxDyeRecipe();
+        assertNotNull(recipe, "Expected at least one shulker_box (type 5) recipe to be loaded");
+        assertEquals(RecipeType.SHULKER_BOX, recipe.getType());
+    }
+
+    @Test
+    void matchRecipeAcceptsInputShulkerBoxCarryingContainerNbt() {
+        UserDataShapelessRecipe recipe = findShulkerBoxDyeRecipe();
+        assertNotNull(recipe);
+
+        // Input shulker box carries container NBT (Items list) that must survive recoloring.
+        Item shulkerInput = Item.get(BlockID.UNDYED_SHULKER_BOX, 0, 1);
+        CompoundTag containerTag = new CompoundTag()
+                .putList(new ListTag<CompoundTag>("Items"));
+        shulkerInput.setCompoundTag(containerTag);
+
+        Item blackDye = Item.get(Item.DYE, ItemDye.BLACK, 1);
+        List<Item> inputs = new ArrayList<>(List.of(shulkerInput, blackDye));
+
+        CraftingRecipe matched = manager.matchRecipe(
+                inputs,
+                recipe.getResult(),
+                List.of()
+        );
+        assertSame(recipe, matched, "Recipe matching must tolerate container NBT on the input shulker box");
+    }
+
+    @Test
+    void applyInputNbtCarriesContainerNbtToOutput() {
+        Item output = Item.get(BlockID.SHULKER_BOX, 0, 1);
+        assertFalse(output.hasCompoundTag());
+
+        Item input = Item.get(BlockID.UNDYED_SHULKER_BOX, 0, 1);
+        input.setCompoundTag(new CompoundTag().putList(new ListTag<CompoundTag>("Items")));
+
+        CraftRecipeActionProcessor.applyInputNbt(output, List.of(input));
+
+        assertTrue(output.hasCompoundTag(), "Container NBT must be carried onto the crafted output");
+    }
+
+    @Test
+    void applyInputNbtLeavesOutputUntouchedWhenNoNbtInput() {
+        Item output = Item.get(BlockID.SHULKER_BOX, 0, 1);
+        Item input = Item.get(BlockID.UNDYED_SHULKER_BOX, 0, 1);
+
+        CraftRecipeActionProcessor.applyInputNbt(output, List.of(input));
+
+        assertFalse(output.hasCompoundTag(), "Output must stay NBT-free when no input carries NBT");
+    }
+
+    @Test
+    void craftingDataPacketBuildsForAllProtocols() {
+        // 构造函数只构建最新版本；此处强制遍历所有协议 (含 legacy < 354 路径) 走 encode()，验证 SHULKER_BOX 分支。
+        for (cn.nukkit.GameVersion version : cn.nukkit.GameVersion.getValues()) {
+            assertDoesNotThrow(() -> manager.getCachedPacket(version),
+                    "CraftingDataPacket must encode for " + version);
+        }
+    }
+
+    private UserDataShapelessRecipe findShulkerBoxDyeRecipe() {
+        for (Recipe recipe : manager.getRecipes()) {
+            if (recipe instanceof UserDataShapelessRecipe userData) {
+                Item result = userData.getResult();
+                if (result.getId() == BlockID.SHULKER_BOX
+                        && userData.getIngredientList().stream()
+                                .anyMatch(i -> i.getId() == BlockID.UNDYED_SHULKER_BOX)) {
+                    return userData;
+                }
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
The structure of `shulker_box` type and `shapeless` type is the same in JSON. So can register `shulker_box` as `shapeless` directly.

## Type `shulker_box`
```json
        {
            "id": "bundle_dye_0",
            "type": 5,
            "input": [
                {
                    "type": "default",
                    "count": 1,
                    "itemId": 267,
                    "auxValue": 32767
                },
                {
                    "type": "default",
                    "count": 1,
                    "itemId": 445,
                    "auxValue": 32767
                }
            ],
            "output": [
                {
                    "legacyId": 264,
                    "id": "minecraft:black_bundle"
                }
            ],
            "block": "crafting_table",
            "priority": 0
        },
```

## type `shapeless`
```json
        {
            "id": "minecraft:cobweb_to_string",
            "type": 0,
            "input": [
                {
                    "type": "default",
                    "count": 1,
                    "itemId": 358,
                    "auxValue": 32767
                }
            ],
            "output": [
                {
                    "legacyId": 358,
                    "id": "minecraft:string"
                }
            ],
            "block": "deprecated",
            "priority": 0
        }
```

## before
<img width="670" height="614" alt="image" src="https://github.com/user-attachments/assets/9cf866bd-4d10-4f5f-84cb-38a7e7ee4910" />

## after

<img width="636" height="586" alt="image" src="https://github.com/user-attachments/assets/3edb4779-aba6-43de-ab14-51bf56ea07db" />
