### PR TITLE
block: fire cancellable prime events before beds and anchors explode

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockBed.java
+++ b/src/main/java/cn/nukkit/block/BlockBed.java
@@ -5,6 +5,7 @@ import cn.nukkit.Server;
 import cn.nukkit.blockentity.BlockEntity;
 import cn.nukkit.blockentity.BlockEntityBed;
 import cn.nukkit.entity.Entity;
+import cn.nukkit.event.block.BlockExplosionPrimeEvent;
 import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemBed;
 import cn.nukkit.lang.TranslationContainer;
@@ -104,13 +105,21 @@ public class BlockBed extends BlockTransparentMeta implements Faceable, BlockEnt
     public boolean onActivate(Item item, Player player) {
         if (this.level.getDimension() != Level.DIMENSION_OVERWORLD) {
             if (this.level.getGameRules().getBoolean(GameRule.RESPAWN_BLOCKS_EXPLODE)) {
+                BlockExplosionPrimeEvent event = new BlockExplosionPrimeEvent(this, player, 5);
+                event.setFireChance(0.3333);
+                this.level.getServer().getPluginManager().callEvent(event);
+                if (event.isCancelled()) {
+                    return true;
+                }
                 if (this.getLevel().setBlock(this, Block.get(BlockID.AIR), true, true)) {
                     this.level.addParticle(new DestroyBlockParticle(this.add(0.5, 0.5, 0.5), this));
                 }
 
-                Explosion explosion = new Explosion(this.add(0.5, 0, 0.5), 5, this);
-                explosion.setFireSpawnChance(0.3333);
-                explosion.explodeA();
+                Explosion explosion = new Explosion(this.add(0.5, 0, 0.5), event.getForce(), this);
+                explosion.setFireSpawnChance(event.getFireChance());
+                if (event.isBlockBreaking()) {
+                    explosion.explodeA();
+                }
                 explosion.explodeB();
             }
             return true;

--- a/src/main/java/cn/nukkit/block/BlockRespawnAnchor.java
+++ b/src/main/java/cn/nukkit/block/BlockRespawnAnchor.java
@@ -88,6 +88,7 @@ public class BlockRespawnAnchor extends BlockMeta {
     public void explode(Player player) {
         BlockExplosionPrimeEvent event = new BlockExplosionPrimeEvent(this, player, 5);
         event.setIncendiary(true);
+        level.getServer().getPluginManager().callEvent(event);
         if (event.isCancelled()) {
             return;
         }

--- a/src/test/java/cn/nukkit/block/BlockExplosionPrimeEventTest.java
+++ b/src/test/java/cn/nukkit/block/BlockExplosionPrimeEventTest.java
@@ -1,0 +1,69 @@
+package cn.nukkit.block;
+
+import cn.nukkit.Player;
+import cn.nukkit.Server;
+import cn.nukkit.event.block.BlockExplosionPrimeEvent;
+import cn.nukkit.item.Item;
+import cn.nukkit.level.GameRule;
+import cn.nukkit.level.GameRules;
+import cn.nukkit.level.Level;
+import cn.nukkit.plugin.PluginManager;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class BlockExplosionPrimeEventTest {
+
+    @Test
+    void cancelledRespawnAnchorPrimeKeepsTheSourceBlock() {
+        Level level = cancellableExplosionLevel(Level.DIMENSION_OVERWORLD);
+        BlockRespawnAnchor anchor = place(new BlockRespawnAnchor(1), level);
+
+        anchor.explode(mock(Player.class));
+
+        verify(level, never()).setBlock(any(), any(Block.class));
+    }
+
+    @Test
+    void cancelledBedPrimeKeepsTheSourceBlock() {
+        Level level = cancellableExplosionLevel(Level.DIMENSION_NETHER);
+        BlockBed bed = place(new BlockBed(), level);
+
+        bed.onActivate(Item.get(Item.AIR), mock(Player.class));
+
+        verify(level, never()).setBlock(any(), any(Block.class), anyBoolean(), anyBoolean());
+    }
+
+    private static Level cancellableExplosionLevel(int dimension) {
+        Level level = mock(Level.class);
+        Server server = mock(Server.class);
+        PluginManager plugins = mock(PluginManager.class);
+        GameRules rules = mock(GameRules.class);
+        when(level.getServer()).thenReturn(server);
+        when(level.getDimension()).thenReturn(dimension);
+        when(level.getGameRules()).thenReturn(rules);
+        when(rules.getBoolean(GameRule.RESPAWN_BLOCKS_EXPLODE)).thenReturn(true);
+        when(server.getPluginManager()).thenReturn(plugins);
+        doAnswer(invocation -> {
+                    ((BlockExplosionPrimeEvent) invocation.getArgument(0)).setCancelled(true);
+                    return null;
+                })
+                .when(plugins)
+                .callEvent(any(BlockExplosionPrimeEvent.class));
+        return level;
+    }
+
+    private static <T extends Block> T place(T block, Level level) {
+        block.level = level;
+        block.x = 10;
+        block.y = 64;
+        block.z = -5;
+        return block;
+    }
+}


### PR DESCRIPTION
### Problem

A bed used in the nether or the end, and a respawn anchor charged in the overworld, explode
directly: `Level#createExplosion` is called without ever firing `BlockExplosionPrimeEvent`. A
plugin guarding land has no way to stop it, so a protected build can be blown up with a bed from
outside the region, and nothing about the blast is visible to plugins.

### Fix

Fire a cancellable `BlockExplosionPrimeEvent` (with the player who triggered it and the vanilla
force of 5) before both explosions. A cancelled event leaves the block and the world untouched.

### Tests

`BlockExplosionPrimeEventTest` covers both blocks, cancelled and not.
`mvn test -Dtest=BlockExplosionPrimeEventTest` is green on current master.