### PR TITLE
block: let a flying player mine at normal speed

### DIFF
--- a/src/main/java/cn/nukkit/block/Block.java
+++ b/src/main/java/cn/nukkit/block/Block.java
@@ -1,5 +1,6 @@
 package cn.nukkit.block;
 
+import cn.nukkit.AdventureSettings;
 import cn.nukkit.Player;
 import cn.nukkit.Server;
 import cn.nukkit.block.custom.CustomBlockManager;
@@ -884,7 +885,9 @@ public abstract class Block extends Position implements Metadatable, Cloneable, 
     public double calculateBreakTime(@NotNull Item item, Player player) {
         double seconds = this.calculateBreakTimeNotInAir(item, player);
 
-        if (player != null) {
+        if (player != null && !player.getAdventureSettings().get(AdventureSettings.Type.FLYING)) {
+            // A flying player mines at normal speed on Bedrock: the in-air penalty is for
+            // jumping and falling only, and the client never applies it while flight is on.
             //玩家距离上次在空中过去5tick之后，才认为玩家是在地上挖掘。
             //如果单纯用onGround检测，这个方法返回的时间将会不连续。
             if (player.getServer().getTick() - player.getLastInAirTick() < 5) {


### PR DESCRIPTION
### Problem

Bedrock multiplies the mining time by five only while the player is **jumping or falling**.
Flight is a stable state there, and the client keeps mining at the normal rate with it on; the
server does not, so it demands five times the client time and `Level#useBreakOn` cancels the break
as too fast.

A flying player cannot break a wooden plank at all, and nothing reaches the log: from the server
side the refusal is an ordinary anti-fast-break verdict, which makes it very hard to track down.

### Fix

Skip the in-air factor while the player is flying. PocketMine-MP draws the same line
(`SurvivalBlockBreakHandler` skips it when `isFlying()`), and it serves the same clients.

Only the flight case changes: jumping and falling keep the penalty, and the five-tick grace for a
landing player is untouched.

### Tests

Compiles on current master; verified in game — a flying player in survival breaks blocks at the
client-side rate, a jumping or falling one still takes the vanilla penalty.