### PR TITLE
fix(inventory): measure an empty slot by the item being added

### DIFF
--- a/src/main/java/cn/nukkit/inventory/BaseInventory.java
+++ b/src/main/java/cn/nukkit/inventory/BaseInventory.java
@@ -327,10 +327,12 @@ public abstract class BaseInventory implements Inventory {
         int count = item.getCount();
         boolean checkDamage = item.hasMeta();
         boolean checkTag = item.getCompoundTag() != null;
+        // The stack limit of the item being added, not of whatever occupies the slot right now:
+        // an empty slot holds air, and air stacks to 64 even when the incoming item does not.
+        int maxStackSize = Math.min(item.getMaxStackSize(), this.getMaxStackSize());
         int i1 = this.getSize();
         for (int i = 0; i < i1; ++i) {
             Item slot = this.getItemFast(i);
-            int maxStackSize = Math.min(slot.getMaxStackSize(), this.getMaxStackSize());
             if (item.equals(slot, checkDamage, checkTag)) {
                 int diff;
                 if ((diff = maxStackSize - slot.getCount()) > 0) {

--- a/src/test/java/cn/nukkit/inventory/BaseInventoryCanAddItemTest.java
+++ b/src/test/java/cn/nukkit/inventory/BaseInventoryCanAddItemTest.java
@@ -1,0 +1,71 @@
+package cn.nukkit.inventory;
+
+import cn.nukkit.MockServer;
+import cn.nukkit.item.Item;
+import cn.nukkit.item.ItemID;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BaseInventoryCanAddItemTest {
+
+    @BeforeAll
+    static void init() {
+        MockServer.init();
+    }
+
+    @BeforeEach
+    void resetServer() {
+        MockServer.reset();
+    }
+
+    private static final class TestInventory extends BaseInventory {
+
+        TestInventory() {
+            super(Mockito.mock(InventoryHolder.class), InventoryType.CHEST);
+        }
+    }
+
+    @Test
+    void anEmptySlotHoldsOneUnstackableItem() {
+        TestInventory inventory = new TestInventory();
+        int size = inventory.getSize();
+
+        assertTrue(inventory.canAddItem(Item.get(ItemID.DIAMOND_HELMET, 0, size)));
+        assertFalse(inventory.canAddItem(Item.get(ItemID.DIAMOND_HELMET, 0, size + 1)));
+    }
+
+    @Test
+    void anEmptySlotStillHoldsAFullStackOfAStackableItem() {
+        TestInventory inventory = new TestInventory();
+        int capacity = inventory.getSize() * Math.min(Item.get(Item.STONE).getMaxStackSize(), inventory.getMaxStackSize());
+
+        assertTrue(inventory.canAddItem(Item.get(Item.STONE, 0, capacity)));
+        assertFalse(inventory.canAddItem(Item.get(Item.STONE, 0, capacity + 1)));
+    }
+
+    @Test
+    void aPartiallyFilledStackStillCountsItsRemainder() {
+        TestInventory inventory = new TestInventory();
+        inventory.slots.put(0, Item.get(Item.STONE, 0, 60));
+        int stack = Math.min(Item.get(Item.STONE).getMaxStackSize(), inventory.getMaxStackSize());
+        int capacity = (inventory.getSize() - 1) * stack + (stack - 60);
+
+        assertTrue(inventory.canAddItem(Item.get(Item.STONE, 0, capacity)));
+        assertFalse(inventory.canAddItem(Item.get(Item.STONE, 0, capacity + 1)));
+    }
+
+    @Test
+    void aFilledInventoryRefusesAnUnstackableItem() {
+        TestInventory inventory = new TestInventory();
+        for (int slot = 0; slot < inventory.getSize(); slot++) {
+            inventory.slots.put(slot, Item.get(Item.STONE, 0, 1));
+        }
+
+        assertFalse(inventory.canAddItem(Item.get(ItemID.DIAMOND_HELMET)));
+    }
+}


### PR DESCRIPTION
### Problem

`Inventory#canAddItem` sizes every **empty** slot by the stack limit of whatever already sits in
it. An empty slot holds air, and air stacks to 64, so 61 golden horse armours "fit" into a single
free slot: the check passes, `addItem` then puts one armour per slot and hands the rest back.

A plugin that charges before it gives takes payment for 61 items and delivers 4. This is how it
surfaced for us: a shop sold 61 pieces of horse armour, the money was taken for all of them and
the overflow silently disappeared. Every non-stackable item is affected — armour, tools, weapons,
potions, buckets, boats, saddles, maps, spawn eggs.

### Fix

Size an empty slot by the **incoming** item, which is exactly what `addItem` already does when it
fills one. Stackable items keep the numbers they had; only the empty-slot arithmetic changes.

### Tests

`BaseInventoryCanAddItemTest` covers both directions (non-stackable overflow is now refused,
stackable capacity is unchanged). `mvn test -Dtest=BaseInventoryCanAddItemTest` is green on
current master.