### PR TITLE
block: ask before a dispenser or a dropper fires

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockDispenser.java
+++ b/src/main/java/cn/nukkit/block/BlockDispenser.java
@@ -5,6 +5,7 @@ import cn.nukkit.blockentity.BlockEntity;
 import cn.nukkit.blockentity.BlockEntityDispenser;
 import cn.nukkit.dispenser.DispenseBehavior;
 import cn.nukkit.dispenser.DispenseBehaviorRegister;
+import cn.nukkit.event.block.BlockDispenseEvent;
 import cn.nukkit.inventory.ContainerInventory;
 import cn.nukkit.inventory.Inventory;
 import cn.nukkit.item.Item;
@@ -202,6 +203,17 @@ public class BlockDispenser extends BlockSolidMeta implements Faceable, BlockEnt
             pk.data = 1200;
 
             level.addChunkPacket(getChunkX(), getChunkZ(), pk.clone());
+            return;
+        }
+
+        // A dispenser fires with nobody behind it, so land guards never see a break or a place
+        // event for what it does. Ask before the behavior runs: cancelling here consumes nothing
+        // and stays silent, which is exactly how a dispenser with an empty slot behaves.
+        BlockDispenseEvent dispenseEvent =
+                new BlockDispenseEvent(this, facing, this.getSide(facing), original.clone());
+        this.level.getServer().getPluginManager().callEvent(dispenseEvent);
+
+        if (dispenseEvent.isCancelled()) {
             return;
         }
 

--- a/src/main/java/cn/nukkit/block/BlockDropper.java
+++ b/src/main/java/cn/nukkit/block/BlockDropper.java
@@ -3,6 +3,7 @@ package cn.nukkit.block;
 import cn.nukkit.Player;
 import cn.nukkit.blockentity.BlockEntity;
 import cn.nukkit.blockentity.BlockEntityDropper;
+import cn.nukkit.event.block.BlockDispenseEvent;
 import cn.nukkit.event.inventory.InventoryMoveItemEvent;
 import cn.nukkit.inventory.ContainerInventory;
 import cn.nukkit.inventory.Inventory;
@@ -177,6 +178,18 @@ public class BlockDropper extends BlockSolidMeta implements Faceable, BlockEntit
 
         if (target != null) {
             target = target.clone();
+
+            // Same question as the dispenser above: the dropper hands an item to whatever stands
+            // in front of it, and no player event is fired for that.
+            BlockFace dropperFace = this.getBlockFace();
+            BlockDispenseEvent dispenseEvent =
+                    new BlockDispenseEvent(
+                            this, dropperFace, this.getSide(dropperFace), target.clone());
+            this.level.getServer().getPluginManager().callEvent(dispenseEvent);
+
+            if (dispenseEvent.isCancelled()) {
+                return;
+            }
 
             // 优先推入相邻容器；失败则弹入世界（原版 dropper 行为）
             if (!this.dispenseToContainer((BlockEntityDropper) blockEntity, target)) {

--- a/src/main/java/cn/nukkit/event/block/BlockDispenseEvent.java
+++ b/src/main/java/cn/nukkit/event/block/BlockDispenseEvent.java
@@ -1,0 +1,57 @@
+package cn.nukkit.event.block;
+
+import cn.nukkit.block.Block;
+import cn.nukkit.event.Cancellable;
+import cn.nukkit.event.HandlerList;
+import cn.nukkit.item.Item;
+import cn.nukkit.math.BlockFace;
+
+/**
+ * Called before a dispenser or a dropper releases an item.
+ *
+ * <p>Dispensing has no player behind it: the block fires from a lever, from a comparator, from
+ * another machine. Without this event a plugin that guards land can only see the moment a player
+ * breaks or places a block, so a dispenser standing one cell outside a protected area pours lava
+ * into it, lights it, throws primed TNT at it, spawns mobs in it and places shulker boxes in it,
+ * and none of the usual guards are ever asked.
+ *
+ * <p>The event carries the cell the block fires into ({@link #getTarget()}), because that is the
+ * cell every dispense behavior actually changes, and the item that is about to leave the
+ * container. Cancelling it stops the dispense completely: nothing is consumed, no behavior runs
+ * and no sound or particle is sent, so a refused dispenser looks like a dispenser that has
+ * nothing to fire.
+ */
+public class BlockDispenseEvent extends BlockEvent implements Cancellable {
+
+    private static final HandlerList handlers = new HandlerList();
+
+    public static HandlerList getHandlers() {
+        return handlers;
+    }
+
+    private final BlockFace face;
+    private final Block target;
+    private final Item item;
+
+    public BlockDispenseEvent(Block block, BlockFace face, Block target, Item item) {
+        super(block);
+        this.face = face;
+        this.target = target;
+        this.item = item;
+    }
+
+    /** The direction the block is facing. */
+    public BlockFace getFace() {
+        return this.face;
+    }
+
+    /** The cell in front of the block, the one a dispense behavior changes. */
+    public Block getTarget() {
+        return this.target;
+    }
+
+    /** A copy of the item that is about to be dispensed. Changing it changes nothing. */
+    public Item getItem() {
+        return this.item;
+    }
+}


### PR DESCRIPTION
### Problem

A dispenser has no player behind it, so nothing it does reaches a plugin that guards land: it
pours lava and water into a protected area from one cell outside, lights it, throws primed TNT at
it, spawns mobs in it and places shulker boxes in it — and no break or place event is ever fired.

### Fix

Add a cancellable `BlockDispenseEvent` carrying the item and the cell the block fires into, and
call it from `BlockDispenser#dispense` and `BlockDropper#dispense` before anything is consumed.

A cancelled dispense runs no behavior, plays no sound and takes nothing out of the container, so
it looks like a dispenser that had nothing to fire.

Compiles on current master; verified in game with a plugin that cancels the event inside a
protected region.