### PR TITLE
fix(inventory): never drop creative UI slots on the floor

### DIFF
--- a/src/main/java/cn/nukkit/inventory/AnvilInventory.java
+++ b/src/main/java/cn/nukkit/inventory/AnvilInventory.java
@@ -31,8 +31,16 @@ public class AnvilInventory extends FakeBlockUIComponent {
         who.resetCraftingGridType();
 
         for (int i = 0; i < 2; ++i) {
-            this.getHolder().getLevel().dropItem(this.getHolder().add(0.5, 0.5, 0.5), this.getItem(i));
+            Item item = this.getItem(i);
             this.clear(i);
+            if (item.isNull() || who.isCreative()) {
+                continue;
+            }
+            for (Item drop : who.getInventory().addItem(item)) {
+                if (!who.dropItem(drop)) {
+                    this.getHolder().getLevel().dropItem(this.getHolder().add(0.5, 0.5, 0.5), drop);
+                }
+            }
         }
     }
 

--- a/src/main/java/cn/nukkit/inventory/BeaconInventory.java
+++ b/src/main/java/cn/nukkit/inventory/BeaconInventory.java
@@ -26,7 +26,7 @@ public class BeaconInventory extends FakeBlockUIComponent {
         super.onClose(who);
 
         // Drop item in slot if client doesn't automatically move it to player's inventory
-        if (!who.isConnected()) {
+        if (!who.isConnected() && !who.isCreative()) {
             this.getHolder().getLevel().dropItem(this.getHolder().add(0.5, 0.5, 0.5), this.getItem(0));
         }
         this.clear(0);

--- a/src/main/java/cn/nukkit/inventory/CartographyTableInventory.java
+++ b/src/main/java/cn/nukkit/inventory/CartographyTableInventory.java
@@ -26,7 +26,8 @@ public class CartographyTableInventory extends FakeBlockUIComponent {
 
         for (int i = 0; i < 2; i++) {
             Item item = this.getItem(i);
-            if (item.isNull()) {
+            if (item.isNull() || who.isCreative()) {
+                this.clear(i);
                 continue;
             }
             Item[] drops = who.getInventory().addItem(item);

--- a/src/main/java/cn/nukkit/inventory/EnchantInventory.java
+++ b/src/main/java/cn/nukkit/inventory/EnchantInventory.java
@@ -42,7 +42,8 @@ public class EnchantInventory extends FakeBlockUIComponent {
         // Return input slots, dropping the unplaced remainder so it isn't lost.
         for (int i = 0; i < 2; ++i) {
             Item item = this.getItem(i);
-            if (item.isNull()) {
+            if (item.isNull() || who.isCreative()) {
+                this.clear(i);
                 continue;
             }
             Item[] drops = who.getInventory().addItem(item);

--- a/src/main/java/cn/nukkit/inventory/GrindstoneInventory.java
+++ b/src/main/java/cn/nukkit/inventory/GrindstoneInventory.java
@@ -204,10 +204,12 @@ public class GrindstoneInventory extends FakeBlockUIComponent {
         super.onClose(who);
         who.craftingType = Player.CRAFTING_SMALL;
 
-        Item[] drops = who.getInventory().addItem(this.getItem(EQUIPMENT), this.getItem(INGREDIENT));
-        for (Item drop : drops) {
-            if (!who.dropItem(drop)) {
-                this.getHolder().getLevel().dropItem(this.getHolder().add(0.5, 0.5, 0.5), drop);
+        if (!who.isCreative()) {
+            Item[] drops = who.getInventory().addItem(this.getItem(EQUIPMENT), this.getItem(INGREDIENT));
+            for (Item drop : drops) {
+                if (!who.dropItem(drop)) {
+                    this.getHolder().getLevel().dropItem(this.getHolder().add(0.5, 0.5, 0.5), drop);
+                }
             }
         }
 

--- a/src/main/java/cn/nukkit/inventory/SmithingInventory.java
+++ b/src/main/java/cn/nukkit/inventory/SmithingInventory.java
@@ -115,7 +115,9 @@ public class SmithingInventory extends FakeBlockUIComponent {
         super.onClose(who);
         who.craftingType = Player.CRAFTING_SMALL;
 
-        who.giveItem(getItem(EQUIPMENT), getItem(INGREDIENT), getItem(TEMPLATE));
+        if (!who.isCreative()) {
+            who.giveItem(getItem(EQUIPMENT), getItem(INGREDIENT), getItem(TEMPLATE));
+        }
 
         this.clear(EQUIPMENT);
         this.clear(INGREDIENT);

--- a/src/main/java/cn/nukkit/inventory/StonecutterInventory.java
+++ b/src/main/java/cn/nukkit/inventory/StonecutterInventory.java
@@ -23,10 +23,12 @@ public class StonecutterInventory extends FakeBlockUIComponent {
         super.onClose(who);
         who.craftingType = Player.CRAFTING_SMALL;
 
-        Item[] drops = who.getInventory().addItem(this.getItem(0));
-        for (Item drop : drops) {
-            if (!who.dropItem(drop)) {
-                this.getHolder().getLevel().dropItem(this.getHolder().add(0.5, 0.5, 0.5), drop);
+        if (!who.isCreative()) {
+            Item[] drops = who.getInventory().addItem(this.getItem(0));
+            for (Item drop : drops) {
+                if (!who.dropItem(drop)) {
+                    this.getHolder().getLevel().dropItem(this.getHolder().add(0.5, 0.5, 0.5), drop);
+                }
             }
         }
 

--- a/src/main/java/cn/nukkit/inventory/TradeInventory.java
+++ b/src/main/java/cn/nukkit/inventory/TradeInventory.java
@@ -72,7 +72,8 @@ public class TradeInventory extends BaseInventory {
         // Return input slots, dropping the unplaced remainder so it isn't lost.
         for (int i = 0; i <= 1; i++) {
             Item item = this.getItem(i);
-            if (item.isNull()) {
+            if (item.isNull() || who.isCreative()) {
+                this.clear(i);
                 continue;
             }
             Item[] drops = who.getInventory().addItem(item);


### PR DESCRIPTION
### Problem

Closing an anvil, a grindstone, a smithing table, a stonecutter, a cartography table, an
enchanting table, a trade window or a beacon returns whatever sat in the temporary UI slots to the
player and drops the remainder into the world.

In creative that remainder is free: the items came out of an infinite inventory, so a player with
a full inventory turns every closed station into real item entities on the floor — which a
survival player then picks up. The drop also bypasses the plugin path that decides whether a
player may drop items at all.

### Fix

Creative UI slots are cleared instead of being returned or dropped. The anvil also stops dropping
its two slots unconditionally: like every other station it puts them back into the inventory first
and only drops what does not fit.

Survival behaviour is unchanged — the items still come back to the player, and only the overflow
is dropped.

### Tests

Compiles on current master; verified in game (creative player with a full inventory closing each
of the eight stations leaves nothing on the ground, survival player keeps his items).