### PR TITLE
entity: keep controllable rides moving on 1.21.80 and newer

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -4079,6 +4079,19 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                             }
                         }
                     }
+                } else if (this.riding instanceof EntityControllable controllable
+                        && this.protocol >= ProtocolInfo.v1_21_80) {
+                    // Since 1.21.80 the client stopped sending PlayerInputPacket, so
+                    // PlayerInputProcessor never runs any more and every controllable ride
+                    // except the boat, the minecart and the happy ghast lost its input: a
+                    // saddled horse could be mounted and then stood still forever. The move
+                    // vector lives in the auth input packet now, and it drives the very same
+                    // EntityControllable hook the legacy packet used to drive.
+                    double moveVecX = NukkitMath.clamp(authPacket.getMotion().getX(), -1, 1);
+                    double moveVecY = NukkitMath.clamp(authPacket.getMotion().getY(), -1, 1);
+                    if (moveVecX != 0 || moveVecY != 0) {
+                        controllable.onPlayerInput(this, moveVecX, moveVecY);
+                    }
                 }
 
                 if (authPacket.getInputData().contains(AuthInputAction.START_SPRINTING)) {


### PR DESCRIPTION
### Problem

Since protocol `v1_21_80` the client no longer sends `PlayerInputPacket`, and
`PlayerInputProcessor#isSupported()` stops at that version. The auth input path only forwards the
move vector to minecarts, happy ghasts and boats, so every other `EntityControllable` ride loses
its input entirely: a saddled horse, pig, llama or strider can still be mounted, but it never
moves again on a modern client. Nothing is logged — the rider simply sits still.

### Fix

Forward the auth input move vector to any other `EntityControllable` the player is riding, on the
same terms the legacy packet used: clamped to `[-1, 1]` and only when the stick is actually
pushed, so an idle rider does not pin the mob yaw to the player's every tick.

### Tests

Compiles on current master; verified in game on 1.26.4x — a saddled horse, pig and strider are
controllable again, and older clients still ride through the legacy packet path unchanged.