### PR TITLE
fix(entity): open the horse screen so a rider can reach the saddle and armor slots

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -21,6 +21,7 @@ import cn.nukkit.entity.item.*;
 import cn.nukkit.entity.mob.EntityWalkingMob;
 import cn.nukkit.entity.mob.EntityWolf;
 import cn.nukkit.entity.passive.EntityHappyGhast;
+import cn.nukkit.entity.passive.EntityHorseBase;
 import cn.nukkit.entity.passive.EntityVillager;
 import cn.nukkit.entity.projectile.EntityArrow;
 import cn.nukkit.entity.projectile.EntityThrownTrident;
@@ -4620,6 +4621,12 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                                 if (this.protocol >= ProtocolInfo.v1_19_0) {
                                     this.addWindow(((InventoryHolder) targetEntity).getInventory());
                                 }
+                            } else if (this.riding instanceof EntityHorseBase horseRide
+                                    && (targetEntity == null || targetEntity == this.riding)) {
+                                // Bedrock has no other way to reach the saddle and armor slots:
+                                // the rider presses the inventory button and expects the horse
+                                // screen, not their own bag.
+                                this.addWindow(horseRide.getInventory());
                             } else if (this.protocol >= 407) {
                                 if (this.inventory.open(this)) {
                                     this.inventoryOpen = true;

--- a/src/main/java/cn/nukkit/entity/passive/EntityHorseBase.java
+++ b/src/main/java/cn/nukkit/entity/passive/EntityHorseBase.java
@@ -141,6 +141,15 @@ public class EntityHorseBase extends EntityWalkingAnimal implements EntityRideab
 
     @Override
     public boolean onInteract(Player player, Item item, Vector3 clickedPos) {
+        if (player.isSneaking() && !this.isBaby() && this.horseInventory != null
+                && !this.isFeedItem(item) && item.getId() != Item.SADDLE
+                && !item.isHorseArmor() && item.getId() != Item.CHEST) {
+            // Crouch and use opens the horse screen, the way vanilla Bedrock does. An item the
+            // horse itself accepts keeps its own meaning: a crouching player still saddles,
+            // feeds and armors the animal by tapping it.
+            player.addWindow(this.horseInventory);
+            return false;
+        }
         if (this.isFeedItem(item) && !this.isInLoveCooldown()) {
             this.level.addLevelSoundEvent(this, LevelSoundEventPacket.SOUND_EAT);
             this.level.addParticle(new ItemBreakParticle(this.add(0, this.getMountedYOffset(), 0), Item.get(item.getId(), 0, 1)));
@@ -252,6 +261,16 @@ public class EntityHorseBase extends EntityWalkingAnimal implements EntityRideab
                 item.getId() == Item.SUGAR ||
                 item.getId() == Item.BREAD ||
                 item.getId() == Item.GOLDEN_CARROT;
+    }
+
+    @Override
+    public void close() {
+        if (this.horseInventory != null) {
+            for (Player viewer : new ArrayList<>(this.horseInventory.getViewers())) {
+                viewer.removeWindow(this.horseInventory);
+            }
+        }
+        super.close();
     }
 
     @Override

--- a/src/main/java/cn/nukkit/inventory/HorseInventory.java
+++ b/src/main/java/cn/nukkit/inventory/HorseInventory.java
@@ -20,7 +20,7 @@ import java.util.Map;
  * <p>
  * Adapted from PowerNukkitX (<a href="https://github.com/PowerNukkitX/PowerNukkitX">PowerNukkitX</a>)
  */
-public class HorseInventory extends BaseInventory {
+public class HorseInventory extends ContainerInventory {
 
     public static final int SLOT_SADDLE = 0;
     public static final int SLOT_ARMOR = 1;

--- a/src/test/java/cn/nukkit/inventory/HorseInventoryTest.java
+++ b/src/test/java/cn/nukkit/inventory/HorseInventoryTest.java
@@ -6,6 +6,8 @@ import cn.nukkit.entity.passive.EntityHorseBase;
 import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemNamespaceId;
 import cn.nukkit.network.protocol.DataPacket;
+import cn.nukkit.math.Vector3;
+import cn.nukkit.network.protocol.ContainerOpenPacket;
 import cn.nukkit.network.protocol.MobArmorEquipmentPacket;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -88,6 +90,44 @@ class HorseInventoryTest {
         assertEquals(77L, packet.eid);
         assertEquals(Item.DIAMOND_HORSE_ARMOR, packet.slots[1].getId());
         assertEquals(Item.DIAMOND_HORSE_ARMOR, packet.body.getId());
+    }
+
+
+    @Test
+    void openingTheScreenAnnouncesTheHorseContainer() {
+        Player viewer = Mockito.mock(Player.class);
+        EntityHorseBase horse = Mockito.mock(EntityHorseBase.class);
+        Mockito.when(horse.canWearHorseArmor()).thenReturn(true);
+        Mockito.when(horse.getId()).thenReturn(91L);
+        Mockito.when(horse.getViewers()).thenReturn(Map.of());
+        HorseInventory inventory = new HorseInventory(horse, 0);
+
+        inventory.onOpen(viewer);
+
+        ArgumentCaptor<DataPacket> captor = ArgumentCaptor.forClass(DataPacket.class);
+        verify(viewer, atLeastOnce()).dataPacket(captor.capture());
+        ContainerOpenPacket open = captor.getAllValues().stream()
+                .filter(ContainerOpenPacket.class::isInstance)
+                .map(ContainerOpenPacket.class::cast)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("the horse screen was never announced"));
+        assertEquals(InventoryType.HORSE.getNetworkType(), open.type);
+        assertEquals(91L, open.entityId);
+    }
+
+    @Test
+    void crouchingOpensTheScreenWithoutMounting() throws Exception {
+        Player player = Mockito.mock(Player.class);
+        Mockito.when(player.isSneaking()).thenReturn(true);
+        EntityHorseBase horse = Mockito.mock(EntityHorseBase.class, Mockito.CALLS_REAL_METHODS);
+        Mockito.doReturn(Map.of()).when(horse).getViewers();
+        Mockito.doReturn(false).when(horse).isBaby();
+        HorseInventory inventory = new HorseInventory(horse, 0);
+        setHorseInventory(horse, inventory);
+
+        assertFalse(horse.onInteract(player, Item.get(Item.DIAMOND, 0, 1), new Vector3()));
+
+        verify(player).addWindow(inventory);
     }
 
     private static void setHorseInventory(EntityHorseBase horse, HorseInventory inventory) throws Exception {


### PR DESCRIPTION
### Problem

`HorseInventory` already exists with a saddle slot, an armor slot and chest storage, and
`NetworkMapping` already resolves `HORSE_EQUIP` item stack requests to it — but nothing ever
opens the window. `InteractPacket.ACTION_OPEN_INVENTORY` is only answered for a chest boat,
so the horse screen is unreachable and the armor slot can never be filled from the client.

On Bedrock this is the only way to armor a horse: once the animal is saddled, tapping it mounts
the player (`EntityHorseBase#onInteract` falls through to the mount branch), and a mounted player
does not send an interaction for the animal underneath. Reported by a player as "I can't put armor
on my horse after saddling it".

### Fix

* `HorseInventory` extends `ContainerInventory`, so opening it sends `ContainerOpenPacket` with
  `type = InventoryType.HORSE` and the horse entity id, and closing answers with
  `ContainerClosePacket` — the same contract every other entity backed container already uses.
* A rider pressing the inventory button gets the horse screen instead of their own bag.
* Crouch + use opens the same screen without mounting. Items the horse itself accepts (feed,
  saddle, horse armor, chest) keep their meaning, so a crouching player can still saddle, feed
  and armor the animal by tapping it.
* The window is removed from its viewers when the horse is closed, so a killed or despawned
  animal cannot leave an open screen behind.

### Compatibility

No new packet fields and no protocol gate: `ContainerOpenPacket` has no version branches,
`ContainerType.HORSE` is 12 on every supported version, and `ContainerSlotType.HORSE_EQUIP` is
already mapped per protocol (it is only rejected for `CRAFTER_BLOCK_CONTAINER` / `DYNAMIC_CONTAINER`,
never for horse slots). Tested on a server serving clients from 1.20 up to 1.26.45.

### Tests

Two cases added to `HorseInventoryTest`:

* `openingTheScreenAnnouncesTheHorseContainer` — opening the inventory sends a `ContainerOpenPacket`
  carrying the horse container type and the horse entity id;
* `crouchingOpensTheScreenWithoutMounting` — a crouching player gets the window and the interaction
  does not consume the held item.

`mvn test -Dtest=HorseInventoryTest` is green on current master (5 tests).