### PR TITLE
fix(inventory): propagate event-authored workstation outputs

### DIFF
--- a/src/main/java/cn/nukkit/inventory/request/CraftGrindstoneActionProcessor.java
+++ b/src/main/java/cn/nukkit/inventory/request/CraftGrindstoneActionProcessor.java
@@ -64,6 +64,11 @@ public class CraftGrindstoneActionProcessor implements ItemStackRequestActionPro
         if (event.isCancelled()) {
             return context.error();
         }
+        Item eventOutput = event.getNewItem();
+        if (eventOutput == null || eventOutput.isNull()) {
+            return context.error();
+        }
+        result = eventOutput.clone();
 
         int experienceDropped = event.getExperienceDropped();
         if (experienceDropped > 0) {

--- a/src/main/java/cn/nukkit/inventory/request/CraftRecipeActionProcessor.java
+++ b/src/main/java/cn/nukkit/inventory/request/CraftRecipeActionProcessor.java
@@ -46,6 +46,7 @@ public class CraftRecipeActionProcessor implements ItemStackRequestActionProcess
     public static final String RECIPE_NET_ID_KEY = "recipeNetId";
     public static final String ENCH_RECIPE_KEY = "enchRecipe";
     public static final String TIMES_CRAFTED_KEY = "timesCrafted";
+    public static final String EVENT_AUTHORED_MULTI_OUTPUT_KEY = "eventAuthoredMultiOutput";
 
     @Override
     public ItemStackRequestActionType getType() {
@@ -80,15 +81,17 @@ public class CraftRecipeActionProcessor implements ItemStackRequestActionProcess
             return handleStonecutter(player, stonecutterRecipe, action, context);
         }
 
-        // 合成前触发 CraftItemEvent 以供插件拦截。携带只读快照使 getTransaction() 与旧版路径一致
-        // Fire CraftItemEvent with a read-only snapshot so getTransaction() matches the legacy path
+        // MultiRecipe output is dynamic and is handled after the client result is
+        // server-validated below. Never expose a null primary output to listeners.
         Item recipeResult = recipe instanceof MultiRecipe ? null : recipe.getResult();
-        CraftingTransaction snapshot = new ItemStackRequestCraftingTransaction(
-                player, collectCraftingInputList(player), recipeResult, recipe);
-        CraftItemEvent craftEvent = new CraftItemEvent(snapshot);
-        Server.getInstance().getPluginManager().callEvent(craftEvent);
-        if (craftEvent.isCancelled()) {
-            return context.error();
+        if (recipeResult != null) {
+            if (recipe instanceof UserDataShapelessRecipe) {
+                applyInputNbt(recipeResult, collectCraftingInputList(player));
+            }
+            recipeResult = fireCraftItemEvent(player, recipe, recipeResult);
+            if (recipeResult == null) {
+                return context.error();
+            }
         }
 
         context.put(CreateActionProcessor.RECIPE_DATA_KEY, recipe);
@@ -113,6 +116,11 @@ public class CraftRecipeActionProcessor implements ItemStackRequestActionProcess
             if (!validateMultiRecipeConsumePlan(player, multiRecipe, output, context)) {
                 return context.error();
             }
+            Item authoritativeOutput = fireCraftItemEvent(player, recipe, output);
+            if (authoritativeOutput == null) {
+                return context.error();
+            }
+            context.put(EVENT_AUTHORED_MULTI_OUTPUT_KEY, authoritativeOutput);
             return context.success();
         }
 
@@ -143,16 +151,17 @@ public class CraftRecipeActionProcessor implements ItemStackRequestActionProcess
                         player.getName(), times);
                 return context.error();
             }
-            context.put(CreateActionProcessor.RECIPE_OUTPUTS_KEY, scaleItems(multiOutput.getAllResults(), times));
+            List<Item> outputs = scaleItems(multiOutput.getAllResults(), times);
+            Item authoritativePrimary = recipeResult.clone();
+            authoritativePrimary.setCount(authoritativePrimary.getCount() * times);
+            outputs.set(0, authoritativePrimary);
+            context.put(CreateActionProcessor.RECIPE_OUTPUTS_KEY, outputs);
             context.put(CreateActionProcessor.CREATED_SLOTS_KEY, new HashSet<>());
             return context.success();
         }
 
         Item output = recipeResult.clone();
         output.setCount(output.getCount() * times);
-        if (recipe instanceof UserDataShapelessRecipe) {
-            applyInputNbt(output, collectCraftingInputList(player));
-        }
         output.autoAssignStackNetworkId();
         player.getUIInventory().setItem(PlayerUIComponent.CREATED_ITEM_OUTPUT_UI_SLOT, output, false);
 
@@ -237,6 +246,9 @@ public class CraftRecipeActionProcessor implements ItemStackRequestActionProcess
         }
 
         Item finalOutput = event.getNewItem();
+        if (finalOutput == null || finalOutput.isNull()) {
+            return context.error();
+        }
         int finalCost = event.getXpCost();
 
         if (!player.isCreative()) {
@@ -260,6 +272,21 @@ public class CraftRecipeActionProcessor implements ItemStackRequestActionProcess
 
     private static boolean isApplicableEnchant(Enchantment enchantment, Item input) {
         return input.getId() == Item.BOOK || enchantment.canEnchant(input);
+    }
+
+    private static Item fireCraftItemEvent(Player player, Recipe recipe, Item output) {
+        if (output == null || output.isNull()) {
+            return null;
+        }
+        CraftingTransaction snapshot = new ItemStackRequestCraftingTransaction(
+                player, collectCraftingInputList(player), output, recipe);
+        CraftItemEvent craftEvent = new CraftItemEvent(snapshot);
+        Server.getInstance().getPluginManager().callEvent(craftEvent);
+        if (craftEvent.isCancelled()) {
+            return null;
+        }
+        Item eventOutput = snapshot.getPrimaryOutput();
+        return eventOutput == null || eventOutput.isNull() ? null : eventOutput.clone();
     }
 
     private ActionResponse handleTrade(CraftRecipeAction action, Player player, ItemStackRequestContext context) {
@@ -644,7 +671,8 @@ public class CraftRecipeActionProcessor implements ItemStackRequestActionProcess
         if (!validateSmithingConsumePlan(player, context, equipment, ingredient, template)) {
             return context.error();
         }
-        if (!fireSmithingEvent(smithingInventory, result, player)) {
+        result = fireSmithingEvent(smithingInventory, result, player);
+        if (result == null) {
             return context.error();
         }
         result.autoAssignStackNetworkId();
@@ -670,7 +698,8 @@ public class CraftRecipeActionProcessor implements ItemStackRequestActionProcess
                 smithingInventory.getEquipment(), smithingInventory.getIngredient(), smithingInventory.getTemplate())) {
             return context.error();
         }
-        if (!fireSmithingEvent(smithingInventory, result, player)) {
+        result = fireSmithingEvent(smithingInventory, result, player);
+        if (result == null) {
             return context.error();
         }
         result.autoAssignStackNetworkId();
@@ -690,9 +719,9 @@ public class CraftRecipeActionProcessor implements ItemStackRequestActionProcess
     /**
      * Mirror {@code SmithingTransaction.execute()}: plugins receive the full set
      * of input slots + projected output so they can veto smithing-table usage.
-     * Returns {@code false} when the event is cancelled.
+     * Returns the event-authoritative result, or {@code null} when cancelled.
      */
-    private static boolean fireSmithingEvent(SmithingInventory inventory, Item result, Player player) {
+    private static Item fireSmithingEvent(SmithingInventory inventory, Item result, Player player) {
         SmithingTableEvent event = new SmithingTableEvent(
                 inventory,
                 inventory.getEquipment().clone(),
@@ -702,7 +731,10 @@ public class CraftRecipeActionProcessor implements ItemStackRequestActionProcess
                 player
         );
         Server.getInstance().getPluginManager().callEvent(event);
-        return !event.isCancelled();
+        Item eventOutput = event.getResultItem();
+        return event.isCancelled() || eventOutput == null || eventOutput.isNull()
+                ? null
+                : eventOutput.clone();
     }
 
     /**
@@ -741,6 +773,11 @@ public class CraftRecipeActionProcessor implements ItemStackRequestActionProcess
         if (event.isCancelled()) {
             return context.error();
         }
+        Item eventOutput = event.getOutputItem();
+        if (eventOutput == null || eventOutput.isNull()) {
+            return context.error();
+        }
+        output = eventOutput.clone();
 
         context.put(CreateActionProcessor.RECIPE_DATA_KEY, recipe);
         output.autoAssignStackNetworkId();

--- a/src/main/java/cn/nukkit/inventory/request/CraftRecipeOptionalProcessor.java
+++ b/src/main/java/cn/nukkit/inventory/request/CraftRecipeOptionalProcessor.java
@@ -92,6 +92,11 @@ public class CraftRecipeOptionalProcessor implements ItemStackRequestActionProce
             if (repairEvent.isCancelled()) {
                 return context.error();
             }
+            Item eventOutput = repairEvent.getNewItem();
+            if (eventOutput == null || eventOutput.isNull()) {
+                return context.error();
+            }
+            result = eventOutput.clone();
             int finalCost = repairEvent.getCost();
             if (!player.isCreative() && finalCost > 0) {
                 if (player.getExperienceLevel() < finalCost) {

--- a/src/main/java/cn/nukkit/inventory/request/CraftResultDeprecatedActionProcessor.java
+++ b/src/main/java/cn/nukkit/inventory/request/CraftResultDeprecatedActionProcessor.java
@@ -43,7 +43,15 @@ public class CraftResultDeprecatedActionProcessor implements ItemStackRequestAct
                 if (!CraftRecipeActionProcessor.validateCraftingRecipe(player, recipe, output, 1)) {
                     return context.error();
                 }
-                context.put(MULTI_RESULTS_KEY, List.of(results));
+                Item eventOutput = context.get(CraftRecipeActionProcessor.EVENT_AUTHORED_MULTI_OUTPUT_KEY);
+                if (eventOutput == null || eventOutput.isNull()) {
+                    return context.error();
+                }
+                output = eventOutput.clone();
+                if (times != null && times > 1) {
+                    output.setCount(output.getCount() * times);
+                }
+                context.put(MULTI_RESULTS_KEY, List.of(output.clone()));
                 output.autoAssignStackNetworkId();
                 player.getUIInventory().setItem(PlayerUIComponent.CREATED_ITEM_OUTPUT_UI_SLOT, output, false);
                 ItemStackResponseSlot slot = new ItemStackResponseSlot(

--- a/src/main/java/cn/nukkit/inventory/transaction/CraftingTransaction.java
+++ b/src/main/java/cn/nukkit/inventory/transaction/CraftingTransaction.java
@@ -4,7 +4,6 @@ import cn.nukkit.Player;
 import cn.nukkit.Server;
 import cn.nukkit.event.inventory.CraftItemEvent;
 import cn.nukkit.inventory.*;
-import cn.nukkit.inventory.transaction.action.CraftingTakeResultAction;
 import cn.nukkit.inventory.transaction.action.InventoryAction;
 import cn.nukkit.inventory.transaction.action.SlotChangeAction;
 import cn.nukkit.item.Item;
@@ -77,10 +76,16 @@ public class CraftingTransaction extends InventoryTransaction {
     }
 
     public void setPrimaryOutput(Item item) {
+        if (item == null || item.isNull()) {
+            throw new IllegalArgumentException("Primary result item must not be null or air");
+        }
         if (primaryOutput == null) {
             primaryOutput = item.clone();
-        } else if (!primaryOutput.equals(item)) {
+        } else if (!primaryOutput.equals(item, true, false) || primaryOutput.getCount() != item.getCount()) {
             throw new RuntimeException("Primary result item has already been set and does not match the current item (expected " + primaryOutput + ", got " + item + ')');
+        } else {
+            // Same item identity may still carry event-authored NBT.
+            primaryOutput = item.clone();
         }
     }
 
@@ -115,35 +120,32 @@ public class CraftingTransaction extends InventoryTransaction {
 
     /**
      * Replaces the client-authored output with the server-rebuilt one, covering primaryOutput,
-     * CraftingTakeResultAction source and the inventory SlotChangeAction target, so that the
-     * authoritative NBT lands in the player's inventory.
+     * parsed result actions and inventory targets so that authoritative NBT lands
+     * in the player's inventory.
      */
     void applyAuthoritativeOutput(Item authoritativeOutput) {
-        if (authoritativeOutput == null || authoritativeOutput.equalsExact(this.primaryOutput)) {
+        Item rewritten = applyEventOutputToActions(this.primaryOutput, authoritativeOutput);
+        if (rewritten == null) {
             return;
         }
-
-        this.primaryOutput = authoritativeOutput.clone();
-
-        for (InventoryAction action : this.actions) {
-            if (action instanceof CraftingTakeResultAction resultAction) {
-                resultAction.setSourceItem(authoritativeOutput.clone());
-            } else if (action instanceof SlotChangeAction slotChangeAction) {
-                if (slotChangeAction.getSourceItem().isNull()
-                        && slotChangeAction.getTargetItem().getId() == authoritativeOutput.getId()
-                        && slotChangeAction.getTargetItem().getCount() > 0) {
-                    slotChangeAction.setTargetItem(authoritativeOutput.clone());
-                }
-            }
-        }
+        this.primaryOutput = rewritten;
     }
 
     @Override
     protected boolean callExecuteEvent() {
         CraftItemEvent ev;
+        Item originalOutput = this.primaryOutput == null ? null : this.primaryOutput.clone();
 
         this.source.getServer().getPluginManager().callEvent(ev = new CraftItemEvent(this));
-        return !ev.isCancelled();
+        if (ev.isCancelled()) {
+            return false;
+        }
+        Item rewritten = applyEventOutputToActions(originalOutput, this.primaryOutput);
+        if (rewritten == null) {
+            return false;
+        }
+        this.primaryOutput = rewritten;
+        return true;
     }
 
     @Override

--- a/src/main/java/cn/nukkit/inventory/transaction/EnchantTransaction.java
+++ b/src/main/java/cn/nukkit/inventory/transaction/EnchantTransaction.java
@@ -92,6 +92,7 @@ public class EnchantTransaction extends InventoryTransaction {
         }
 
         EnchantInventory inv = (EnchantInventory) getSource().getWindowById(Player.ENCHANT_WINDOW_ID);
+        Item originalOutput = this.outputItem.clone();
         EnchantItemEvent ev = new EnchantItemEvent(inv, inputItem, outputItem, cost, source);
         source.getServer().getPluginManager().callEvent(ev);
         if (ev.isCancelled()) {
@@ -100,6 +101,13 @@ public class EnchantTransaction extends InventoryTransaction {
             // Cancelled by plugin, means handled OK
             return true;
         }
+        Item authoritativeOutput = applyEventOutputToActions(originalOutput, ev.getNewItem());
+        if (authoritativeOutput == null) {
+            this.sendInventories();
+            source.setNeedSendInventory(true);
+            return true;
+        }
+        this.outputItem = authoritativeOutput;
 
         // This will process all the slot changes
         for (InventoryAction a : this.actions) {
@@ -108,12 +116,6 @@ public class EnchantTransaction extends InventoryTransaction {
             } else {
                 a.onExecuteFail(source);
             }
-        }
-
-        if (!ev.getNewItem().equals(this.outputItem, true, true)) {
-            // Plugin changed item, so the previous slot change is going to be invalid
-            // Send the replaced item to the enchant inventory manually
-            inv.setItem(0, ev.getNewItem(), true);
         }
 
         if (!source.isCreative()) {

--- a/src/main/java/cn/nukkit/inventory/transaction/GrindstoneTransaction.java
+++ b/src/main/java/cn/nukkit/inventory/transaction/GrindstoneTransaction.java
@@ -103,6 +103,7 @@ public class GrindstoneTransaction extends InventoryTransaction {
 
         GrindstoneInventory inventory = (GrindstoneInventory) getSource().getWindowById(Player.GRINDSTONE_WINDOW_ID);
         int experience = inventory.calculateExperience();
+        Item originalOutput = this.outputItem.clone();
         GrindItemEvent event = new GrindItemEvent(inventory, this.equipmentItem, this.outputItem, this.ingredientItem, experience, this.source);
         this.source.getServer().getPluginManager().callEvent(event);
         if (event.isCancelled()) {
@@ -110,6 +111,13 @@ public class GrindstoneTransaction extends InventoryTransaction {
             source.setNeedSendInventory(true);
             return true;
         }
+        Item authoritativeOutput = applyEventOutputToActions(originalOutput, event.getNewItem());
+        if (authoritativeOutput == null) {
+            this.sendInventories();
+            source.setNeedSendInventory(true);
+            return true;
+        }
+        this.outputItem = authoritativeOutput;
 
         for (InventoryAction action : this.actions) {
             if (action.execute(this.source)) {

--- a/src/main/java/cn/nukkit/inventory/transaction/InventoryTransaction.java
+++ b/src/main/java/cn/nukkit/inventory/transaction/InventoryTransaction.java
@@ -147,6 +147,30 @@ public class InventoryTransaction {
         this.inventories.add(inventory);
     }
 
+    /**
+     * Replaces every executable occurrence of a pre-event workstation output.
+     * Events are fired after the network action list is built, so changing only
+     * the event item would otherwise leave the old clone to be delivered.
+     *
+     * @return a detached authoritative output, or {@code null} for an invalid event output
+     */
+    protected final Item applyEventOutputToActions(Item originalOutput, Item eventOutput) {
+        if (originalOutput == null || eventOutput == null || eventOutput.isNull()) {
+            return null;
+        }
+
+        Item authoritativeOutput = eventOutput.clone();
+        for (InventoryAction action : this.actions) {
+            if (action.getSourceItem().equalsExact(originalOutput)) {
+                action.setSourceItem(authoritativeOutput.clone());
+            }
+            if (action.getTargetItem().equalsExact(originalOutput)) {
+                action.setTargetItem(authoritativeOutput.clone());
+            }
+        }
+        return authoritativeOutput;
+    }
+
     protected final Pattern TRIM_PATTERN = Pattern.compile("^minecraft:[a-z_]+_smithing_template$");
 
     protected boolean matchItems(boolean clientAuthTrim, boolean clientAuthLapis) {

--- a/src/main/java/cn/nukkit/inventory/transaction/RepairItemTransaction.java
+++ b/src/main/java/cn/nukkit/inventory/transaction/RepairItemTransaction.java
@@ -89,6 +89,7 @@ public class RepairItemTransaction extends InventoryTransaction {
             this.source.getServer().getLogger().debug("Got unexpected cost " + inventory.getCost() + " from " + this.source.getName() + " (expected " + this.cost + ')');
         }
 
+        Item originalOutput = this.outputItem.clone();
         RepairItemEvent event = new RepairItemEvent(inventory, this.inputItem, this.outputItem, this.materialItem, this.cost, this.source);
         this.source.getServer().getPluginManager().callEvent(event);
         if (event.isCancelled()) {
@@ -96,6 +97,13 @@ public class RepairItemTransaction extends InventoryTransaction {
             source.setNeedSendInventory(true);
             return true;
         }
+        Item authoritativeOutput = applyEventOutputToActions(originalOutput, event.getNewItem());
+        if (authoritativeOutput == null) {
+            this.sendInventories();
+            source.setNeedSendInventory(true);
+            return true;
+        }
+        this.outputItem = authoritativeOutput;
 
         for (InventoryAction action : this.actions) {
             if (action.execute(this.source)) {

--- a/src/main/java/cn/nukkit/inventory/transaction/SmithingTransaction.java
+++ b/src/main/java/cn/nukkit/inventory/transaction/SmithingTransaction.java
@@ -126,6 +126,7 @@ public class SmithingTransaction extends InventoryTransaction {
         Item equipment = equipmentItem != null? equipmentItem : air;
         Item ingredient = ingredientItem != null? ingredientItem : air;
         Item template = templateItem != null? templateItem : air;
+        Item originalOutput = this.outputItem.clone();
         SmithingTableEvent event = new SmithingTableEvent(inventory, equipment, outputItem, ingredient, template, source);
         this.source.getServer().getPluginManager().callEvent(event);
         if (event.isCancelled()) {
@@ -133,6 +134,13 @@ public class SmithingTransaction extends InventoryTransaction {
             source.setNeedSendInventory(true);
             return true;
         }
+        Item authoritativeOutput = applyEventOutputToActions(originalOutput, event.getResultItem());
+        if (authoritativeOutput == null) {
+            this.sendInventories();
+            source.setNeedSendInventory(true);
+            return true;
+        }
+        this.outputItem = authoritativeOutput;
 
         for (InventoryAction action : this.actions) {
             if (action.execute(this.source)) {

--- a/src/main/java/cn/nukkit/inventory/transaction/action/InventoryAction.java
+++ b/src/main/java/cn/nukkit/inventory/transaction/action/InventoryAction.java
@@ -54,6 +54,14 @@ public abstract class InventoryAction {
     }
 
     /**
+     * Replaces the source item of this action. Workstation transactions use this
+     * when an event authoritatively changes an output after actions were parsed.
+     */
+    public void setSourceItem(Item sourceItem) {
+        this.sourceItem = sourceItem;
+    }
+
+    /**
      * Replaces the target item of this action.
      */
     public void setTargetItem(Item targetItem) {

--- a/src/test/java/cn/nukkit/inventory/request/CakeCraftingReproTest.java
+++ b/src/test/java/cn/nukkit/inventory/request/CakeCraftingReproTest.java
@@ -3,7 +3,9 @@ package cn.nukkit.inventory.request;
 import cn.nukkit.GameVersion;
 import cn.nukkit.MockServer;
 import cn.nukkit.Player;
+import cn.nukkit.event.inventory.CraftItemEvent;
 import cn.nukkit.inventory.*;
+import cn.nukkit.inventory.special.RepairItemRecipe;
 import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemBucket;
 import cn.nukkit.network.protocol.DataPacket;
@@ -42,6 +44,7 @@ class CakeCraftingReproTest {
     static CraftingManager manager;
     static int cakeNetworkId;
     static int breadNetworkId;
+    static PluginManager pluginManager;
 
     @BeforeAll
     static void init() {
@@ -67,7 +70,7 @@ class CakeCraftingReproTest {
         ui = new PlayerUIInventory(player);
         inventory = new PlayerInventory(player);
         cn.nukkit.inventory.PlayerOffhandInventory offhand = new cn.nukkit.inventory.PlayerOffhandInventory(player);
-        PluginManager pluginManager = Mockito.mock(PluginManager.class);
+        pluginManager = Mockito.mock(PluginManager.class);
         Mockito.when(player.getUIInventory()).thenReturn(ui);
         Mockito.when(player.getInventory()).thenReturn(inventory);
         Mockito.when(player.getCursorInventory()).thenReturn(ui.getCursorInventory());
@@ -238,6 +241,78 @@ class CakeCraftingReproTest {
 
         assertOk();
         assertEquals(Item.BREAD, inventory.getItem(0).getId(), "bread should reach hotbar 0");
+    }
+
+    @Test
+    void eventAuthoredNbtReachesDeliveredSingleAndMultiOutputCrafts() {
+        authorCraftOutput("kit:craft");
+        ui.getBigCraftingGrid().setItem(0, Item.get(Item.WHEAT, 0, 1), false);
+        ui.getBigCraftingGrid().setItem(1, Item.get(Item.WHEAT, 0, 1), false);
+        ui.getBigCraftingGrid().setItem(2, Item.get(Item.WHEAT, 0, 1), false);
+        ItemStackRequest bread = new ItemStackRequest(1, join(
+                new CraftRecipeAction(breadNetworkId, 1),
+                new ConsumeAction(1, gridSlot(0)),
+                new ConsumeAction(1, gridSlot(1)),
+                new ConsumeAction(1, gridSlot(2)),
+                placeCreatedToHotbar(0, 1)
+        ), new String[0]);
+
+        ItemStackRequestHandler.handleRequests(player, List.of(bread));
+        assertOk();
+        assertEquals("kit:craft", inventory.getItem(0).getNamedTag().getString("km_origin"));
+
+        Mockito.clearInvocations(player);
+        fillGrid();
+        ItemStackRequest cake = new ItemStackRequest(2, join(
+                craftAction(), consumeAll(), createAction(0), placeCreatedToHotbar(1, 1)
+        ), new String[0]);
+
+        ItemStackRequestHandler.handleRequests(player, List.of(cake));
+        assertOk();
+        assertEquals("kit:craft", inventory.getItem(1).getNamedTag().getString("km_origin"));
+    }
+
+    @Test
+    void eventAuthoredNbtReachesDeliveredDynamicMultiRecipeOutput() {
+        authorCraftOutput("kit:multi");
+        RepairItemRecipe repair = manager.getMultiRecipes().values().stream()
+                .filter(RepairItemRecipe.class::isInstance)
+                .map(RepairItemRecipe.class::cast)
+                .findFirst()
+                .orElseThrow();
+        Item clean = Item.get(Item.DIAMOND_PICKAXE, 1000, 1);
+        Item tagged = Item.get(Item.DIAMOND_PICKAXE, 1000, 1);
+        tagged.setNamedTag(tagged.getOrCreateNamedTag().putString("km_origin", "kit:input"));
+        ui.getBigCraftingGrid().setItem(0, clean, false);
+        ui.getBigCraftingGrid().setItem(1, tagged, false);
+        Item repaired = Item.get(Item.DIAMOND_PICKAXE,
+                repair.calculateDamage(1000, 1000, clean.getMaxDurability()), 1);
+        ItemStackRequest request = new ItemStackRequest(3, join(
+                new CraftRecipeAction(repair.getNetworkId(), 1),
+                new CraftResultsDeprecatedAction(new Item[]{repaired}, 1),
+                new ConsumeAction(1, gridSlot(0)),
+                new ConsumeAction(1, gridSlot(1)),
+                createAction(0),
+                placeCreatedToHotbar(2, 1)
+        ), new String[0]);
+
+        ItemStackRequestHandler.handleRequests(player, List.of(request));
+
+        assertOk();
+        assertEquals("kit:multi", inventory.getItem(2).getNamedTag().getString("km_origin"));
+    }
+
+    private static void authorCraftOutput(String origin) {
+        Mockito.doAnswer(invocation -> {
+            Object called = invocation.getArgument(0);
+            if (called instanceof CraftItemEvent event) {
+                Item output = event.getTransaction().getPrimaryOutput().clone();
+                assertNotNull(output, "CraftItemEvent must never expose a null output");
+                output.setNamedTag(output.getOrCreateNamedTag().putString("km_origin", origin));
+                event.getTransaction().setPrimaryOutput(output);
+            }
+            return null;
+        }).when(pluginManager).callEvent(Mockito.any());
     }
 
     // H: 同一输出重复 Create

--- a/src/test/java/cn/nukkit/inventory/request/WorkstationEventOutputRequestTest.java
+++ b/src/test/java/cn/nukkit/inventory/request/WorkstationEventOutputRequestTest.java
@@ -1,0 +1,260 @@
+package cn.nukkit.inventory.request;
+
+import cn.nukkit.GameVersion;
+import cn.nukkit.MockServer;
+import cn.nukkit.Player;
+import cn.nukkit.block.Block;
+import cn.nukkit.event.inventory.EnchantItemEvent;
+import cn.nukkit.event.inventory.GrindItemEvent;
+import cn.nukkit.event.inventory.RepairItemEvent;
+import cn.nukkit.event.inventory.SmithingTableEvent;
+import cn.nukkit.event.inventory.StonecutterItemEvent;
+import cn.nukkit.inventory.*;
+import cn.nukkit.item.Item;
+import cn.nukkit.item.enchantment.Enchantment;
+import cn.nukkit.level.Level;
+import cn.nukkit.level.Position;
+import cn.nukkit.network.protocol.DataPacket;
+import cn.nukkit.network.protocol.ItemStackResponsePacket;
+import cn.nukkit.network.protocol.PlayerEnchantOptionsPacket;
+import cn.nukkit.network.protocol.types.inventory.ContainerSlotType;
+import cn.nukkit.network.protocol.types.inventory.itemstack.request.ItemStackRequest;
+import cn.nukkit.network.protocol.types.inventory.itemstack.request.ItemStackRequestSlotData;
+import cn.nukkit.network.protocol.types.inventory.itemstack.request.action.ConsumeAction;
+import cn.nukkit.network.protocol.types.inventory.itemstack.request.action.CraftGrindstoneAction;
+import cn.nukkit.network.protocol.types.inventory.itemstack.request.action.CraftRecipeAction;
+import cn.nukkit.network.protocol.types.inventory.itemstack.request.action.CraftRecipeOptionalAction;
+import cn.nukkit.network.protocol.types.inventory.itemstack.request.action.ItemStackRequestAction;
+import cn.nukkit.network.protocol.types.inventory.itemstack.request.action.PlaceAction;
+import cn.nukkit.network.protocol.types.inventory.itemstack.response.ItemStackResponseStatus;
+import cn.nukkit.plugin.PluginManager;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.atLeastOnce;
+
+class WorkstationEventOutputRequestTest {
+
+    private Player player;
+    private PlayerUIInventory ui;
+    private PlayerInventory inventory;
+    private PluginManager pluginManager;
+    private CraftingManager manager;
+    private Level level;
+
+    @BeforeAll
+    static void init() {
+        MockServer.init();
+        Item.initCreativeItems();
+    }
+
+    @BeforeEach
+    void setUp() {
+        MockServer.reset();
+        PlayerEnchantOptionsPacket.RECIPE_MAP.clear();
+        player = Mockito.mock(Player.class);
+        player.protocol = GameVersion.V1_26_20.getProtocol();
+        ui = new PlayerUIInventory(player);
+        inventory = new PlayerInventory(player);
+        pluginManager = Mockito.mock(PluginManager.class);
+        manager = new CraftingManager();
+        level = Mockito.mock(Level.class);
+
+        Mockito.when(player.getServer()).thenReturn(MockServer.get());
+        Mockito.when(player.getName()).thenReturn("test");
+        Mockito.when(player.getGameVersion()).thenReturn(GameVersion.V1_26_20);
+        Mockito.when(player.isCreative()).thenReturn(true);
+        Mockito.when(player.getUIInventory()).thenReturn(ui);
+        Mockito.when(player.getInventory()).thenReturn(inventory);
+        Mockito.when(player.getCursorInventory()).thenReturn(ui.getCursorInventory());
+        Mockito.when(player.getCraftingGrid()).thenReturn(ui.getCraftingGrid());
+        Mockito.when(player.getOffhandInventory()).thenReturn(new PlayerOffhandInventory(player));
+        Mockito.when(player.getLevel()).thenReturn(level);
+        Mockito.when(level.getBlock(Mockito.anyInt(), Mockito.anyInt(), Mockito.anyInt()))
+                .thenReturn(Block.get(Block.AIR));
+        Mockito.when(MockServer.get().getPluginManager()).thenReturn(pluginManager);
+        Mockito.when(MockServer.get().getCraftingManager()).thenReturn(manager);
+
+        Mockito.doAnswer(invocation -> {
+            Object event = invocation.getArgument(0);
+            Item output = null;
+            if (event instanceof RepairItemEvent e) {
+                output = e.getNewItem();
+            } else if (event instanceof GrindItemEvent e) {
+                output = e.getNewItem();
+            } else if (event instanceof EnchantItemEvent e) {
+                output = e.getNewItem();
+            } else if (event instanceof SmithingTableEvent e) {
+                output = e.getResultItem();
+            } else if (event instanceof StonecutterItemEvent e) {
+                output = e.getOutputItem();
+            }
+            if (output != null && !output.isNull()) {
+                output.setNamedTag(output.getOrCreateNamedTag().putString("km_origin", "kit:workstation"));
+            }
+            return null;
+        }).when(pluginManager).callEvent(Mockito.any());
+    }
+
+    @Test
+    void anvilEventOutputIsActuallyDelivered() {
+        AnvilInventory anvil = new AnvilInventory(ui, position());
+        bindWindow(anvil, Player.ANVIL_WINDOW_ID);
+        Item input = Item.get(Item.DIAMOND_SWORD, 10, 1).autoAssignStackNetworkId();
+        assertTrue(anvil.setItem(0, input, false));
+        input = anvil.getInputSlot();
+
+        request(new String[]{"renamed"},
+                new CraftRecipeOptionalAction(0, 0),
+                consume(1, ContainerSlotType.ANVIL_INPUT, 1, input),
+                place(0, 1));
+
+        assertDeliveredTag(0);
+    }
+
+    @Test
+    void grindstoneEventOutputIsActuallyDelivered() {
+        GrindstoneInventory grindstone = new GrindstoneInventory(ui, position());
+        bindWindow(grindstone, Player.GRINDSTONE_WINDOW_ID);
+        Item input = Item.get(Item.DIAMOND_SWORD, 200, 1);
+        input.addEnchantment(Enchantment.getEnchantment(Enchantment.ID_DAMAGE_ALL).setLevel(1));
+        input.autoAssignStackNetworkId();
+        assertTrue(grindstone.setItem(0, input, false));
+        input = grindstone.getEquipment();
+
+        request(new String[0],
+                new CraftGrindstoneAction(0, 1, 0),
+                consume(1, ContainerSlotType.GRINDSTONE_INPUT, 16, input),
+                place(1, 1));
+
+        assertDeliveredTag(1);
+    }
+
+    @Test
+    void enchantEventOutputIsActuallyDelivered() throws Exception {
+        EnchantInventory enchant = new EnchantInventory(ui, position());
+        bindWindow(enchant, Player.ENCHANT_WINDOW_ID);
+        Item input = Item.get(Item.DIAMOND_SWORD, 0, 1).autoAssignStackNetworkId();
+        assertTrue(enchant.setItem(0, input, false));
+        input = enchant.getInputSlot();
+        int recipeId = PlayerEnchantOptionsPacket.assignRecipeId(new PlayerEnchantOptionsPacket.EnchantOptionData(
+                1, 0,
+                List.of(new PlayerEnchantOptionsPacket.EnchantData(Enchantment.ID_DAMAGE_ALL, 1)),
+                List.of(), List.of(), "test", 0));
+        markPublishedOption(enchant, recipeId);
+
+        request(new String[0],
+                new CraftRecipeAction(recipeId, 1),
+                consume(1, ContainerSlotType.ENCHANTING_INPUT, 14, input),
+                place(2, 1));
+
+        assertDeliveredTag(2);
+    }
+
+    @Test
+    void smithingEventOutputIsActuallyDelivered() {
+        SmithingTransformRecipe recipe = manager.getSmithingRecipes().values().stream()
+                .filter(r -> r instanceof SmithingTransformRecipe)
+                .map(r -> (SmithingTransformRecipe) r)
+                .filter(r -> r.getResult().getId() == Item.NETHERITE_SWORD)
+                .findFirst()
+                .orElseThrow();
+        SmithingInventory smithing = new SmithingInventory(ui, position());
+        bindWindow(smithing, Player.SMITHING_WINDOW_ID);
+        Item equipment = recipe.getEquipment().clone().autoAssignStackNetworkId();
+        Item ingredient = recipe.getIngredient().clone().autoAssignStackNetworkId();
+        Item template = recipe.getTemplate().clone().autoAssignStackNetworkId();
+        smithing.setEquipment(equipment);
+        smithing.setIngredient(ingredient);
+        smithing.setTemplate(template);
+        equipment = smithing.getEquipment();
+        ingredient = smithing.getIngredient();
+        template = smithing.getTemplate();
+
+        request(new String[0],
+                new CraftRecipeAction(recipe.getNetworkId(), 1),
+                consume(1, ContainerSlotType.SMITHING_TABLE_INPUT, 51, equipment),
+                consume(1, ContainerSlotType.SMITHING_TABLE_MATERIAL, 52, ingredient),
+                consume(1, ContainerSlotType.SMITHING_TABLE_TEMPLATE, 53, template),
+                place(3, 1));
+
+        assertDeliveredTag(3);
+    }
+
+    @Test
+    void stonecutterEventOutputIsActuallyDelivered() {
+        StonecutterRecipe recipe = manager.getStonecutterRecipes().stream()
+                .filter(r -> !r.getIngredient().isNull() && !r.getResult().isNull())
+                .findFirst()
+                .orElseThrow();
+        StonecutterInventory stonecutter = new StonecutterInventory(ui, position());
+        bindWindow(stonecutter, Player.STONECUTTER_WINDOW_ID);
+        Item input = recipe.getIngredient().clone().autoAssignStackNetworkId();
+        assertTrue(stonecutter.setItem(0, input, false));
+        input = stonecutter.getInput();
+
+        request(new String[0],
+                new CraftRecipeAction(recipe.getNetworkId(), 1),
+                consume(recipe.getIngredient().getCount(), ContainerSlotType.STONECUTTER_INPUT, 3, input),
+                place(4, recipe.getResult().getCount()));
+
+        assertDeliveredTag(4);
+    }
+
+    private Position position() {
+        return new Position(0, 0, 0, level);
+    }
+
+    private void bindWindow(Inventory window, int windowId) {
+        Mockito.when(player.getTopWindow()).thenReturn(Optional.of(window));
+        Mockito.when(player.getWindowById(windowId)).thenReturn(window);
+        Mockito.when(player.getWindowId(window)).thenReturn(windowId);
+        Mockito.when(player.getWindowId(ui)).thenReturn(0);
+        Mockito.when(player.getWindowId(inventory)).thenReturn(0);
+    }
+
+    private static ConsumeAction consume(int count, ContainerSlotType type, int slot, Item item) {
+        return new ConsumeAction(count, new ItemStackRequestSlotData(type, slot, item.getStackNetId(), null));
+    }
+
+    private static PlaceAction place(int hotbarSlot, int count) {
+        return new PlaceAction(count,
+                new ItemStackRequestSlotData(ContainerSlotType.CREATED_OUTPUT,
+                        PlayerUIComponent.CREATED_ITEM_OUTPUT_UI_SLOT, 0, null),
+                new ItemStackRequestSlotData(ContainerSlotType.HOTBAR, hotbarSlot, 0, null));
+    }
+
+    private void request(String[] filters, ItemStackRequestAction... actions) {
+        ItemStackRequestHandler.handleRequests(player,
+                List.of(new ItemStackRequest(1, actions, filters)));
+        ArgumentCaptor<DataPacket> captor = ArgumentCaptor.forClass(DataPacket.class);
+        Mockito.verify(player, atLeastOnce()).dataPacket(captor.capture());
+        ItemStackResponsePacket response = captor.getAllValues().stream()
+                .filter(ItemStackResponsePacket.class::isInstance)
+                .map(ItemStackResponsePacket.class::cast)
+                .reduce((first, second) -> second)
+                .orElseThrow();
+        assertEquals(ItemStackResponseStatus.OK, response.entries.get(0).getResult());
+    }
+
+    private void assertDeliveredTag(int slot) {
+        assertEquals("kit:workstation", inventory.getItem(slot).getNamedTag().getString("km_origin"));
+        assertTrue(ui.getItem(PlayerUIComponent.CREATED_ITEM_OUTPUT_UI_SLOT).isNull());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void markPublishedOption(EnchantInventory inventory, int recipeId) throws Exception {
+        Field field = EnchantInventory.class.getDeclaredField("publishedOptionIds");
+        field.setAccessible(true);
+        ((Set<Integer>) field.get(inventory)).add(recipeId);
+    }
+}

--- a/src/test/java/cn/nukkit/inventory/transaction/EventAuthoredLegacyTransactionTest.java
+++ b/src/test/java/cn/nukkit/inventory/transaction/EventAuthoredLegacyTransactionTest.java
@@ -1,0 +1,200 @@
+package cn.nukkit.inventory.transaction;
+
+import cn.nukkit.MockServer;
+import cn.nukkit.Player;
+import cn.nukkit.block.Block;
+import cn.nukkit.event.inventory.CraftItemEvent;
+import cn.nukkit.event.inventory.EnchantItemEvent;
+import cn.nukkit.event.inventory.GrindItemEvent;
+import cn.nukkit.event.inventory.RepairItemEvent;
+import cn.nukkit.event.inventory.SmithingTableEvent;
+import cn.nukkit.event.inventory.StonecutterItemEvent;
+import cn.nukkit.inventory.*;
+import cn.nukkit.inventory.transaction.action.*;
+import cn.nukkit.item.Item;
+import cn.nukkit.level.Level;
+import cn.nukkit.level.Position;
+import cn.nukkit.network.protocol.types.NetworkInventoryAction;
+import cn.nukkit.plugin.PluginManager;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EventAuthoredLegacyTransactionTest {
+
+    private Player player;
+    private PlayerUIInventory ui;
+    private PlayerInventory inventory;
+    private PluginManager pluginManager;
+    private Level level;
+
+    @BeforeAll
+    static void init() {
+        MockServer.init();
+    }
+
+    @BeforeEach
+    void setUp() {
+        MockServer.reset();
+        player = Mockito.mock(Player.class);
+        player.craftingType = Player.CRAFTING_BIG;
+        ui = new PlayerUIInventory(player);
+        inventory = new PlayerInventory(player);
+        pluginManager = Mockito.mock(PluginManager.class);
+        level = Mockito.mock(Level.class);
+        player.level = level;
+
+        Mockito.when(player.getServer()).thenReturn(MockServer.get());
+        Mockito.when(player.getName()).thenReturn("test");
+        Mockito.when(player.isCreative()).thenReturn(true);
+        Mockito.when(player.getUIInventory()).thenReturn(ui);
+        Mockito.when(player.getInventory()).thenReturn(inventory);
+        Mockito.when(player.getCraftingGrid()).thenReturn(ui.getBigCraftingGrid());
+        Mockito.when(player.getCursorInventory()).thenReturn(ui.getCursorInventory());
+        Mockito.when(MockServer.get().getPluginManager()).thenReturn(pluginManager);
+        Mockito.when(level.getBlock(Mockito.anyInt(), Mockito.anyInt(), Mockito.anyInt()))
+                .thenReturn(Block.get(Block.AIR));
+
+        Mockito.doAnswer(invocation -> {
+            Object event = invocation.getArgument(0);
+            Item output = null;
+            if (event instanceof CraftItemEvent e) {
+                output = e.getTransaction().getPrimaryOutput().clone();
+                output.setNamedTag(output.getOrCreateNamedTag().putString("km_origin", "kit:legacy"));
+                e.getTransaction().setPrimaryOutput(output);
+                return null;
+            } else if (event instanceof RepairItemEvent e) {
+                output = e.getNewItem();
+            } else if (event instanceof GrindItemEvent e) {
+                output = e.getNewItem();
+            } else if (event instanceof EnchantItemEvent e) {
+                output = e.getNewItem();
+            } else if (event instanceof SmithingTableEvent e) {
+                output = e.getResultItem();
+            } else if (event instanceof StonecutterItemEvent e) {
+                output = e.getOutputItem();
+            }
+            if (output != null && !output.isNull()) {
+                output.setNamedTag(output.getOrCreateNamedTag().putString("km_origin", "kit:legacy"));
+            }
+            return null;
+        }).when(pluginManager).callEvent(Mockito.any());
+    }
+
+    @Test
+    void craftingEventOutputRewritesAndExecutesRealSlotAction() {
+        Item output = Item.get(Item.BREAD, 0, 1);
+        List<InventoryAction> actions = new ArrayList<>();
+        actions.add(new CraftingTakeResultAction(output.clone(), Item.get(Item.AIR)));
+        actions.add(delivery(0, output));
+        CraftingTransaction transaction = new CraftingTransaction(player, actions) {
+            @Override public boolean canExecute() { return true; }
+        };
+
+        assertTrue(transaction.execute());
+        assertDelivered(0);
+    }
+
+    @Test
+    void anvilEventOutputRewritesAndExecutesRealSlotAction() {
+        AnvilInventory anvil = new AnvilInventory(ui, position());
+        bindWindow(Player.ANVIL_WINDOW_ID, anvil);
+        Item output = Item.get(Item.DIAMOND_SWORD, 10, 1);
+        RepairItemTransaction transaction = new RepairItemTransaction(player, List.of(
+                new RepairItemAction(output.clone(), Item.get(Item.AIR), NetworkInventoryAction.SOURCE_TYPE_ANVIL_RESULT),
+                delivery(1, output))) {
+            @Override public boolean canExecute() { return true; }
+        };
+
+        assertTrue(transaction.execute());
+        assertDelivered(1);
+    }
+
+    @Test
+    void grindstoneEventOutputRewritesAndExecutesRealSlotAction() {
+        GrindstoneInventory grindstone = new GrindstoneInventory(ui, position());
+        bindWindow(Player.GRINDSTONE_WINDOW_ID, grindstone);
+        Item output = Item.get(Item.DIAMOND_SWORD, 10, 1);
+        GrindstoneTransaction transaction = new GrindstoneTransaction(player, List.of(
+                new GrindstoneItemAction(output.clone(), Item.get(Item.AIR), NetworkInventoryAction.SOURCE_TYPE_ANVIL_RESULT),
+                delivery(2, output))) {
+            @Override public boolean canExecute() { return true; }
+        };
+
+        assertTrue(transaction.execute());
+        assertDelivered(2);
+    }
+
+    @Test
+    void enchantEventOutputRewritesAndExecutesRealSlotAction() {
+        EnchantInventory enchant = new EnchantInventory(ui, position());
+        bindWindow(Player.ENCHANT_WINDOW_ID, enchant);
+        Item output = Item.get(Item.DIAMOND_SWORD, 0, 1);
+        EnchantTransaction transaction = new EnchantTransaction(player, List.of(
+                new EnchantingAction(output.clone(), Item.get(Item.AIR), NetworkInventoryAction.SOURCE_TYPE_ENCHANT_OUTPUT),
+                delivery(3, output))) {
+            @Override public boolean canExecute() { return true; }
+        };
+
+        assertTrue(transaction.execute());
+        assertDelivered(3);
+    }
+
+    @Test
+    void smithingEventOutputRewritesAndExecutesRealSlotAction() {
+        SmithingInventory smithing = new SmithingInventory(ui, position());
+        bindWindow(Player.SMITHING_WINDOW_ID, smithing);
+        Item output = Item.get(Item.NETHERITE_SWORD, 0, 1);
+        SmithingTransaction transaction = new SmithingTransaction(player, List.of(
+                new SmithingItemAction(output.clone(), Item.get(Item.AIR), 2),
+                delivery(4, output))) {
+            @Override public boolean canExecute() { return true; }
+        };
+
+        assertTrue(transaction.execute());
+        assertDelivered(4);
+    }
+
+    @Test
+    void stonecutterEventOutputIsUsedByItsRealManualDeliveryPath() {
+        StonecutterInventory stonecutter = new StonecutterInventory(ui, position());
+        bindWindow(Player.STONECUTTER_WINDOW_ID, stonecutter);
+        Item input = Item.get(Item.STONE, 0, 1);
+        Item output = Item.get(Item.STONE_BRICKS, 0, 1);
+        assertTrue(stonecutter.setItem(0, input, false));
+        CraftingManager manager = new CraftingManager();
+        manager.registerStonecutterRecipe(new StonecutterRecipe("test:stone", 0, output, input));
+        Mockito.when(MockServer.get().getCraftingManager()).thenReturn(manager);
+        StonecutterTransaction transaction = new StonecutterTransaction(player, List.of(
+                new StonecutterItemAction(Item.get(Item.AIR), input,
+                        NetworkInventoryAction.SOURCE_TYPE_CRAFTING_USE_INGREDIENT),
+                new StonecutterItemAction(output, Item.get(Item.AIR),
+                        NetworkInventoryAction.SOURCE_TYPE_CRAFTING_RESULT)));
+
+        assertTrue(transaction.execute());
+        assertDelivered(0);
+    }
+
+    private Position position() {
+        return new Position(0, 0, 0, level);
+    }
+
+    private void bindWindow(int id, Inventory window) {
+        Mockito.when(player.getWindowById(id)).thenReturn(window);
+    }
+
+    private SlotChangeAction delivery(int slot, Item output) {
+        return new SlotChangeAction(inventory, slot, Item.get(Item.AIR), output.clone());
+    }
+
+    private void assertDelivered(int slot) {
+        assertEquals("kit:legacy", inventory.getItem(slot).getNamedTag().getString("km_origin"));
+    }
+}


### PR DESCRIPTION
### Problem

Workstation transactions (crafting table, enchanting table, grindstone, smithing table, anvil,
and their `ItemStackRequest` counterparts) build the network action list **before** the plugin
event is fired. A plugin that changes the output item inside the event — adds NBT, renames it,
swaps enchantments — sees its change accepted, but the player receives the pre-event clone that
was captured earlier. The event looks honoured and is not.

### Fix

Treat the event result as authoritative: after the event returns, replace every executable
occurrence of the pre-event output in the parsed actions and inventory targets, so the item the
event authored is the item delivered. A cancelled event still cancels the transaction.

Both paths are covered — legacy `InventoryTransaction` and the server-authoritative
`ItemStackRequest` processors.

### Tests

`WorkstationEventOutputRequestTest`, `EventAuthoredLegacyTransactionTest` and
`CakeCraftingReproTest` (regression: ordinary crafting keeps working). Green on current master.