### PR TITLE
fix(leveldb): accept block states written by PocketMine-MP

### DIFF
--- a/src/main/java/cn/nukkit/level/format/leveldb/structure/StateBlockStorage.java
+++ b/src/main/java/cn/nukkit/level/format/leveldb/structure/StateBlockStorage.java
@@ -23,6 +23,7 @@ import lombok.extern.log4j.Log4j2;
 import org.cloudburstmc.nbt.NBTInputStream;
 import org.cloudburstmc.nbt.NBTOutputStream;
 import org.cloudburstmc.nbt.NbtMap;
+import org.cloudburstmc.nbt.NbtMapBuilder;
 import org.cloudburstmc.nbt.NbtUtils;
 
 import java.io.IOException;
@@ -33,6 +34,14 @@ import static cn.nukkit.level.format.leveldb.LevelDBConstants.SUB_CHUNK_SIZE;
 
 @Log4j2
 public class StateBlockStorage {
+
+    /**
+     * PocketMine-MP writes this private key into every block state it stores. Vanilla palettes
+     * do not contain it and states are matched as whole NBT maps, so a world saved by PMMP
+     * matches nothing at all - down to minecraft:air - and loads as solid info_update.
+     * Dropping the key here keeps everything downstream working with plain vanilla states.
+     */
+    private static final String PMMP_DATA_VERSION = "PMMPDataVersion";
 
     private static final int SECTION_SIZE = 16 * 16 * 16;
 
@@ -136,6 +145,11 @@ public class StateBlockStorage {
             for (int i = 0; i < paletteSize; ++i) {
                 try {
                     NbtMap state = (NbtMap) inputStream.readTag();
+                    if (state.containsKey(PMMP_DATA_VERSION)) {
+                        NbtMapBuilder withoutForeignKeys = state.toBuilder();
+                        withoutForeignKeys.remove(PMMP_DATA_VERSION);
+                        state = withoutForeignKeys.build();
+                    }
                     //noinspection ResultOfMethodCallIgnored
                     state.hashCode(); // cache hashCode
 


### PR DESCRIPTION
### Problem

A world saved by PocketMine-MP loads on Nukkit-MOT as solid `minecraft:info_update` — every single block, including `minecraft:air`.

PocketMine-MP writes a private `PMMPDataVersion` key into every block state it stores in the LevelDB sub chunk palette. Vanilla palettes do not have that key, and `StateBlockStorage` looks states up as whole NBT maps, so not a single entry matches.

The failure is quiet: `Chunk contains unknown block` is only printed at `debug-level: 2`, so on the default level the load looks perfectly clean and the symptom reads like a broken resource pack.

### Fix

Drop the foreign key right after the palette entry is read, so everything downstream keeps working with plain vanilla states.

### Testing

Opened a world written by PocketMine-MP 5.44.2 on a Nukkit-MOT server:

- before: every block in the world is `info_update`;
- after: the world loads exactly as it was built, no unknown-block lines at `debug-level: 2`.