### PR TITLE
block: match the vanilla shulker box hardness

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockShulkerBox.java
+++ b/src/main/java/cn/nukkit/block/BlockShulkerBox.java
@@ -59,7 +59,7 @@ public class BlockShulkerBox extends BlockTransparentMeta implements BlockEntity
 
     @Override
     public double getHardness() {
-        return 2.5;
+        return 2;
     }
 
     @Override


### PR DESCRIPTION
The client computes its own break animation from the vanilla block data, where a shulker box has a
destroy time of `2.0`, while `BlockShulkerBox` reports `2.5`. The server therefore always expects
the break to take 25 % longer than the client shows, marks the finished break as too fast and
cancels it: with a hand, a wooden or a stone pickaxe the box never breaks at all, and with an iron
or better pickaxe it only survives because the 150 ms grace covers the gap.

Report the vanilla value so both sides agree.

Compiles on current master; verified in game — a shulker box now breaks with any tool.