### PR TITLE
fix(portal): make a nether trip land somewhere sane without generating the search box

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -2226,9 +2226,14 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
 
         if (this.server.isNetherAllowed()) {
             if (this.server.vanillaPortals && (this.inPortalTicks == 40 || this.inPortalTicks == 10 && this.gamemode == CREATIVE) && this.portalPos == null) {
-                Position portalPos = this.level.calculatePortalMirror(this);
+                Position portalPos = this.level.calculatePortalMirror(this, this.netherReturnLevel());
                 if (portalPos == null) {
                     return;
+                }
+                if (this.level.getDimension() != Level.DIMENSION_NETHER) {
+                    // Remember which world is being left: the way back has to land here and not in
+                    // whatever world happens to be the default one.
+                    this.namedTag.putString(NETHER_RETURN_WORLD_TAG, this.level.getFolderName());
                 }
 
                 for (int x = -1; x < 2; x++) {
@@ -2265,8 +2270,10 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                             Position foundPortal = BlockNetherPortal.findNearestPortal(portalPos);
                             getServer().getScheduler().scheduleTask(InternalPlugin.INSTANCE, () -> {
                                 if (foundPortal == null) {
-                                    BlockNetherPortal.spawnPortal(portalPos);
-                                    teleport(portalPos.add(1.5, 1, 0.5), TeleportCause.NETHER_PORTAL);
+                                    // The frame may end up at another height than asked for, so the
+                                    // player follows the frame instead of the mirrored position.
+                                    Position spawnedPortal = BlockNetherPortal.spawnPortal(portalPos);
+                                    teleport(spawnedPortal.add(1.5, 1, 0.5), TeleportCause.NETHER_PORTAL);
                                 } else {
                                     teleport(BlockNetherPortal.getSafePortal(foundPortal), TeleportCause.NETHER_PORTAL);
                                 }
@@ -2310,6 +2317,29 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
         if (this.getFreezingTicks() == 140 && this.getServer().getTick() % 40 == 0) {
             this.attack(new EntityDamageEvent(this, DamageCause.FREEZING, getFrostbiteInjury()));
         }
+    }
+
+    /**
+     * Player data tag holding the world left through a nether portal.
+     */
+    private static final String NETHER_RETURN_WORLD_TAG = "NetherReturnWorld";
+
+    /**
+     * World the way back from the nether should land in, or {@code null} when it is unknown.
+     *
+     * <p>Without it every way back goes to the default world, which is only ever right on a server
+     * whose single overworld is also the default one. With a hub as the default world the player
+     * returned to a hub coordinate mirrored from the nether - eight times out from the hub build,
+     * in mid-air over ungenerated terrain. The tag lives in the player data, so a relog or a
+     * restart inside the nether does not lose the way home.
+     */
+    private Level netherReturnLevel() {
+        String world = this.namedTag.getString(NETHER_RETURN_WORLD_TAG);
+        if (world == null || world.isEmpty()) {
+            return null;
+        }
+        Level level = this.server.getLevelByName(world);
+        return level != null && level.getDimension() != Level.DIMENSION_NETHER ? level : null;
     }
 
     /**

--- a/src/main/java/cn/nukkit/block/BlockNetherPortal.java
+++ b/src/main/java/cn/nukkit/block/BlockNetherPortal.java
@@ -424,7 +424,43 @@ public class BlockNetherPortal extends BlockFlowable implements Faceable {
         lvl.setBlockAt(x + 2, y, z, OBSIDIAN);
         lvl.setBlockAt(x + 3, y, z, OBSIDIAN);
 
+        sealPortalSite(lvl, spawned.getFloorX(), spawned.getFloorY(), spawned.getFloorZ());
+
         return spawned;
+    }
+
+    /**
+     * Makes the ground a fresh frame stands on safe to arrive at.
+     *
+     * <p>The frame itself is only two obsidian blocks wide, so a player coming through steps off
+     * it right away. Over a lava sea, a cave mouth or a cliff that step is a fall, and the frame
+     * may have been carved out of lava that flows straight back in. So the floor under the whole
+     * cleared box is laid solid and the lava touching it is replaced with plain rock.
+     */
+    private static void sealPortalSite(Level level, int x, int y, int z) {
+        for (int xx = -1; xx < 4; xx++) {
+            for (int zz = -1; zz < 3; zz++) {
+                if (!isSolidAt(level, x + xx, y, z + zz)) {
+                    level.setBlockAt(x + xx, y, z + zz, OBSIDIAN);
+                }
+            }
+        }
+
+        // Liquid on the outside of the box turns into rock, liquid inside it into air: draining
+        // the inside alone leaves the sea around it to flow straight back into the frame.
+        int filler = level.getDimension() == Level.DIMENSION_NETHER ? NETHERRACK : STONE;
+        for (int xx = -2; xx < 5; xx++) {
+            for (int zz = -2; zz < 4; zz++) {
+                for (int yy = 0; yy <= 5; yy++) {
+                    int id = level.getBlockIdAt(x + xx, y + yy, z + zz);
+                    if (!Block.isLava(id) && !Block.isWater(id)) {
+                        continue;
+                    }
+                    boolean shell = xx == -2 || xx == 4 || zz == -2 || zz == 3 || yy == 0 || yy == 5;
+                    level.setBlockAt(x + xx, y + yy, z + zz, shell ? filler : AIR);
+                }
+            }
+        }
     }
 
     /**
@@ -467,11 +503,26 @@ public class BlockNetherPortal extends BlockFlowable implements Faceable {
             return false;
         }
         for (int yy = 1; yy <= 4; yy++) {
-            if (isSolidAt(level, x + 1, y + yy, z + 1) || isSolidAt(level, x + 2, y + yy, z + 1)) {
+            if (isBlockedAt(level, x + 1, y + yy, z + 1) || isBlockedAt(level, x + 2, y + yy, z + 1)) {
                 return false;
             }
         }
         return true;
+    }
+
+    /**
+     * Whether the given cell keeps a portal frame from standing here.
+     *
+     * <p>Lava counts, and that is the whole point of this method: it is not a footing and it is
+     * not free room either. Treating it as free room is what built frames inside the lava seas of
+     * the nether, so a player stepping through arrived standing in lava.
+     */
+    private static boolean isBlockedAt(Level level, int x, int y, int z) {
+        int id = level.getBlockIdAt(x, y, z);
+        if (id == AIR || id == NETHER_PORTAL) {
+            return false;
+        }
+        return Block.isBlockSolidById(id) || Block.isLava(id) || Block.isWater(id);
     }
 
     private static boolean isSolidAt(Level level, int x, int y, int z) {

--- a/src/main/java/cn/nukkit/block/BlockNetherPortal.java
+++ b/src/main/java/cn/nukkit/block/BlockNetherPortal.java
@@ -4,6 +4,7 @@ import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemBlock;
 import cn.nukkit.level.Level;
 import cn.nukkit.level.Position;
+import cn.nukkit.level.format.FullChunk;
 import cn.nukkit.math.AxisAlignedBB;
 import cn.nukkit.math.BlockFace;
 import cn.nukkit.math.BlockFace.Axis;
@@ -278,18 +279,34 @@ public class BlockNetherPortal extends BlockFlowable implements Faceable {
         return Position.fromObject(down.up(), portal.getLevel());
     }
 
+    /**
+     * How far, in blocks, an existing portal is looked up on the other side.
+     */
+    private static final int PORTAL_SEARCH_RADIUS = 128;
+
+    /**
+     * Looks up the portal closest to the given position.
+     *
+     * <p>The search walks chunks in rings around the origin and stops at the first portal it
+     * finds, so the result is the nearest one and the cost is paid only until then. Chunks that
+     * are not generated yet are skipped instead of being generated on the spot: a player stepping
+     * into a portal must not pay for generating the whole search box, and the portal is going to
+     * be built next to the mirrored position anyway.
+     */
     public static Position findNearestPortal(Position pos) {
         Level level = pos.getLevel();
-        Position found = null;
+        int originChunkX = pos.getFloorX() >> 4;
+        int originChunkZ = pos.getFloorZ() >> 4;
+        int chunkRadius = (PORTAL_SEARCH_RADIUS >> 4) + 1;
 
-        for (int xx = -128; xx <= 128; xx++) {
-            for (int zz = -128; zz <= 128; zz++) {
-                for (int y = 0; y  < level.getMaxBlockY(); y++) {
-                    int x = pos.getFloorX() + xx, z = pos.getFloorZ() + zz;
-                    if (level.getBlockIdAt(x, y, z) == NETHER_PORTAL) {
-                        found = new Position(x, y, z, level);
-                        break;
+        Position found = null;
+        for (int ring = 0; ring <= chunkRadius && found == null; ring++) {
+            for (int chunkX = originChunkX - ring; chunkX <= originChunkX + ring && found == null; chunkX++) {
+                for (int chunkZ = originChunkZ - ring; chunkZ <= originChunkZ + ring && found == null; chunkZ++) {
+                    if (Math.max(Math.abs(chunkX - originChunkX), Math.abs(chunkZ - originChunkZ)) != ring) {
+                        continue;
                     }
+                    found = findPortalInChunk(level, chunkX, chunkZ);
                 }
             }
         }
@@ -310,6 +327,34 @@ public class BlockNetherPortal extends BlockFlowable implements Faceable {
             }
         }
         return found;
+    }
+
+    private static Position findPortalInChunk(Level level, int chunkX, int chunkZ) {
+        FullChunk chunk = level.getChunk(chunkX, chunkZ, false);
+        if (chunk == null) {
+            // Load from disk, but never generate: generating here is what made stepping into a
+            // portal take seconds on a fresh nether.
+            if (!level.loadChunk(chunkX, chunkZ, false)) {
+                return null;
+            }
+            chunk = level.getChunk(chunkX, chunkZ, false);
+        }
+        if (chunk == null || !chunk.isGenerated()) {
+            return null;
+        }
+
+        int minY = level.getMinBlockY();
+        int maxY = level.getMaxBlockY();
+        for (int x = 0; x < 16; x++) {
+            for (int z = 0; z < 16; z++) {
+                for (int y = minY; y < maxY; y++) {
+                    if (chunk.getBlockId(x, y, z) == NETHER_PORTAL) {
+                        return new Position((chunkX << 4) + x, y, (chunkZ << 4) + z, level);
+                    }
+                }
+            }
+        }
+        return null;
     }
 
     public static void spawnPortal(Position pos) {

--- a/src/main/java/cn/nukkit/block/BlockNetherPortal.java
+++ b/src/main/java/cn/nukkit/block/BlockNetherPortal.java
@@ -285,6 +285,14 @@ public class BlockNetherPortal extends BlockFlowable implements Faceable {
     private static final int PORTAL_SEARCH_RADIUS = 128;
 
     /**
+     * How far the search may pull inactive chunks from disk.
+     *
+     * <p>Scaling a portal coordinate loses at most seven blocks, so the frame used for the trip
+     * is always in the same or an adjacent chunk on the way back.
+     */
+    private static final int PORTAL_DISK_LOAD_CHUNK_RADIUS = 1;
+
+    /**
      * Looks up the portal closest to the given position.
      *
      * <p>The search walks chunks in rings around the origin and stops at the first portal it
@@ -306,7 +314,8 @@ public class BlockNetherPortal extends BlockFlowable implements Faceable {
                     if (Math.max(Math.abs(chunkX - originChunkX), Math.abs(chunkZ - originChunkZ)) != ring) {
                         continue;
                     }
-                    found = findPortalInChunk(level, chunkX, chunkZ);
+                    found = findPortalInChunk(
+                            level, chunkX, chunkZ, ring <= PORTAL_DISK_LOAD_CHUNK_RADIUS);
                 }
             }
         }
@@ -329,12 +338,13 @@ public class BlockNetherPortal extends BlockFlowable implements Faceable {
         return found;
     }
 
-    private static Position findPortalInChunk(Level level, int chunkX, int chunkZ) {
+    private static Position findPortalInChunk(
+            Level level, int chunkX, int chunkZ, boolean mayLoadFromDisk) {
         FullChunk chunk = level.getChunk(chunkX, chunkZ, false);
         if (chunk == null) {
-            // Load from disk, but never generate: generating here is what made stepping into a
-            // portal take seconds on a fresh nether.
-            if (!level.loadChunk(chunkX, chunkZ, false)) {
+            // A cold far chunk is not worth blocking the transfer for. The mirror will get a new
+            // frame if no nearby portal exists; already loaded chunks still use the full radius.
+            if (!mayLoadFromDisk || !level.loadChunk(chunkX, chunkZ, false)) {
                 return null;
             }
             chunk = level.getChunk(chunkX, chunkZ, false);

--- a/src/main/java/cn/nukkit/block/BlockNetherPortal.java
+++ b/src/main/java/cn/nukkit/block/BlockNetherPortal.java
@@ -357,9 +357,26 @@ public class BlockNetherPortal extends BlockFlowable implements Faceable {
         return null;
     }
 
-    public static void spawnPortal(Position pos) {
+    /**
+     * How far up and down a footing for a freshly built portal is looked up.
+     */
+    private static final int PORTAL_GROUND_SEARCH = 96;
+
+    /**
+     * Builds a portal frame around the given position and returns where it ended up.
+     *
+     * <p>The Y that comes in is the one the player entered the portal at on the other side, see
+     * {@link Level#calculatePortalMirror}, and it says nothing about the terrain here: coming back
+     * from the nether at Y=72 built the frame in mid-air and left the player standing on its
+     * obsidian floor high above the ground. The frame is therefore lowered onto the first footing
+     * below the mirrored position, or raised onto the first one above it, and only stays at the
+     * mirrored Y when the whole column is empty.
+     */
+    public static Position spawnPortal(Position pos) {
         Level lvl = pos.level;
-        int x = pos.getFloorX(), y = pos.getFloorY(), z = pos.getFloorZ();
+        int x = pos.getFloorX(), z = pos.getFloorZ();
+        int y = frameHeightFor(lvl, x, pos.getFloorY(), z);
+        Position spawned = new Position(x, y, z, lvl);
 
         for (int xx = -1; xx < 4; xx++) {
             for (int yy = 1; yy < 4; yy++)  {
@@ -406,6 +423,64 @@ public class BlockNetherPortal extends BlockFlowable implements Faceable {
         lvl.setBlockAt(x + 1, y, z, OBSIDIAN);
         lvl.setBlockAt(x + 2, y, z, OBSIDIAN);
         lvl.setBlockAt(x + 3, y, z, OBSIDIAN);
+
+        return spawned;
+    }
+
+    /**
+     * Y the portal floor is laid at for a frame asked for at the given position.
+     */
+    private static int frameHeightFor(Level level, int x, int y, int z) {
+        int minY = level.getMinBlockY() + 1;
+        int maxY = level.getMaxBlockY() - 5;
+        if (level.getDimension() == Level.DIMENSION_NETHER) {
+            // Under the bedrock roof: a frame built into it is walled in and unreachable.
+            maxY = Math.min(maxY, 122);
+        }
+        if (maxY <= minY) {
+            return y;
+        }
+
+        int start = Math.max(minY, Math.min(maxY, y));
+        for (int yy = start; yy >= Math.max(minY, start - PORTAL_GROUND_SEARCH); yy--) {
+            if (hasFooting(level, x, yy, z)) {
+                return yy + 1;
+            }
+        }
+        for (int yy = start + 1; yy <= Math.min(maxY, start + PORTAL_GROUND_SEARCH); yy++) {
+            if (hasFooting(level, x, yy, z)) {
+                return yy + 1;
+            }
+        }
+        return start;
+    }
+
+    /**
+     * Whether a frame standing on top of the given layer has ground under it and room above.
+     *
+     * <p>Only the two columns the portal blocks themselves sit in are checked: the frame clears
+     * the space around it anyway, so demanding a flat 4x3 patch would reject every slope and send
+     * the frame back into mid-air.
+     */
+    private static boolean hasFooting(Level level, int x, int y, int z) {
+        if (!isSolidAt(level, x + 1, y, z + 1) && !isSolidAt(level, x + 2, y, z + 1)) {
+            return false;
+        }
+        for (int yy = 1; yy <= 4; yy++) {
+            if (isSolidAt(level, x + 1, y + yy, z + 1) || isSolidAt(level, x + 2, y + yy, z + 1)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isSolidAt(Level level, int x, int y, int z) {
+        int id = level.getBlockIdAt(x, y, z);
+        if (id == AIR || id == NETHER_PORTAL) {
+            return false;
+        }
+        // Water and lava are not a footing: standing on them means falling through or burning.
+        return Block.isBlockSolidById(id);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -5487,6 +5487,18 @@ public class Level implements ChunkManager, Metadatable {
     }
 
     public Position calculatePortalMirror(Vector3 portal) {
+        return this.calculatePortalMirror(portal, null);
+    }
+
+    /**
+     * Mirrors a portal position onto the other side.
+     *
+     * @param overworld world the way back from the nether lands in. {@code null} means the default
+     *                  world, which is only the right answer on a server whose single overworld is
+     *                  also the default one: with a hub as the default world the player comes back
+     *                  eight times out from the hub build instead of the world they left.
+     */
+    public Position calculatePortalMirror(Vector3 portal, Level overworld) {
         Level nether = Server.getInstance().getNetherWorld(this.getName());
         if (nether == null) {
             return null;
@@ -5495,16 +5507,21 @@ public class Level implements ChunkManager, Metadatable {
         double x;
         double y;
         double z;
+        Level target;
         if (this == nether) {
+            target = overworld != null && overworld != this
+                    ? overworld
+                    : Server.getInstance().getDefaultLevel();
             x = portal.getFloorX() << 3;
             y = NukkitMath.clamp(portal.getFloorY(), 70, 246);
             z = portal.getFloorZ() << 3;
         } else {
+            target = nether;
             x = portal.getFloorX() >> 3;
             y = NukkitMath.clamp(portal.getFloorY(), 70, 118);
             z = portal.getFloorZ() >> 3;
         }
-        return new Position(x, y, z, this == nether ? Server.getInstance().getDefaultLevel() : nether);
+        return new Position(x, y, z, target);
     }
 
     public boolean isBlockWaterloggedAt(FullChunk chunk, int x, int y, int z) {


### PR DESCRIPTION
Four related fixes on the nether portal path; they build on each other, so they come as one branch.

### 1. Search the nether side by rings, without generating chunks

`findNearestPortal` walked a fixed 257×257 box over every Y level and kept going after a hit
(the inner `break` only left the Y loop), so a single portal step always paid for the full box.
The lookup went through `Level#getBlockIdAt`, which **generates** a missing chunk on access —
roughly 290 chunks generated inside an `AsyncTask` before the player is teleported anywhere. On a
fresh nether that is seconds of waiting per portal.

Now: rings around the mirrored position, returning on the first portal found (which is also the
nearest). Chunks are loaded from disk but never generated — a portal that does not exist yet is
built next to the mirrored position anyway. Block reads go straight to the chunk, and the Y range
follows the world instead of starting at zero.

### 2. Bring the way back to the world the player left, on the ground

`Level#calculatePortalMirror` hands every way back to `Server#getDefaultLevel()`, which is the
overworld only on a server whose single world is also the default one. With a hub as the default
world the player lands on a hub coordinate mirrored eight times out from the build, over terrain
nobody generated. And `spawnPortal` built the frame at the Y taken from the other side, so even in
the right world the frame hung in mid-air with the player standing on its obsidian floor.

The origin world is remembered in the player data when the portal is entered (so a relog or a
restart inside the nether keeps it, and the default world stays the fallback for players who were
already there). The frame is lowered onto the first footing below the mirrored position, or raised
onto the first one above it, and `spawnPortal` returns where it ended up.

### 3. Keep a fresh frame out of lava and give it a floor

A frame spawned in the nether could be placed inside a lava lake or with no floor under it.

### 4. Do not read hundreds of cold chunks for one transfer

The ring search stopped *generating* the target area, but it still loaded every generated chunk in
a 19×19 square from LevelDB. With chunk caching disabled and the Java LevelDB provider, a return
from the nether without a nearby indexed frame spent 30–40 seconds reading up to 361 cold chunks
and scanning ~24 million block cells.

Only cold chunks in the origin ring and its immediate neighbours are loaded now — enough to
recover the portal used for the trip, since coordinate scaling loses at most seven blocks.
Already-loaded chunks are still searched across the vanilla radius, so an active farther portal
keeps linking as before.

### Tests

Compiles on current master; verified in game on a server serving 1.20 … 1.26.45 clients: both
directions land on solid ground in the correct world, and the transfer is immediate instead of
taking tens of seconds on a cold nether.