### PR TITLE
fix: add missing @Deprecated annotations to mvw() callers

### DIFF
--- a/src/main/java/cn/nukkit/block/custom/container/BlockContainer.java
+++ b/src/main/java/cn/nukkit/block/custom/container/BlockContainer.java
@@ -14,6 +14,7 @@ public interface BlockContainer {
         return 0;
     }
 
+    @Deprecated
     default int getRuntimeId() {
         Server.mvw("BlockContainer#getRuntimeId()");
         return getRuntimeId(GameVersion.getLastVersion());

--- a/src/main/java/cn/nukkit/form/window/FormWindow.java
+++ b/src/main/java/cn/nukkit/form/window/FormWindow.java
@@ -24,6 +24,7 @@ public abstract class FormWindow {
     protected transient boolean closed = false;
     protected final transient List<FormResponseHandler> handlers = new ObjectArrayList<>();
 
+    @Deprecated
     public String getJSONData() {
         Server.mvw("FormWindow#getJSONData()");
         return this.getJSONData(GameVersion.getLastVersion());

--- a/src/main/java/cn/nukkit/item/Item.java
+++ b/src/main/java/cn/nukkit/item/Item.java
@@ -2049,6 +2049,7 @@ public class Item implements Cloneable, BlockID, ItemID, ItemNamespaceId, Protoc
         return RuntimeItems.getMapping(protocolId).toRuntime(this.getId(), this.getDamage());
     }
 
+    @Deprecated
     public final int getNetworkId() {
         Server.mvw("Item#getNetworkId()");
         return this.getNetworkId(GameVersion.getLastVersion());

--- a/src/main/java/cn/nukkit/level/GameRules.java
+++ b/src/main/java/cn/nukkit/level/GameRules.java
@@ -382,6 +382,7 @@ public class GameRules {
             return (Float) value;
         }
 
+        @Deprecated
         public void write(BinaryStream pk, boolean startGame) {
             Server.mvw("GameRules#write(BinaryStream, boolean)");
             write(GameVersion.getLastVersion(), pk, startGame);

--- a/src/main/java/cn/nukkit/level/GlobalBlockPalette.java
+++ b/src/main/java/cn/nukkit/level/GlobalBlockPalette.java
@@ -693,11 +693,13 @@ public class GlobalBlockPalette {
         useHashedBlockNetworkIds = enabled;
     }
 
+    @Deprecated
     public static int getOrCreateRuntimeId(int legacyId) throws NoSuchElementException {
         Server.mvw("GlobalBlockPalette#getOrCreateRuntimeId(int)");
         return getOrCreateRuntimeId(GameVersion.getLastVersion(), legacyId >> 4, legacyId & 0xf);
     }
 
+    @Deprecated
     public static int getLegacyFullId(int runtimeId) {
         Server.mvw("GlobalBlockPalette#getLegacyFullId(int)");
         return getLegacyFullId(GameVersion.getLastVersion(), runtimeId);

--- a/src/main/java/cn/nukkit/level/particle/Particle.java
+++ b/src/main/java/cn/nukkit/level/particle/Particle.java
@@ -169,6 +169,7 @@ public abstract class Particle extends Vector3 {
         super(x, y, z);
     }
 
+    @Deprecated
     public DataPacket[] encode() {
         Server.mvw("Particle#encode()");
         return this.mvEncode(GameVersion.getLastVersion());

--- a/src/main/java/cn/nukkit/utils/Binary.java
+++ b/src/main/java/cn/nukkit/utils/Binary.java
@@ -107,6 +107,7 @@ public class Binary {
         return appendBytes(writeLLong(uuid.getMostSignificantBits()), writeLLong(uuid.getLeastSignificantBits()));
     }
 
+    @Deprecated
     public static byte[] writeMetadata(EntityMetadata metadata) {
         Server.mvw("Binary#writeMetadata(EntityMetadata)");
         return writeMetadata(GameVersion.getLastVersion(), metadata);

--- a/src/main/java/cn/nukkit/utils/BinaryStream.java
+++ b/src/main/java/cn/nukkit/utils/BinaryStream.java
@@ -455,6 +455,7 @@ public class BinaryStream {
         return new SerializedImage(width, height, data);
     }
 
+    @Deprecated
     public Skin getSkin() {
         Server.mvw("BinaryStream#getSkin()");
         return getSkin(ProtocolInfo.CURRENT_PROTOCOL);
@@ -534,6 +535,7 @@ public class BinaryStream {
     private static final String MV_ORIGIN_NAMESPACE = "mv_origin_namespace";
     private static final String MV_ORIGIN_META = "mv_origin_meta";
 
+    @Deprecated
     public Item getSlot() {
         Server.mvw("BinaryStream#getSlot()");
         return this.getSlot(GameVersion.getLastVersion());
@@ -931,6 +933,7 @@ public class BinaryStream {
         return item;
     }
 
+    @Deprecated
     public void putSlot(Item item) {
         Server.mvw("BinaryStream#putSlot(Item)");
         this.putSlot(GameVersion.getLastVersion(), item);
@@ -1814,6 +1817,7 @@ public class BinaryStream {
         this.putByte((byte) (rotation / (360d / 256d)));
     }
 
+    @Deprecated
     public void putGameRules(GameRules gameRules, boolean startGame) {
         Server.mvw("BinaryStream#putGameRules(GameRules, boolean)");
         this.putGameRules(ProtocolInfo.CURRENT_PROTOCOL, gameRules, startGame);


### PR DESCRIPTION
## Summary

11 methods call `Server.mvw()` to warn about multiversion incompatibility at runtime but were missing the `@Deprecated` compile-time annotation. Plugin developers using IDEs would not see any deprecation warning when calling these methods.

## Changes

Added `@Deprecated` to:

- `GameRules.GameRule#write(BinaryStream, boolean)`
- `Particle#encode()`
- `GlobalBlockPalette#getOrCreateRuntimeId(int)`
- `GlobalBlockPalette#getLegacyFullId(int)`
- `FormWindow#getJSONData()`
- `Binary#writeMetadata(EntityMetadata)`
- `BinaryStream#getSkin()`
- `BinaryStream#getSlot()`
- `BinaryStream#putSlot(Item)`
- `BinaryStream#putGameRules(GameRules, boolean)`
- `BlockContainer#getRuntimeId()`

## Test Plan

- [ ] CI passes
- [ ] Verify no duplicate @Deprecated annotations