### PR TITLE
fix(entity): stop treating powder snow as a nether portal

### DIFF
--- a/src/main/java/cn/nukkit/entity/Entity.java
+++ b/src/main/java/cn/nukkit/entity/Entity.java
@@ -2980,8 +2980,7 @@ public abstract class Entity extends Location implements Metadatable {
             }
 
             if (block.getId() == Block.POWDER_SNOW) {
-                portal = true;
-                continue;
+                powderSnow = true;
             }
 
             block.onEntityCollide(this);
@@ -2993,6 +2992,18 @@ public abstract class Entity extends Location implements Metadatable {
             inPortalTicks++;
         } else {
             this.inPortalTicks = 0;
+        }
+
+        if (powderSnow) {
+            if (this.getFreezingTicks() < 140) {
+                this.addFreezingTicks(1);
+            }
+        } else if (this.getFreezingTicks() > 0) {
+            this.addFreezingTicks(-1);
+        }
+
+        if (this.getFreezingTicks() == 140 && this.getServer().getTick() % 40 == 0) {
+            this.attack(new EntityDamageEvent(this, EntityDamageEvent.DamageCause.FREEZING, getFrostbiteInjury()));
         }
 
         if (vector.lengthSquared() > 0) {


### PR DESCRIPTION
### Problem

`Entity#checkBlockCollision` declares a `powderSnow` flag, never uses it, and sets the **portal**
flag for powder snow instead. Any non-player entity standing in powder snow for the portal delay
is therefore teleported to the nether: farm animals and pets vanish from a fenced pen with nothing
in the log. `Player#checkBlockCollision`, which owns its own copy of this loop, handles the same
block correctly — so the bug only bites mobs.

### Fix

Powder snow sets its own flag and no longer skips the collision callbacks. The freezing counter
and the frostbite damage mirror the player path, so mobs freeze in powder snow the way vanilla
expects instead of travelling between dimensions.

### Tests

Compiles on current master; verified in game — animals left in powder snow now freeze and take
frostbite damage, and no longer end up in the nether.