### PR TITLE
fix(item): give a block above id 255 its real item form

### DIFF
--- a/src/main/java/cn/nukkit/item/Item.java
+++ b/src/main/java/cn/nukkit/item/Item.java
@@ -1070,6 +1070,25 @@ public class Item implements Cloneable, BlockID, ItemID, ItemNamespaceId, Protoc
             Item item;
 
             if (c == null) {
+                // A block id above 255 is not an item id. The item form of such a block is its
+                // negative alias (255 - blockId) -- that is the one the network item palette
+                // knows. Without this a block that hands out Item.get(BlockID.X) as its drop
+                // (quartz bricks, chiseled and cracked nether bricks, resin bricks, soul soil)
+                // produces an item nothing can encode: every getNamespaceId() on it throws
+                // "Unknown legacy2Runtime mapping", and the same broken id comes back from NBT
+                // on every load.
+                Class<?> blockClass = null;
+                if (id > 255) {
+                    if (id >= CustomBlockManager.LOWEST_CUSTOM_BLOCK_ID) {
+                        CustomBlockManager custom = CustomBlockManager.get();
+                        blockClass = custom == null ? null : custom.getClassType(id);
+                    } else if (id < Block.list.length) {
+                        blockClass = Block.list[id];
+                    }
+                }
+                if (blockClass != null) {
+                    return get(255 - id, meta, count, tags);
+                }
                 item = new Item(id, meta, count);
             } else if (id < 256 && id != 166) {
                 if (meta >= 0) {


### PR DESCRIPTION
### Problem

`Item.get(id)` treats every id as an item id. For a block whose id is above 255 that is wrong:
the item form of such a block is the negative alias (`255 - blockId`), the one the network item
palette knows. `Item.get(559)` therefore returns a bare `Item(559)` that no protocol can encode —
`getNamespaceId()` throws `Unknown legacy2Runtime mapping: id=559`.

Several blocks hand out exactly that as their drop (`BlockBricksQuartz`,
`BlockBricksNetherChiseled`, `BlockBricksNetherCracked`, `BlockBricksResin`,
`BlockCampfireSoul`), so mining quartz bricks yields an item that breaks every inventory path
touching it, and the broken id survives in the player's NBT.

### Fix

Map such an id to its negative alias, one hop, before falling back to a bare `Item`.
447 of the 458 blocks above id 255 without their own item class are fixed by this; the rest keep
the old fallback.

### Tests

Compiles and runs on current master; verified in game on a server serving 1.20 … 1.26.45 clients
(quartz bricks now drop a usable item and survive a relog).