### PR TITLE
fix(level): translate a block state back to its real legacy value, not to a padding row

### DIFF
--- a/src/main/java/cn/nukkit/level/BlockPalette.java
+++ b/src/main/java/cn/nukkit/level/BlockPalette.java
@@ -209,10 +209,32 @@ public class BlockPalette {
 
         int legacyId = blockId << Block.DATA_BITS | data;
         this.legacyToRuntimeId.put(legacyId, runtimeId);
-        this.runtimeIdToLegacy.putIfAbsent(runtimeId, legacyId);
+        putCanonicalLegacy(this.runtimeIdToLegacy, runtimeId, legacyId);
         int stateHash = Hash.hashBlock(blockState);
-        this.stateHashToLegacy.putIfAbsent(stateHash, legacyId);
+        putCanonicalLegacy(this.stateHashToLegacy, stateHash, legacyId);
         this.legacyToHashId.putIfAbsent(legacyId, stateHash);
+    }
+
+    /**
+     * Reverse lookup keeps the LOWEST legacy value that maps to a state.
+     * <p>
+     * The legacy data table pads every block to a power of two by repeating its default variant:
+     * {@code minecraft:planks} lists oak at data 0, 6 and 7, {@code minecraft:stone} lists stone at
+     * 0 and 7, and 45 more blocks do the same. All of those rows map to one state, so the reverse
+     * entry was decided by registration order — and when a padding row won, the state translated
+     * back to a data value that Nukkit has no block for. The block then read as an unknown one:
+     * hardness 10, no proper tool, and a vanilla break-time check that cancelled every hit, so oak
+     * planks could not be broken at all, by any tool or by hand.
+     * <p>
+     * The lowest value is the real one in every padded row, and picking it makes the reverse
+     * lookup independent of the order states are registered in. Blocks merged by vanilla into
+     * another id keep their own preset (see {@code NukkitLegacyMapper#getOverrideLegacyId}).
+     */
+    private static void putCanonicalLegacy(Int2IntOpenHashMap reverse, int key, int legacyId) {
+        int known = reverse.get(key);
+        if (known == -1 || legacyId < known) {
+            reverse.put(key, legacyId);
+        }
     }
 
     public void lock() {


### PR DESCRIPTION
### The bug

`legacy_block_data_map.json` pads every block to a power of two by repeating its default variant.
`minecraft:planks` lists oak at data **0, 6 and 7**, `minecraft:stone` lists stone at 0 and 7, and
45 more blocks do the same (`log2`, `stonebrick`, `sapling`, `torch`, `red_flower`, `wooden_door`,
`stone_slab4`, …) — 47 of 380 entries.

All of those rows map to the same block state, but `BlockPalette.registerState` kept the reverse
entry with `putIfAbsent`, so `runtimeIdToLegacy` (and `stateHashToLegacy`) ended up holding
whichever row happened to register first.

When a padding row won, the state translated back to a data value Nukkit has no block for. Oak
planks came back as `5:7` and resolved to `BlockUnknown`: hardness 10, tool type NONE.
`Level#useBreakOn` then measured every hit against that hardness, decided it was far too fast and
cancelled the event before any listener saw it — so the block could not be broken **at all**, with
any tool or by hand, in any game mode, including for operators.

Nothing was logged, because from the server's point of view each refusal is an ordinary
anti-fast-break verdict.

### Why it is hard to reproduce

Which blocks are affected depends on the order states are registered in, which in turn depends on
the set of custom blocks a server registers. On a bare build oak planks resolve to runtime id 14389
and translate back correctly (`5:0`); on our server, which registers a handful of custom blocks,
the same state is 14408 and translates back to `5:7`. The world file itself is fine either way —
the state stored on disk is a plain `minecraft:oak_planks`.

### The fix

The reverse lookup now keeps the **lowest** legacy value that maps to a state. In every padded row
the lowest value is the real one, and picking it makes the reverse lookup independent of
registration order.

Blocks that vanilla merged into another id keep their explicit preset
(`NukkitLegacyMapper#getOverrideLegacyId`), so the lava cauldron round-trip is unchanged.

### Testing

Reproduced and verified on a live 1.26.44 server with custom blocks registered: before the change
oak planks logged `roundtrip=minecraft:oak_planks|rt=14408|back=5:7` and were unbreakable; after it
they translate back to `5:0` and break normally. Stone, logs, stone bricks, torches and flowers —
other blocks with padded rows — were checked as well and behave as before.
