### PR TITLE
refactor: simplify conditional expressions and remove redundant NBT checks

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -2517,7 +2517,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
             }
 
             if (this.riding == null && this.inventory != null) {
-                if (this.isFoodEnabled() && this.getServer().getDifficulty() > 0 && distanceSquared >= 0.05) {
+                if (this.isFoodEnabled() && distanceSquared >= 0.05 && this.getServer().getDifficulty() > 0) {
                     double jump = 0;
                     double distance = Math.sqrt(distanceSquared);
                     double swimming = this.isInsideOfWater() ? 0.01 * distance : 0;
@@ -3867,7 +3867,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                     this.forceMovement = this.getLocation();
                 }
 
-                if (this.forceMovement != null && (newPos.distanceSquared(this.forceMovement) > 0.1 || revert)) {
+                if (this.forceMovement != null && (revert || newPos.distanceSquared(this.forceMovement) > 0.1)) {
                     this.sendPosition(this.forceMovement, MovePlayerPacket.MODE_RESET);
                 } else {
 
@@ -4251,7 +4251,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                     this.forceMovement = this.getLocation();
                 }
 
-                if (this.forceMovement != null && (clientPosition.distanceSquared(this.forceMovement) > 0.1 || revertMotion)) {
+                if (this.forceMovement != null && (revertMotion || clientPosition.distanceSquared(this.forceMovement) > 0.1)) {
                     this.sendPosition(this.forceMovement, MovePlayerPacket.MODE_RESET);
                 } else {
                     float yaw = authPacket.getYaw() % 360;
@@ -5258,8 +5258,8 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                             lastRightClickPos = blockVector;
                             lastRightClickTime = System.currentTimeMillis();
 
-                            if (spamming && (this.getInventory().getItemInHandFast().getBlockId() == BlockID.AIR
-                                    || (this.isSpectator() && !this.server.useClientSpectator))) {
+                            if (spamming && ((this.isSpectator() && !this.server.useClientSpectator)
+                                    || this.getInventory().getItemInHandFast().getBlockId() == BlockID.AIR)) {
                                 return;
                             }
 
@@ -5765,7 +5765,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
         }
 
         // HACK: Client spams multiple left clicks so we need to skip them.
-        if ((this.lastBreakPosition.equals(blockPos) && (currentBreak - this.lastBreak) < 10) || pos.distanceSquared(this) > 100) {
+        if (((currentBreak - this.lastBreak) < 10 && this.lastBreakPosition.equals(blockPos)) || pos.distanceSquared(this) > 100) {
             return;
         }
 
@@ -5907,7 +5907,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
         int maxMsgLength = this.protocol >= ProtocolInfo.v1_18_0 ? 512 : 255;
 
         for (String msg : message.split("\n")) {
-            if (!msg.trim().isEmpty() && msg.length() <= maxMsgLength) {
+            if (msg.length() <= maxMsgLength && !msg.trim().isEmpty()) {
                 PlayerChatEvent chatEvent = new PlayerChatEvent(this, msg);
                 this.server.getPluginManager().callEvent(chatEvent);
                 if (!chatEvent.isCancelled()) {
@@ -6378,7 +6378,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                 }
             }
 
-            if (ev != null && !Objects.equals(this.username, "") && this.spawned && !Objects.equals(ev.getQuitMessage().toString(), "")) {
+            if (ev != null && this.spawned && !Objects.equals(this.username, "") && !Objects.equals(ev.getQuitMessage().toString(), "")) {
                 this.server.broadcastMessage(ev.getQuitMessage());
             }
 
@@ -8232,7 +8232,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
             return false;
         }
         Player other = (Player) obj;
-        return Objects.equals(this.getUniqueId(), other.getUniqueId()) && this.getId() == other.getId();
+        return this.getId() == other.getId() && Objects.equals(this.getUniqueId(), other.getUniqueId());
     }
 
     public boolean isBreakingBlock() {

--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -995,7 +995,7 @@ public class Server {
                 content.close();
 
                 boolean isMaster = Nukkit.getBranch().equals("master");
-                if (!this.getNukkitVersion().equals(latest) && !this.getNukkitVersion().equals("git-null") && isMaster) {
+                if (isMaster && !this.getNukkitVersion().equals(latest) && !this.getNukkitVersion().equals("git-null")) {
                     this.getLogger().info("§c[Nukkit-MOT][Update] §eThere is a new build of §cNukkit§3-§dMOT §eavailable! Current: " + this.getNukkitVersion() + " Latest: " + latest);
                     this.getLogger().info("§c[Nukkit-MOT][Update] §eYou can download the latest build from https://github.com/MemoriesOfTime/Nukkit-MOT/");
                 } else if (!isMaster) {

--- a/src/main/java/cn/nukkit/block/BlockBarrel.java
+++ b/src/main/java/cn/nukkit/block/BlockBarrel.java
@@ -117,7 +117,7 @@ public class BlockBarrel extends BlockSolidMeta implements Faceable, BlockEntity
 
         BlockEntityBarrel barrel = (BlockEntityBarrel) blockEntity;
 
-        if (barrel.namedTag.contains("Lock") && barrel.namedTag.get("Lock") instanceof StringTag) {
+        if (barrel.namedTag.get("Lock") instanceof StringTag) {
             if (!barrel.namedTag.getString("Lock").equals(item.getCustomName())) {
                 return true;
             }

--- a/src/main/java/cn/nukkit/block/BlockBeehive.java
+++ b/src/main/java/cn/nukkit/block/BlockBeehive.java
@@ -123,7 +123,7 @@ public class BlockBeehive extends BlockSolidMeta implements Faceable, BlockEntit
     }
 
     public void honeyCollected(Player player) {
-        honeyCollected(player, level.getServer().getDifficulty() > 0 && !player.isCreative());
+        honeyCollected(player, !player.isCreative() && level.getServer().getDifficulty() > 0);
     }
 
     public void honeyCollected(Player player, boolean angerBees) {

--- a/src/main/java/cn/nukkit/block/BlockBrewingStand.java
+++ b/src/main/java/cn/nukkit/block/BlockBrewingStand.java
@@ -126,7 +126,7 @@ public class BlockBrewingStand extends BlockTransparentMeta implements BlockEnti
                 }
             }
 
-            if (brewing.namedTag.contains("Lock") && brewing.namedTag.get("Lock") instanceof StringTag) {
+            if (brewing.namedTag.get("Lock") instanceof StringTag) {
                 if (!brewing.namedTag.getString("Lock").equals(item.getCustomName())) {
                     return false;
                 }

--- a/src/main/java/cn/nukkit/block/BlockChest.java
+++ b/src/main/java/cn/nukkit/block/BlockChest.java
@@ -203,7 +203,7 @@ public class BlockChest extends BlockTransparentMeta implements Faceable, BlockE
                 chest = (BlockEntityChest) BlockEntity.createBlockEntity(BlockEntity.CHEST, this.getChunk(), nbt);
             }
 
-            if (chest.namedTag.contains("Lock") && chest.namedTag.get("Lock") instanceof StringTag) {
+            if (chest.namedTag.get("Lock") instanceof StringTag) {
                 if (!chest.namedTag.getString("Lock").equals(item.getCustomName())) {
                     return true;
                 }

--- a/src/main/java/cn/nukkit/block/BlockEnchantingTable.java
+++ b/src/main/java/cn/nukkit/block/BlockEnchantingTable.java
@@ -128,7 +128,7 @@ public class BlockEnchantingTable extends BlockTransparent implements BlockEntit
                 enchantTable = (BlockEntityEnchantTable) BlockEntity.createBlockEntity(BlockEntity.ENCHANT_TABLE, this.getChunk(), nbt);
             }
 
-            if (enchantTable.namedTag.contains("Lock") && enchantTable.namedTag.get("Lock") instanceof StringTag) {
+            if (enchantTable.namedTag.get("Lock") instanceof StringTag) {
                 if (!enchantTable.namedTag.getString("Lock").equals(item.getCustomName())) {
                     return true;
                 }

--- a/src/main/java/cn/nukkit/block/BlockEnderChest.java
+++ b/src/main/java/cn/nukkit/block/BlockEnderChest.java
@@ -153,7 +153,7 @@ public class BlockEnderChest extends BlockTransparentMeta implements Faceable, B
                 chest = (BlockEntityEnderChest) BlockEntity.createBlockEntity(BlockEntity.ENDER_CHEST, this.getChunk(), nbt);
             }
 
-            if (chest.namedTag.contains("Lock") && chest.namedTag.get("Lock") instanceof StringTag) {
+            if (chest.namedTag.get("Lock") instanceof StringTag) {
                 if (!chest.namedTag.getString("Lock").equals(item.getCustomName())) {
                     return true;
                 }

--- a/src/main/java/cn/nukkit/block/BlockFire.java
+++ b/src/main/java/cn/nukkit/block/BlockFire.java
@@ -120,7 +120,7 @@ public class BlockFire extends BlockFlowable {
                     this.getLevel().canBlockSeeSky(this.south()) ||
                     this.getLevel().canBlockSeeSky(this.north());
 
-            if (!forever && this.getLevel().isRaining() && canBlockSeeSky) {
+            if (!forever && canBlockSeeSky && this.getLevel().isRaining()) {
                 this.getLevel().setBlock(this, Block.get(BlockID.AIR), true);
             }
 

--- a/src/main/java/cn/nukkit/block/BlockFlower.java
+++ b/src/main/java/cn/nukkit/block/BlockFlower.java
@@ -120,7 +120,7 @@ public class BlockFlower extends BlockFlowable {
                         Utils.random.nextInt(-1, 2),
                         Utils.random.nextInt(-3, 4));
 
-                if (level.getBlock(vec).getId() == AIR && level.getBlock(vec.down()).getId() == GRASS && vec.getY() >= 0 && vec.getY() < 256) {
+                if (vec.getY() >= 0 && vec.getY() < 256 && level.getBlock(vec).getId() == AIR && level.getBlock(vec.down()).getId() == GRASS) {
                     if (Utils.random.nextInt(10) == 0) {
                         this.level.setBlock(vec, this.getUncommonFlower(), true);
                     } else {

--- a/src/main/java/cn/nukkit/block/BlockFurnaceBurning.java
+++ b/src/main/java/cn/nukkit/block/BlockFurnaceBurning.java
@@ -117,7 +117,7 @@ public class BlockFurnaceBurning extends BlockSolidMeta implements Faceable, Blo
         if (player != null) {
             BlockEntityFurnace furnace = this.getOrCreateBlockEntity();
 
-            if (furnace.namedTag.contains("Lock") && furnace.namedTag.get("Lock") instanceof StringTag) {
+            if (furnace.namedTag.get("Lock") instanceof StringTag) {
                 if (!furnace.namedTag.getString("Lock").equals(item.getCustomName())) {
                     return true;
                 }

--- a/src/main/java/cn/nukkit/block/BlockShelf.java
+++ b/src/main/java/cn/nukkit/block/BlockShelf.java
@@ -119,7 +119,7 @@ public abstract class BlockShelf extends BlockTransparentMeta implements Faceabl
     public int onTouch(@NotNull Vector3 vector, @NotNull Item item, @NotNull BlockFace face, float fx, float fy, float fz,
                        @Nullable Player player, PlayerInteractEvent.Action action) {
         if (action != PlayerInteractEvent.Action.RIGHT_CLICK_BLOCK || player == null || player.isSneaking()
-                || face != this.getBlockFace() || fy <= 0.25f || fy >= 0.75f) {
+                || fy <= 0.25f || fy >= 0.75f || face != this.getBlockFace()) {
             return super.onTouch(vector, item, face, fx, fy, fz, player, action);
         }
 

--- a/src/main/java/cn/nukkit/block/BlockSmokerLit.java
+++ b/src/main/java/cn/nukkit/block/BlockSmokerLit.java
@@ -73,7 +73,7 @@ public class BlockSmokerLit extends BlockFurnaceBurning {
                 return false;
             }
 
-            if (smoker.namedTag.contains("Lock") && smoker.namedTag.get("Lock") instanceof StringTag) {
+            if (smoker.namedTag.get("Lock") instanceof StringTag) {
                 if (!smoker.namedTag.getString("Lock").equals(item.getCustomName())) {
                     return true;
                 }

--- a/src/main/java/cn/nukkit/block/BlockWitherRose.java
+++ b/src/main/java/cn/nukkit/block/BlockWitherRose.java
@@ -28,7 +28,7 @@ public class BlockWitherRose extends BlockFlower {
 
     @Override
     public void onEntityCollide(Entity entity) {
-        if (level.getServer().getDifficulty() != 0 && entity instanceof EntityLiving living) {
+        if (entity instanceof EntityLiving living && level.getServer().getDifficulty() != 0) {
             if (!living.invulnerable && !living.hasEffect(Effect.WITHER)
                     && (!(living instanceof Player) || !((Player) living).isCreative() && !((Player) living).isSpectator())) {
                 Effect effect = Effect.getEffect(Effect.WITHER);

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityBanner.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityBanner.java
@@ -67,7 +67,8 @@ public class BlockEntityBanner extends BlockEntitySpawnable {
     }
 
     public BannerPattern getPattern(int index) {
-        return BannerPattern.fromCompoundTag(this.namedTag.getList("Patterns").size() > index && index >= 0 ? this.namedTag.getList("Patterns", CompoundTag.class).get(index) : new CompoundTag());
+        ListTag<CompoundTag> patterns = this.namedTag.getList("Patterns", CompoundTag.class);
+        return BannerPattern.fromCompoundTag(index >= 0 && index < patterns.size() ? patterns.get(index) : new CompoundTag());
     }
 
     public void removePattern(int index) {

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityBell.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityBell.java
@@ -24,19 +24,19 @@ public class BlockEntityBell extends BlockEntitySpawnable {
 
     @Override
     protected void initBlockEntity() {
-        if (!namedTag.contains("Ringing") || !(namedTag.get("Ringing") instanceof ByteTag)) {
+        if (!(namedTag.get("Ringing") instanceof ByteTag)) {
             ringing = false;
         } else {
             ringing = namedTag.getBoolean("Ringing");
         }
 
-        if (!namedTag.contains("Direction") || !(namedTag.get("Direction") instanceof IntTag)) {
+        if (!(namedTag.get("Direction") instanceof IntTag)) {
             direction = 255;
         } else {
             direction = namedTag.getInt("Direction");
         }
 
-        if (!namedTag.contains("Ticks") || !(namedTag.get("Ticks") instanceof IntTag)) {
+        if (!(namedTag.get("Ticks") instanceof IntTag)) {
             ticks = 0;
         } else {
             ticks = namedTag.getInt("Ticks");

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityBrewingStand.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityBrewingStand.java
@@ -37,7 +37,7 @@ public class BlockEntityBrewingStand extends BlockEntitySpawnable implements Inv
     protected void initBlockEntity() {
         inventory = new BrewingInventory(this);
 
-        if (!namedTag.contains("Items") || !(namedTag.get("Items") instanceof ListTag)) {
+        if (!(namedTag.get("Items") instanceof ListTag)) {
             namedTag.putList(new ListTag<CompoundTag>("Items"));
         }
 

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityCampfire.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityCampfire.java
@@ -41,7 +41,7 @@ public class BlockEntityCampfire extends BlockEntitySpawnable implements Invento
             burnTime[i -1] = namedTag.getInt("ItemTime" + i);
             keepItem[i -1] = namedTag.getBoolean("KeepItem" + 1);
 
-            if (this.namedTag.contains("Item" + i) && this.namedTag.get("Item" + i) instanceof CompoundTag) {
+            if (this.namedTag.get("Item" + i) instanceof CompoundTag) {
                 inventory.setItem(i - 1, NBTIO.getItemHelper(this.namedTag.getCompound("Item" + i)));
             }
 

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityCopperGolemStatue.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityCopperGolemStatue.java
@@ -111,11 +111,11 @@ public class BlockEntityCopperGolemStatue extends BlockEntitySpawnable {
     public void initActorDataFromItem(@NotNull cn.nukkit.item.Item item) {
         if (item.hasCustomBlockData()) {
             CompoundTag customBlockData = item.getCustomBlockData();
-            if (customBlockData.contains("Actor") && customBlockData.get("Actor") instanceof CompoundTag actorTag) {
+            if (customBlockData.get("Actor") instanceof CompoundTag actorTag) {
                 if (actorTag.contains("ActorIdentifier")) {
                     this.actorIdentifier = actorTag.getString("ActorIdentifier");
                 }
-                if (actorTag.contains("SaveData") && actorTag.get("SaveData") instanceof CompoundTag saveData) {
+                if (actorTag.get("SaveData") instanceof CompoundTag saveData) {
                     this.actorSaveData = saveData;
                 }
             }

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityDispenser.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityDispenser.java
@@ -26,7 +26,7 @@ public class BlockEntityDispenser extends BlockEntitySpawnable implements Invent
     protected void initBlockEntity() {
         this.inventory = new DispenserInventory(this);
 
-        if (!this.namedTag.contains("Items") || !(this.namedTag.get("Items") instanceof ListTag)) {
+        if (!(this.namedTag.get("Items") instanceof ListTag)) {
             this.namedTag.putList(new ListTag<CompoundTag>("Items"));
         }
 

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityDropper.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityDropper.java
@@ -23,7 +23,7 @@ public class BlockEntityDropper extends BlockEntitySpawnable implements Inventor
 
         this.inventory = new DropperInventory(this);
 
-        if (!this.namedTag.contains("Items") || !(this.namedTag.get("Items") instanceof ListTag)) {
+        if (!(this.namedTag.get("Items") instanceof ListTag)) {
             this.namedTag.putList(new ListTag<CompoundTag>("Items"));
         }
 

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityFurnace.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityFurnace.java
@@ -54,7 +54,7 @@ public class BlockEntityFurnace extends BlockEntitySpawnable implements Inventor
             this.inventory = new FurnaceInventory(this);
         }
 
-        if (!this.namedTag.contains("Items") || !(this.namedTag.get("Items") instanceof ListTag)) {
+        if (!(this.namedTag.get("Items") instanceof ListTag)) {
             this.namedTag.putList(new ListTag<CompoundTag>("Items"));
         }
 
@@ -62,22 +62,26 @@ public class BlockEntityFurnace extends BlockEntitySpawnable implements Inventor
             this.inventory.setItem(i, this.getItem(i));
         }
 
-        if (!this.namedTag.contains("BurnTime") || this.namedTag.getShort("BurnTime") < 0) {
+        int burnTimeTag = this.namedTag.getShort("BurnTime");
+        int cookTimeTag = this.namedTag.getShort("CookTime");
+        int burnDurationTag = this.namedTag.getShort("BurnDuration");
+
+        if (!this.namedTag.contains("BurnTime") || burnTimeTag < 0) {
             burnTime = 0;
         } else {
-            burnTime = this.namedTag.getShort("BurnTime");
+            burnTime = burnTimeTag;
         }
 
-        if (!this.namedTag.contains("CookTime") || this.namedTag.getShort("CookTime") < 0 || (this.namedTag.getShort("BurnTime") == 0 && this.namedTag.getShort("CookTime") > 0)) {
+        if (!this.namedTag.contains("CookTime") || cookTimeTag < 0 || (burnTimeTag == 0 && cookTimeTag > 0)) {
             cookTime = 0;
         } else {
-            cookTime = this.namedTag.getShort("CookTime");
+            cookTime = cookTimeTag;
         }
 
-        if (!this.namedTag.contains("BurnDuration") || this.namedTag.getShort("BurnDuration") < 0) {
+        if (!this.namedTag.contains("BurnDuration") || burnDurationTag < 0) {
             burnDuration = 0;
         } else {
-            burnDuration = this.namedTag.getShort("BurnDuration");
+            burnDuration = burnDurationTag;
         }
 
         if (!this.namedTag.contains("MaxTime")) {

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityHopper.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityHopper.java
@@ -57,7 +57,7 @@ public class BlockEntityHopper extends BlockEntitySpawnableContainer implements 
 
         this.inventory = new HopperInventory(this);
 
-        if (!this.namedTag.contains("Items") || !(this.namedTag.get("Items") instanceof ListTag)) {
+        if (!(this.namedTag.get("Items") instanceof ListTag)) {
             this.namedTag.putList(new ListTag<CompoundTag>("Items"));
         }
 

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityLectern.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityLectern.java
@@ -69,7 +69,7 @@ public class BlockEntityLectern extends BlockEntitySpawnable {
     }
 
     public boolean hasBook() {
-        return this.namedTag.contains("book") && this.namedTag.get("book") instanceof CompoundTag;
+        return this.namedTag.get("book") instanceof CompoundTag;
     }
 
     public Item getBook() {

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityShelf.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityShelf.java
@@ -26,7 +26,7 @@ public class BlockEntityShelf extends BlockEntitySpawnable implements InventoryH
     protected void initBlockEntity() {
         this.inventory = new ShelfInventory(this);
 
-        if (this.namedTag.contains("Items") && this.namedTag.get("Items") instanceof ListTag) {
+        if (this.namedTag.get("Items") instanceof ListTag) {
             ListTag<CompoundTag> list = this.namedTag.getList("Items", CompoundTag.class);
             for (CompoundTag compound : list.getAll()) {
                 Item item = NBTIO.getItemHelper(compound);

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityShulkerBox.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityShulkerBox.java
@@ -27,7 +27,7 @@ public class BlockEntityShulkerBox extends BlockEntitySpawnable implements Inven
     protected void initBlockEntity() {
         this.inventory = new ShulkerBoxInventory(this);
 
-        if (!this.namedTag.contains("Items") || !(this.namedTag.get("Items") instanceof ListTag)) {
+        if (!(this.namedTag.get("Items") instanceof ListTag)) {
             this.namedTag.putList(new ListTag<CompoundTag>("Items"));
         }
 

--- a/src/main/java/cn/nukkit/blockentity/BlockEntitySpawnableContainer.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntitySpawnableContainer.java
@@ -23,7 +23,7 @@ public abstract class BlockEntitySpawnableContainer extends BlockEntitySpawnable
 
     @Override
     protected void initBlockEntity() {
-        if (!this.namedTag.contains("Items") || !(this.namedTag.get("Items") instanceof ListTag)) {
+        if (!(this.namedTag.get("Items") instanceof ListTag)) {
             this.namedTag.putList(new ListTag<CompoundTag>("Items"));
         }
 

--- a/src/main/java/cn/nukkit/blockentity/BlockEntitySpawner.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntitySpawner.java
@@ -57,31 +57,31 @@ public class BlockEntitySpawner extends BlockEntitySpawnable {
 
     @Override
     protected void initBlockEntity() {
-        if (!this.namedTag.contains(TAG_SPAWN_RANGE) || !(this.namedTag.get(TAG_SPAWN_RANGE) instanceof ShortTag)) {
+        if (!(this.namedTag.get(TAG_SPAWN_RANGE) instanceof ShortTag)) {
             this.namedTag.putShort(TAG_SPAWN_RANGE, SPAWN_RANGE);
         }
 
-        if (!this.namedTag.contains(TAG_MIN_SPAWN_DELAY) || !(this.namedTag.get(TAG_MIN_SPAWN_DELAY) instanceof ShortTag)) {
+        if (!(this.namedTag.get(TAG_MIN_SPAWN_DELAY) instanceof ShortTag)) {
             this.namedTag.putShort(TAG_MIN_SPAWN_DELAY, MIN_SPAWN_DELAY);
         }
 
-        if (!this.namedTag.contains(TAG_MAX_SPAWN_DELAY) || !(this.namedTag.get(TAG_MAX_SPAWN_DELAY) instanceof ShortTag)) {
+        if (!(this.namedTag.get(TAG_MAX_SPAWN_DELAY) instanceof ShortTag)) {
             this.namedTag.putShort(TAG_MAX_SPAWN_DELAY, MAX_SPAWN_DELAY);
         }
 
-        if (!this.namedTag.contains(TAG_MAX_NEARBY_ENTITIES) || !(this.namedTag.get(TAG_MAX_NEARBY_ENTITIES) instanceof ShortTag)) {
+        if (!(this.namedTag.get(TAG_MAX_NEARBY_ENTITIES) instanceof ShortTag)) {
             this.namedTag.putShort(TAG_MAX_NEARBY_ENTITIES, MAX_NEARBY_ENTITIES);
         }
 
-        if (!this.namedTag.contains(TAG_REQUIRED_PLAYER_RANGE) || !(this.namedTag.get(TAG_REQUIRED_PLAYER_RANGE) instanceof ShortTag)) {
+        if (!(this.namedTag.get(TAG_REQUIRED_PLAYER_RANGE) instanceof ShortTag)) {
             this.namedTag.putShort(TAG_REQUIRED_PLAYER_RANGE, REQUIRED_PLAYER_RANGE);
         }
 
-        if (!this.namedTag.contains(TAG_MINIMUM_SPAWN_COUNT) || !(this.namedTag.get(TAG_MINIMUM_SPAWN_COUNT) instanceof ShortTag)) {
+        if (!(this.namedTag.get(TAG_MINIMUM_SPAWN_COUNT) instanceof ShortTag)) {
             this.namedTag.putShort(TAG_MINIMUM_SPAWN_COUNT, MINIMUM_SPAWN_COUNT);
         }
 
-        if (!this.namedTag.contains(TAG_MAXIMUM_SPAWN_COUNT) || !(this.namedTag.get(TAG_MAXIMUM_SPAWN_COUNT) instanceof ShortTag)) {
+        if (!(this.namedTag.get(TAG_MAXIMUM_SPAWN_COUNT) instanceof ShortTag)) {
             this.namedTag.putShort(TAG_MAXIMUM_SPAWN_COUNT, MAXIMUM_SPAWN_COUNT);
         }
 

--- a/src/main/java/cn/nukkit/command/SimpleCommandMap.java
+++ b/src/main/java/cn/nukkit/command/SimpleCommandMap.java
@@ -229,7 +229,7 @@ public class SimpleCommandMap implements CommandMap {
         // So basically we can't override the main name of a command, but we can override aliases if we're not an alias
 
         // Added the last statement which will allow us to override a VanillaCommand unconditionally
-        if (alreadyRegistered && existingCommand.getLabel() != null && existingCommand.getLabel().equals(label) && existingCommandIsNotVanilla) {
+        if (alreadyRegistered && existingCommandIsNotVanilla && existingCommand.getLabel() != null && existingCommand.getLabel().equals(label)) {
             return false;
         }
 

--- a/src/main/java/cn/nukkit/entity/BaseEntity.java
+++ b/src/main/java/cn/nukkit/entity/BaseEntity.java
@@ -778,7 +778,7 @@ public abstract class BaseEntity extends EntityCreature implements EntityAgeable
      * @return 是否满足
      */
     public boolean isMeetAttackConditions(Vector3 target) {
-        return this.getServer().getMobAiEnabled() && target instanceof Entity;
+        return target instanceof Entity && this.getServer().getMobAiEnabled();
     }
 
     /**

--- a/src/main/java/cn/nukkit/entity/Entity.java
+++ b/src/main/java/cn/nukkit/entity/Entity.java
@@ -3665,7 +3665,7 @@ public abstract class Entity extends Location implements Metadatable {
         List<EntityProperty> entityPropertyList = EntityProperty.getEntityProperty(this.getIdentifier().toString());
 
         for (EntityProperty property : entityPropertyList) {
-            if(Objects.equals(property.getIdentifier(), identifier) && property instanceof EnumEntityProperty enumEntityProperty) {
+            if(property instanceof EnumEntityProperty enumEntityProperty && Objects.equals(property.getIdentifier(), identifier)) {
                 int index = enumEntityProperty.findIndex(value);
 
                 if(index >= 0) {
@@ -3682,8 +3682,8 @@ public abstract class Entity extends Location implements Metadatable {
         List<EntityProperty> entityPropertyList = EntityProperty.getEntityProperty(this.getIdentifier().toString());
 
         for (EntityProperty property : entityPropertyList) {
-            if (!identifier.equals(property.getIdentifier()) ||
-                    !(property instanceof EnumEntityProperty enumProperty)) {
+            if (!(property instanceof EnumEntityProperty enumProperty) ||
+                    !identifier.equals(property.getIdentifier())) {
                 continue;
             }
             String[] values = enumProperty.getEnums();

--- a/src/main/java/cn/nukkit/entity/EntityHuman.java
+++ b/src/main/java/cn/nukkit/entity/EntityHuman.java
@@ -124,7 +124,7 @@ public class EntityHuman extends EntityHumanType {
                 this.setNameTag(this.namedTag.getString("NameTag"));
             }
 
-            if (this.namedTag.contains("Skin") && this.namedTag.get("Skin") instanceof CompoundTag) {
+            if (this.namedTag.get("Skin") instanceof CompoundTag) {
                 CompoundTag skinTag = this.namedTag.getCompound("Skin");
                 if (!skinTag.contains("Transparent")) {
                     skinTag.putBoolean("Transparent", false);

--- a/src/main/java/cn/nukkit/entity/EntityHumanType.java
+++ b/src/main/java/cn/nukkit/entity/EntityHumanType.java
@@ -50,7 +50,7 @@ public abstract class EntityHumanType extends EntityCreature implements Inventor
         this.inventory = new PlayerInventory(this);
         this.offhandInventory = new PlayerOffhandInventory(this);
 
-        if (this.namedTag.contains("Inventory") && this.namedTag.get("Inventory") instanceof ListTag) {
+        if (this.namedTag.get("Inventory") instanceof ListTag) {
             ListTag<CompoundTag> inventoryList = this.namedTag.getList("Inventory", CompoundTag.class);
             for (CompoundTag item : inventoryList.getAll()) {
                 int slot = item.getByte("Slot");
@@ -68,7 +68,7 @@ public abstract class EntityHumanType extends EntityCreature implements Inventor
 
         this.enderChestInventory = new PlayerEnderChestInventory(this);
 
-        if (this.namedTag.contains("EnderItems") && this.namedTag.get("EnderItems") instanceof ListTag) {
+        if (this.namedTag.get("EnderItems") instanceof ListTag) {
             ListTag<CompoundTag> inventoryList = this.namedTag.getList("EnderItems", CompoundTag.class);
             for (CompoundTag item : inventoryList.getAll()) {
                 this.enderChestInventory.setItem(item.getByte("Slot"), NBTIO.getItemHelper(item));

--- a/src/main/java/cn/nukkit/entity/EntityLiving.java
+++ b/src/main/java/cn/nukkit/entity/EntityLiving.java
@@ -73,7 +73,7 @@ public abstract class EntityLiving extends Entity implements EntityDamageable {
             this.namedTag.remove("HealF");
         }
 
-        if (!this.namedTag.contains("Health") || !(this.namedTag.get("Health") instanceof FloatTag)) {
+        if (!(this.namedTag.get("Health") instanceof FloatTag)) {
             this.namedTag.putFloat("Health", this.getMaxHealth());
         }
 

--- a/src/main/java/cn/nukkit/entity/EntityWalking.java
+++ b/src/main/java/cn/nukkit/entity/EntityWalking.java
@@ -36,7 +36,7 @@ public abstract class EntityWalking extends BaseEntity {
             return;
         }
 
-        if (this.followTarget != null && !this.followTarget.closed && this.followTarget.isAlive() && this.followTarget.canBeFollowed() && targetOption((EntityCreature) this.followTarget, this.distanceSquared(this.followTarget)) && this.target != null) {
+        if (this.followTarget != null && this.target != null && !this.followTarget.closed && this.followTarget.isAlive() && this.followTarget.canBeFollowed() && targetOption((EntityCreature) this.followTarget, this.distanceSquared(this.followTarget))) {
             return;
         }
 

--- a/src/main/java/cn/nukkit/entity/EntityWalking.java
+++ b/src/main/java/cn/nukkit/entity/EntityWalking.java
@@ -36,7 +36,7 @@ public abstract class EntityWalking extends BaseEntity {
             return;
         }
 
-        if (this.followTarget != null && this.target != null && !this.followTarget.closed && this.followTarget.isAlive() && this.followTarget.canBeFollowed() && targetOption((EntityCreature) this.followTarget, this.distanceSquared(this.followTarget))) {
+        if (this.followTarget != null && !this.followTarget.closed && this.followTarget.isAlive() && this.followTarget.canBeFollowed() && targetOption((EntityCreature) this.followTarget, this.distanceSquared(this.followTarget)) && this.target != null) {
             return;
         }
 

--- a/src/main/java/cn/nukkit/entity/data/Skin.java
+++ b/src/main/java/cn/nukkit/entity/data/Skin.java
@@ -90,7 +90,7 @@ public class Skin {
 
     private boolean isValidSkin(boolean doNotLimitSkinGeometry) {
         String geometryData = this.getGeometryData();
-        return skinId != null && !skinId.trim().isEmpty() && skinId.length() < 100 && //skinId
+        return skinId != null && skinId.length() < 100 && !skinId.trim().isEmpty() && //skinId
                 skinData != null && skinData.width >= 64 && skinData.height >= 32 &&
                 skinData.data.length >= SINGLE_SKIN_SIZE && (doNotLimitSkinGeometry || skinData.data.length <= MAX_DATA_SIZE) && //skinData
                 ((geometryData != null && !geometryData.isEmpty()) &&

--- a/src/main/java/cn/nukkit/entity/item/EntityBoat.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityBoat.java
@@ -479,7 +479,7 @@ public class EntityBoat extends EntityVehicle {
         pk.motionY = (float) motionY;
         pk.motionZ = (float) motionZ;
         for (Player player : getViewers().values()) {
-            if (passengers.indexOf(player) == RIDER_INDEX && player.protocol < ProtocolInfo.v1_21_130_28) {
+            if (player.protocol < ProtocolInfo.v1_21_130_28 && passengers.indexOf(player) == RIDER_INDEX) {
                 continue;
             }
             player.dataPacket(pk);

--- a/src/main/java/cn/nukkit/entity/item/EntityChestBoat.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityChestBoat.java
@@ -95,7 +95,7 @@ public class EntityChestBoat extends EntityBoat implements InventoryHolder {
         super.initEntity();
 
         this.inventory = new ChestBoatInventory(this);
-        if (this.namedTag.contains("Items") && this.namedTag.get("Items") instanceof ListTag) {
+        if (this.namedTag.get("Items") instanceof ListTag) {
             ListTag<CompoundTag> inventoryList = this.namedTag.getList("Items", CompoundTag.class);
             for (CompoundTag item : inventoryList.getAll()) {
                 this.inventory.setItem(item.getByte("Slot"), NBTIO.getItemHelper(item));

--- a/src/main/java/cn/nukkit/entity/item/EntityMinecartAbstract.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityMinecartAbstract.java
@@ -189,7 +189,7 @@ public abstract class EntityMinecartAbstract extends EntityVehicle implements En
         // Collisions
         if (this instanceof InventoryHolder) {
             for (cn.nukkit.entity.Entity entity : level.getNearbyEntities(boundingBox.grow(0.2D, 0, 0.2D), this)) {
-                if (!passengers.contains(entity) && entity instanceof EntityMinecartAbstract) {
+                if (entity instanceof EntityMinecartAbstract && !passengers.contains(entity)) {
                     entity.applyEntityCollision(this);
                 }
             }

--- a/src/main/java/cn/nukkit/entity/item/EntityMinecartChest.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityMinecartChest.java
@@ -91,7 +91,7 @@ public class EntityMinecartChest extends EntityMinecartAbstract implements Inven
         super.initEntity();
 
         this.inventory = new MinecartChestInventory(this);
-        if (this.namedTag.contains("Items") && this.namedTag.get("Items") instanceof ListTag) {
+        if (this.namedTag.get("Items") instanceof ListTag) {
             ListTag<CompoundTag> inventoryList = this.namedTag.getList("Items", CompoundTag.class);
             for (CompoundTag item : inventoryList.getAll()) {
                 this.inventory.setItem(item.getByte("Slot"), NBTIO.getItemHelper(item));

--- a/src/main/java/cn/nukkit/entity/item/EntityMinecartHopper.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityMinecartHopper.java
@@ -99,7 +99,7 @@ public class EntityMinecartHopper extends EntityMinecartAbstract implements Inve
         super.initEntity();
 
         this.inventory = new MinecartHopperInventory(this);
-        if (this.namedTag.contains("Items") && this.namedTag.get("Items") instanceof ListTag) {
+        if (this.namedTag.get("Items") instanceof ListTag) {
             ListTag<CompoundTag> inventoryList = this.namedTag.getList("Items", CompoundTag.class);
             for (CompoundTag item : inventoryList.getAll()) {
                 this.inventory.setItem(item.getByte("Slot"), NBTIO.getItemHelper(item));
@@ -225,7 +225,7 @@ public class EntityMinecartHopper extends EntityMinecartAbstract implements Inve
                             item.count--;
                             pushedItem = true;
                         }
-                    } else if (targetInv.getSmelting().getId() == itemToAdd.getId() && targetInv.getSmelting().getDamage() == itemToAdd.getDamage() && smelting.count < smelting.getMaxStackSize()) {
+                    } else if (smelting.getId() == itemToAdd.getId() && smelting.getDamage() == itemToAdd.getDamage() && smelting.count < smelting.getMaxStackSize()) {
                         event = new InventoryMoveItemEvent(this.inventory, targetInv, this, itemToAdd, InventoryMoveItemEvent.Action.SLOT_CHANGE);
                         this.server.getPluginManager().callEvent(event);
 

--- a/src/main/java/cn/nukkit/entity/mob/EntityCreaking.java
+++ b/src/main/java/cn/nukkit/entity/mob/EntityCreaking.java
@@ -133,6 +133,6 @@ public class EntityCreaking extends EntityWalkingMob {
     }
 
     private boolean hasHeartPosition() {
-        return this.namedTag.contains(TAG_HEART_X) || this.creakingHeart != null;
+        return this.creakingHeart != null || this.namedTag.contains(TAG_HEART_X);
     }
 }

--- a/src/main/java/cn/nukkit/entity/mob/EntitySwimmingMob.java
+++ b/src/main/java/cn/nukkit/entity/mob/EntitySwimmingMob.java
@@ -193,8 +193,8 @@ public abstract class EntitySwimmingMob extends EntitySwimming implements Entity
 
     @Override
     public boolean isMeetAttackConditions(Vector3 target) {
-        return this.getServer().getMobAiEnabled() &&
-                (!this.isFriendly() || !(target instanceof Player)) &&
-                target instanceof Entity;
+        return target instanceof Entity &&
+                this.getServer().getMobAiEnabled() &&
+                (!this.isFriendly() || !(target instanceof Player));
     }
 }

--- a/src/main/java/cn/nukkit/entity/mob/EntityWalkingMob.java
+++ b/src/main/java/cn/nukkit/entity/mob/EntityWalkingMob.java
@@ -201,8 +201,8 @@ public abstract class EntityWalkingMob extends EntityWalking implements EntityMo
 
     @Override
     public boolean isMeetAttackConditions(Vector3 target) {
-        return this.getServer().getMobAiEnabled() &&
-                target instanceof EntityCreature &&
+        return target instanceof EntityCreature &&
+                this.getServer().getMobAiEnabled() &&
                 (!this.isFriendly() || !(target instanceof Player) || ((Entity) target).getId() == this.isAngryTo);
     }
 }

--- a/src/main/java/cn/nukkit/entity/mob/EntityWolf.java
+++ b/src/main/java/cn/nukkit/entity/mob/EntityWolf.java
@@ -417,8 +417,8 @@ public class EntityWolf extends EntityTameableMob implements InventoryHolder {
     @Override
     public void attackEntity(Entity entity) {
         if (entity instanceof Player && (
-            !this.isAngry() && this.isBeggingItem(((Player) entity).getInventory().getItemInHandFast()) ||
-                this.hasOwner() && entity.equals(this.getOwner())
+            this.hasOwner() && entity.equals(this.getOwner()) ||
+                !this.isAngry() && this.isBeggingItem(((Player) entity).getInventory().getItemInHandFast())
         )) return;
 
         if (this.attackDelay > 23 && this.distanceSquared(entity) < 1.5) {

--- a/src/main/java/cn/nukkit/entity/mob/EntityZombie.java
+++ b/src/main/java/cn/nukkit/entity/mob/EntityZombie.java
@@ -83,7 +83,7 @@ public class EntityZombie extends EntityWalkingMob implements EntitySmite {
 
         this.setDamage(new int[] { 0, 2, 3, 4 });
 
-        if (this.namedTag.contains("Armor") && this.namedTag.get("Armor") instanceof ListTag) {
+        if (this.namedTag.get("Armor") instanceof ListTag) {
             ListTag<CompoundTag> listTag = this.namedTag.getList("Armor", CompoundTag.class);
             Item[] loadedArmor = new Item[4];
             int count = 0;

--- a/src/main/java/cn/nukkit/entity/passive/EntityDonkey.java
+++ b/src/main/java/cn/nukkit/entity/passive/EntityDonkey.java
@@ -64,7 +64,7 @@ public class EntityDonkey extends EntityHorseBase {
                 return creature instanceof BaseEntity && ((BaseEntity) creature).isInLove() && creature.isAlive() && !creature.closed && creature.getNetworkId() == this.getNetworkId() && distance <= 100;
             }else if (creature instanceof Player player) {
                 return player.spawned && player.isAlive() && !player.closed &&
-                        this.isFeedItem(Objects.requireNonNullElse(player.getInventory(), EMPTY_INVENTORY).getItemInHandFast()) && distance <= 40;
+                        distance <= 40 && this.isFeedItem(Objects.requireNonNullElse(player.getInventory(), EMPTY_INVENTORY).getItemInHandFast());
             }
         }
         return false;

--- a/src/main/java/cn/nukkit/entity/passive/EntityHorse.java
+++ b/src/main/java/cn/nukkit/entity/passive/EntityHorse.java
@@ -83,7 +83,7 @@ public class EntityHorse extends EntityHorseBase {
                 return creature instanceof BaseEntity && ((BaseEntity) creature).isInLove() && creature.isAlive() && !creature.closed && creature.getNetworkId() == this.getNetworkId() && distance <= 100;
             }else if (creature instanceof Player player) {
                 return player.spawned && player.isAlive() && !player.closed &&
-                        this.isFeedItem(Objects.requireNonNullElse(player.getInventory(), EMPTY_INVENTORY).getItemInHandFast()) && distance <= 40;
+                        distance <= 40 && this.isFeedItem(Objects.requireNonNullElse(player.getInventory(), EMPTY_INVENTORY).getItemInHandFast());
             }
         }
         return false;

--- a/src/main/java/cn/nukkit/entity/passive/EntityLlama.java
+++ b/src/main/java/cn/nukkit/entity/passive/EntityLlama.java
@@ -155,7 +155,7 @@ public class EntityLlama extends EntityHorseBase {
                 return creature instanceof BaseEntity && ((BaseEntity) creature).isInLove() && creature.isAlive() && !creature.closed && creature.getNetworkId() == this.getNetworkId() && distance <= 100;
             }else if (creature instanceof Player player) {
                 return player.spawned && player.isAlive() && !player.closed &&
-                        this.isFeedItem(Objects.requireNonNullElse(player.getInventory(), EMPTY_INVENTORY).getItemInHandFast()) && distance <= 40;
+                        distance <= 40 && this.isFeedItem(Objects.requireNonNullElse(player.getInventory(), EMPTY_INVENTORY).getItemInHandFast());
             }
         }
 

--- a/src/main/java/cn/nukkit/entity/passive/EntityMule.java
+++ b/src/main/java/cn/nukkit/entity/passive/EntityMule.java
@@ -53,7 +53,7 @@ public class EntityMule extends EntityHorseBase {
 
         if (canTarget && (creature instanceof Player player)) {
             return player.spawned && player.isAlive() && !player.closed &&
-                    this.isFeedItem(Objects.requireNonNullElse(player.getInventory(), EMPTY_INVENTORY).getItemInHandFast()) && distance <= 49;
+                    distance <= 49 && this.isFeedItem(Objects.requireNonNullElse(player.getInventory(), EMPTY_INVENTORY).getItemInHandFast());
         }
         return false;
     }

--- a/src/main/java/cn/nukkit/entity/passive/EntityVillager.java
+++ b/src/main/java/cn/nukkit/entity/passive/EntityVillager.java
@@ -138,7 +138,7 @@ public class EntityVillager extends EntityWalkingAnimal implements InventoryHold
         } else {
             this.canTrade = this.namedTag.getBoolean("canTrade");
         }
-        if (!this.namedTag.contains("displayName") && profession != 0) {
+        if (profession != 0 && !this.namedTag.contains("displayName")) {
             this.setDisplayName(getProfessionName(profession));
         } else {
             this.displayName = this.namedTag.getString("displayName");

--- a/src/main/java/cn/nukkit/entity/passive/EntityWalkingAnimal.java
+++ b/src/main/java/cn/nukkit/entity/passive/EntityWalkingAnimal.java
@@ -99,7 +99,7 @@ public abstract class EntityWalkingAnimal extends EntityWalking implements Entit
     @Override
     public boolean targetOption(EntityCreature creature, double distance) {
         if (!this.isInLove() && creature instanceof Player player) {
-            return player.isAlive() && !player.closed && this.isFeedItem(Objects.requireNonNullElse(player.getInventory(), EMPTY_INVENTORY).getItemInHandFast()) && distance <= 49;
+            return player.isAlive() && !player.closed && distance <= 49 && this.isFeedItem(Objects.requireNonNullElse(player.getInventory(), EMPTY_INVENTORY).getItemInHandFast());
         }
         return super.targetOption(creature, distance);
     }

--- a/src/main/java/cn/nukkit/inventory/request/TransferItemActionProcessor.java
+++ b/src/main/java/cn/nukkit/inventory/request/TransferItemActionProcessor.java
@@ -169,7 +169,7 @@ public abstract class TransferItemActionProcessor<T extends TransferItemStackReq
 
         // 防御：如果 src 的底层 setItem 不知为何把原物品写没了（如插件篡改为 AIR），
         // 也要把 src 恢复，避免客户端回滚看到不一致状态。
-        if (srcInv.getItem(srcSlot).isNull() && !fullTransfer) {
+        if (!fullTransfer && srcInv.getItem(srcSlot).isNull()) {
             srcInv.setItemForce(srcSlot, originalSourceItem);
         }
 

--- a/src/main/java/cn/nukkit/item/Item.java
+++ b/src/main/java/cn/nukkit/item/Item.java
@@ -1246,7 +1246,7 @@ public class Item implements Cloneable, BlockID, ItemID, ItemNamespaceId, Protoc
         }
 
         CompoundTag tag = this.getNamedTag();
-        return tag.contains("BlockEntityTag") && tag.get("BlockEntityTag") instanceof CompoundTag;
+        return tag.get("BlockEntityTag") instanceof CompoundTag;
 
     }
 
@@ -1256,7 +1256,7 @@ public class Item implements Cloneable, BlockID, ItemID, ItemNamespaceId, Protoc
         }
         CompoundTag tag = this.getNamedTag();
 
-        if (tag.contains("BlockEntityTag") && tag.get("BlockEntityTag") instanceof CompoundTag) {
+        if (tag.get("BlockEntityTag") instanceof CompoundTag) {
             tag.remove("BlockEntityTag");
             this.setNamedTag(tag);
         }
@@ -1426,7 +1426,7 @@ public class Item implements Cloneable, BlockID, ItemID, ItemNamespaceId, Protoc
         CompoundTag tag = this.getNamedTag();
         if (tag.contains("display")) {
             Tag tag1 = tag.get("display");
-            return tag1 instanceof CompoundTag && ((CompoundTag) tag1).contains("Name") && ((CompoundTag) tag1).get("Name") instanceof StringTag;
+            return tag1 instanceof CompoundTag && ((CompoundTag) tag1).get("Name") instanceof StringTag;
         }
 
         return false;
@@ -1440,7 +1440,7 @@ public class Item implements Cloneable, BlockID, ItemID, ItemNamespaceId, Protoc
         CompoundTag tag = this.getNamedTag();
         if (tag.contains("display")) {
             Tag tag1 = tag.get("display");
-            if (tag1 instanceof CompoundTag && ((CompoundTag) tag1).contains("Name") && ((CompoundTag) tag1).get("Name") instanceof StringTag) {
+            if (tag1 instanceof CompoundTag && ((CompoundTag) tag1).get("Name") instanceof StringTag) {
                 return ((CompoundTag) tag1).getString("Name");
             }
         }
@@ -1464,7 +1464,7 @@ public class Item implements Cloneable, BlockID, ItemID, ItemNamespaceId, Protoc
         } else {
             tag = this.getNamedTag();
         }
-        if (tag.contains("display") && tag.get("display") instanceof CompoundTag) {
+        if (tag.get("display") instanceof CompoundTag) {
             tag.getCompound("display").putString("Name", name);
         } else {
             tag.putCompound("display", new CompoundTag("display")
@@ -1482,7 +1482,7 @@ public class Item implements Cloneable, BlockID, ItemID, ItemNamespaceId, Protoc
 
         CompoundTag tag = this.getNamedTag();
 
-        if (tag.contains("display") && tag.get("display") instanceof CompoundTag) {
+        if (tag.get("display") instanceof CompoundTag) {
             tag.getCompound("display").remove("Name");
             if (tag.getCompound("display").isEmpty()) {
                 tag.remove("display");
@@ -1538,7 +1538,7 @@ public class Item implements Cloneable, BlockID, ItemID, ItemNamespaceId, Protoc
     public Tag getNamedTagEntry(String name) {
         CompoundTag tag = this.getNamedTag();
         if (tag != null) {
-            return tag.contains(name) ? tag.get(name) : null;
+            return tag.get(name);
         }
 
         return null;

--- a/src/main/java/cn/nukkit/item/ItemBookWritable.java
+++ b/src/main/java/cn/nukkit/item/ItemBookWritable.java
@@ -31,7 +31,7 @@ public abstract class ItemBookWritable extends Item {
         Preconditions.checkArgument(pageId >= 0 && pageId < 50, "Page number " + pageId + " is out of range");
         if (this.hasCompoundTag()) {
             CompoundTag tag = this.getNamedTag();
-            if (tag.contains("pages") && tag.get("pages") instanceof ListTag) {
+            if (tag.get("pages") instanceof ListTag) {
                 return tag.getList("pages", CompoundTag.class).size() > pageId;
             }
         }
@@ -45,7 +45,7 @@ public abstract class ItemBookWritable extends Item {
         Preconditions.checkArgument(pageId >= 0 && pageId < 50, "Page number " + pageId + " is out of range");
         if (this.hasCompoundTag()) {
             CompoundTag tag = this.getNamedTag();
-            if (tag.contains("pages") && tag.get("pages") instanceof ListTag) {
+            if (tag.get("pages") instanceof ListTag) {
                 ListTag<CompoundTag> pages = tag.getList("pages", CompoundTag.class);
                 if (pages.size() > pageId) {
                     return pages.get(pageId).getString("text");
@@ -70,7 +70,7 @@ public abstract class ItemBookWritable extends Item {
             tag = new CompoundTag();
         }
         ListTag<CompoundTag> pages;
-        if (!tag.contains("pages") || !(tag.get("pages") instanceof ListTag)) {
+        if (!(tag.get("pages") instanceof ListTag)) {
             pages = new ListTag<>("pages");
             tag.putList(pages);
         } else {
@@ -96,7 +96,7 @@ public abstract class ItemBookWritable extends Item {
         Preconditions.checkArgument(pageId >= 0 && pageId < 50, "Page number " + pageId + " is out of range");
         CompoundTag tag = this.hasCompoundTag() ? this.getNamedTag() : new CompoundTag();
         ListTag<CompoundTag> pages;
-        if (!tag.contains("pages") || !(tag.get("pages") instanceof ListTag)) {
+        if (!(tag.get("pages") instanceof ListTag)) {
             pages = new ListTag<>("pages");
             tag.putList(pages);
         } else {
@@ -118,7 +118,7 @@ public abstract class ItemBookWritable extends Item {
         Preconditions.checkArgument(pageId >= 0 && pageId < 50, "Page number " + pageId + " is out of range");
         if (this.hasCompoundTag()) {
             CompoundTag tag = this.getNamedTag();
-            if (tag.contains("pages") && tag.get("pages") instanceof ListTag) {
+            if (tag.get("pages") instanceof ListTag) {
                 ListTag<CompoundTag> pages = tag.getList("pages", CompoundTag.class);
                 if (pages.size() > pageId) {
                     pages.remove(pageId);
@@ -145,7 +145,7 @@ public abstract class ItemBookWritable extends Item {
         Preconditions.checkArgument(pageId >= 0 && pageId < 50, "Page number " + pageId + " is out of range");
         CompoundTag tag = this.hasCompoundTag() ? this.getNamedTag() : new CompoundTag();
         ListTag<CompoundTag> pages;
-        if (!tag.contains("pages") || !(tag.get("pages") instanceof ListTag)) {
+        if (!(tag.get("pages") instanceof ListTag)) {
             pages = new ListTag<>("pages");
             tag.putList(pages);
         } else {
@@ -173,7 +173,7 @@ public abstract class ItemBookWritable extends Item {
         Preconditions.checkArgument(pageId2 >= 0 && pageId2 < 50, "Page number " + pageId2 + " is out of range");
         if (this.hasCompoundTag()) {
             CompoundTag tag = this.getNamedTag();
-            if (tag.contains("pages") && tag.get("pages") instanceof ListTag) {
+            if (tag.get("pages") instanceof ListTag) {
                 ListTag<CompoundTag> pages = tag.getList("pages", CompoundTag.class);
                 if (pages.size() > pageId1 && pages.size() > pageId2) {
                     String pageContents1 = pages.get(pageId1).getString("text");
@@ -193,7 +193,7 @@ public abstract class ItemBookWritable extends Item {
     public List getPages() {
         CompoundTag tag = this.hasCompoundTag() ? this.getNamedTag() : new CompoundTag();
         ListTag<CompoundTag> pages;
-        if (!tag.contains("pages") || !(tag.get("pages") instanceof ListTag)) {
+        if (!(tag.get("pages") instanceof ListTag)) {
             pages = new ListTag<>("pages");
             tag.putList(pages);
         } else {

--- a/src/main/java/cn/nukkit/item/enchantment/protection/EnchantmentProtectionAll.java
+++ b/src/main/java/cn/nukkit/item/enchantment/protection/EnchantmentProtectionAll.java
@@ -36,7 +36,7 @@ public class EnchantmentProtectionAll extends EnchantmentProtection {
 
         // legacy 额外排除 MAGIC(保护附魔不减免魔法)
         if (level <= 0 || cause == DamageCause.VOID || cause == DamageCause.CUSTOM || cause == DamageCause.HUNGER
-                || (!Server.getInstance().getServerConfig().gameFeatureSettings().vanillaArmorReduction() && cause == DamageCause.MAGIC)) {
+                || (cause == DamageCause.MAGIC && !Server.getInstance().getServerConfig().gameFeatureSettings().vanillaArmorReduction())) {
             return 0;
         }
 

--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -3102,7 +3102,7 @@ public class Level implements ChunkManager, Metadatable {
     }
 
     public Entity getEntity(long entityId) {
-        return this.entities.containsKey(entityId) ? this.entities.get(entityId) : null;
+        return this.entities.get(entityId);
     }
 
     public Entity[] getEntities() {
@@ -3205,7 +3205,7 @@ public class Level implements ChunkManager, Metadatable {
     }
 
     public BlockEntity getBlockEntityById(long blockEntityId) {
-        return this.blockEntities.containsKey(blockEntityId) ? this.blockEntities.get(blockEntityId) : null;
+        return this.blockEntities.get(blockEntityId);
     }
 
     @NonComputationAtomic

--- a/src/main/java/cn/nukkit/level/format/anvil/Chunk.java
+++ b/src/main/java/cn/nukkit/level/format/anvil/Chunk.java
@@ -266,7 +266,7 @@ public class Chunk extends BaseChunk {
         try {
             CompoundTag chunk = NBTIO.read(new ByteArrayInputStream(Zlib.inflate(data)), ByteOrder.BIG_ENDIAN);
 
-            if (!chunk.contains("Level") || !(chunk.get("Level") instanceof CompoundTag)) {
+            if (!(chunk.get("Level") instanceof CompoundTag)) {
                 return null;
             }
 
@@ -285,7 +285,7 @@ public class Chunk extends BaseChunk {
     public static Chunk fromFastBinary(byte[] data, LevelProvider provider) {
         try {
             CompoundTag chunk = NBTIO.read(new DataInputStream(new ByteArrayInputStream(data)), ByteOrder.BIG_ENDIAN);
-            if (!chunk.contains("Level") || !(chunk.get("Level") instanceof CompoundTag)) {
+            if (!(chunk.get("Level") instanceof CompoundTag)) {
                 return null;
             }
 

--- a/src/main/java/cn/nukkit/level/generator/object/ObjectTallGrass.java
+++ b/src/main/java/cn/nukkit/level/generator/object/ObjectTallGrass.java
@@ -44,7 +44,7 @@ public class ObjectTallGrass {
                 y += random.nextRange(-1, 1) * random.nextBoundedInt(3) >> 1;
                 z += random.nextRange(-1, 1);
 
-                if (level.getBlockIdAt(x, y - 1, z) != Block.GRASS || y > 255 || y < 0) {
+                if (y > 255 || y < 0 || level.getBlockIdAt(x, y - 1, z) != Block.GRASS) {
                     break;
                 }
 

--- a/src/main/java/cn/nukkit/level/generator/structure/ScatteredStructurePiece.java
+++ b/src/main/java/cn/nukkit/level/generator/structure/ScatteredStructurePiece.java
@@ -55,7 +55,7 @@ public abstract class ScatteredStructurePiece {
             for (int z = boundingBox.getMin().z; z <= boundingBox.getMax().z; z++) {
                 int y = level.getChunk(x >> 4, z >> 4).getHighestBlockAt(x & 0xf, z & 0xf);
                 int id = level.getBlockIdAt(x, y - 1, z);
-                while (PLANTS.contains(id) && y > 1) {
+                while (y > 1 && PLANTS.contains(id)) {
                     y--;
                     id = level.getBlockIdAt(x, y - 1, z);
                 }

--- a/src/main/java/cn/nukkit/level/generator/structure/StructureBuilder.java
+++ b/src/main/java/cn/nukkit/level/generator/structure/StructureBuilder.java
@@ -79,7 +79,7 @@ public class StructureBuilder {
     public void setBlockDownward(final BlockVector3 pos, final int id, final int meta) {
         final BlockVector3 vec = translate(pos);
         int y = vec.y;
-        while (!Block.solid[level.getBlockIdAt(vec.x, y, vec.z)] && y > 1) {
+        while (y > 1 && !Block.solid[level.getBlockIdAt(vec.x, y, vec.z)]) {
             level.setBlockAt(vec.x, y, vec.z, id, meta);
             y--;
         }

--- a/src/main/java/cn/nukkit/nbt/tag/Tag.java
+++ b/src/main/java/cn/nukkit/nbt/tag/Tag.java
@@ -54,7 +54,7 @@ public abstract class Tag {
             return false;
         }
         Tag o = (Tag) obj;
-        return getId() == o.getId() && !(name == null && o.name != null || name != null && o.name == null) && !(name != null && !name.equals(o.name));
+        return getId() == o.getId() && Objects.equals(name, o.name);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/network/protocol/AvailableCommandsPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/AvailableCommandsPacket.java
@@ -531,7 +531,7 @@ public class AvailableCommandsPacket extends DataPacket {
                 CommandParam commandParam = COMMAND_PARAMS.getType(parameter.type.getId()); //正常来说应该传入最新版的数字id
 
                 if ("execute".equals(name)) {// Hook
-                    if ("command".equals(parameter.name) && protocol >= 575) {
+                    if (protocol >= 575 && "command".equals(parameter.name)) {
                         commandParam = CommandParam.SLASH_COMMAND;
                     }
                 }

--- a/src/main/java/cn/nukkit/network/protocol/LoginPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/LoginPacket.java
@@ -83,7 +83,7 @@ public class LoginPacket extends DataPacket {
             authType = AuthType.values()[authTypeOrdinal + 1];
         }
 
-        if (map.containsKey("Token") && map.get("Token") instanceof String token && !((String) map.get("Token")).isBlank()) {
+        if (map.get("Token") instanceof String token && !token.isBlank()) {
             return new TokenPayload(token, authType);
         } else {
             String certificate = (String) map.get("Certificate");

--- a/src/main/java/cn/nukkit/plugin/PluginDescription.java
+++ b/src/main/java/cn/nukkit/plugin/PluginDescription.java
@@ -158,7 +158,7 @@ public class PluginDescription {
             throw new PluginException("Invalid PluginDescription main, cannot start within the cn.nukkit. package");
         }
 
-        if (plugin.containsKey("commands") && plugin.get("commands") instanceof Map) {
+        if (plugin.get("commands") instanceof Map) {
             this.commands = (Map<String, Object>) plugin.get("commands");
         }
 

--- a/src/main/java/cn/nukkit/resourcepacks/JarPluginResourcePack.java
+++ b/src/main/java/cn/nukkit/resourcepacks/JarPluginResourcePack.java
@@ -44,8 +44,8 @@ public class JarPluginResourcePack extends AbstractResourcePack {
         }
         if (manifest == null) {
             manifest = jar.stream()
-                    .filter(e -> (e.getName().toLowerCase(Locale.ROOT).endsWith("manifest.json") || e.getName().toLowerCase(Locale.ROOT).endsWith("pack_manifest.json"))
-                            && !e.isDirectory())
+                    .filter(e -> !e.isDirectory() &&
+                            (e.getName().toLowerCase(Locale.ROOT).endsWith("manifest.json") || e.getName().toLowerCase(Locale.ROOT).endsWith("pack_manifest.json")))
                     .filter(e -> {
                         File fe = new File(e.getName());
                         if (!fe.getName().equalsIgnoreCase("manifest.json") && !fe.getName().equalsIgnoreCase("pack_manifest.json")) {
@@ -89,7 +89,7 @@ public class JarPluginResourcePack extends AbstractResourcePack {
             }
 
             jar.stream().forEach(entry -> {
-                if (entry.getName().startsWith(RESOURCE_PACK_PATH) && !entry.isDirectory() && !entry.getName().equals(RESOURCE_PACK_PATH + "encryption.key")) {
+                if (!entry.isDirectory() && entry.getName().startsWith(RESOURCE_PACK_PATH) && !entry.getName().equals(RESOURCE_PACK_PATH + "encryption.key")) {
                     try {
                         zipOutputStream.putNextEntry(new ZipEntry(entry.getName().substring(RESOURCE_PACK_PATH.length())));
                         zipOutputStream.write(jar.getInputStream(entry).readAllBytes());

--- a/src/main/java/cn/nukkit/resourcepacks/ZippedResourcePack.java
+++ b/src/main/java/cn/nukkit/resourcepacks/ZippedResourcePack.java
@@ -50,8 +50,8 @@ public class ZippedResourcePack extends AbstractResourcePack {
             }
             if (entry == null) {
                 entry = zip.stream()
-                        .filter(e-> (e.getName().toLowerCase(Locale.ROOT).endsWith("manifest.json") || e.getName().toLowerCase(Locale.ROOT).endsWith("pack_manifest.json"))
-                                && !e.isDirectory())
+                        .filter(e-> !e.isDirectory() &&
+                                (e.getName().toLowerCase(Locale.ROOT).endsWith("manifest.json") || e.getName().toLowerCase(Locale.ROOT).endsWith("pack_manifest.json")))
                         .filter(e-> {
                             File fe = new File(e.getName());
                             if (!fe.getName().equalsIgnoreCase("manifest.json") && !fe.getName().equalsIgnoreCase("pack_manifest.json")) {

--- a/src/main/java/cn/nukkit/utils/BinaryStream.java
+++ b/src/main/java/cn/nukkit/utils/BinaryStream.java
@@ -1083,9 +1083,9 @@ public class BinaryStream {
             return;
         }
 
-        if (item.hasCompoundTag()
-                || (isDurable && protocolId >= ProtocolInfo.v1_12_0)
-                || saveOriginalID) {
+        if ((isDurable && protocolId >= ProtocolInfo.v1_12_0)
+                || saveOriginalID
+                || item.hasCompoundTag()) {
             if (protocolId < ProtocolInfo.v1_12_0) {
                 if (saveOriginalID) {
                     try {

--- a/src/main/java/cn/nukkit/utils/ClientChainData.java
+++ b/src/main/java/cn/nukkit/utils/ClientChainData.java
@@ -339,7 +339,7 @@ public final class ClientChainData implements LoginChainData {
             authType = AuthType.values()[authTypeOrdinal + 1];
         }
 
-        if (map.containsKey("Token") && map.get("Token") instanceof String token && !((String) map.get("Token")).isBlank()) {
+        if (map.get("Token") instanceof String token && !token.isBlank()) {
             return new TokenPayload(token, authType);
         } else {
             String certificate = (String) map.get("Certificate");

--- a/src/main/java/cn/nukkit/utils/Config.java
+++ b/src/main/java/cn/nukkit/utils/Config.java
@@ -173,8 +173,10 @@ public class Config {
         } else {
             if (this.type == Config.DETECT) {
                 String extension = "";
-                if (this.file.getName().lastIndexOf('.') != -1 && this.file.getName().lastIndexOf('.') != 0) {
-                    extension = this.file.getName().substring(this.file.getName().lastIndexOf('.') + 1);
+                String fileName = this.file.getName();
+                int dotIndex = fileName.lastIndexOf('.');
+                if (dotIndex != -1 && dotIndex != 0) {
+                    extension = fileName.substring(dotIndex + 1);
                 }
                 if (format.containsKey(extension)) {
                     this.type = format.get(extension);

--- a/src/main/java/cn/nukkit/utils/ConfigSection.java
+++ b/src/main/java/cn/nukkit/utils/ConfigSection.java
@@ -147,7 +147,7 @@ public class ConfigSection extends LinkedHashMap<String, Object> {
         String[] subKeys = key.split("\\.", 2);
         if (subKeys.length > 1) {
             ConfigSection childSection = new ConfigSection();
-            if (this.containsKey(subKeys[0]) && super.get(subKeys[0]) instanceof ConfigSection)
+            if (super.get(subKeys[0]) instanceof ConfigSection)
                 childSection = (ConfigSection) super.get(subKeys[0]);
             childSection.set(subKeys[1], value);
             super.put(subKeys[0], childSection);


### PR DESCRIPTION
- Remove redundant `contains()` calls before `instanceof` on NBT tags (`CompoundTag.get()` returns null for missing keys, and `null instanceof X` is always false, making the existence check redundant)
- Reorder short-circuit operands to place cheap/constant/type checks before method calls and string operations
- Replace manual null-equality checks with `Objects.equals()` in Tag
- Cache repeated method results in locals (Config, Banner, LoginPacket, ClientChainData) to eliminate duplicate lookups and casts