### PR TITLE
player: trust the requested name for offline lookups

### DIFF
--- a/src/main/java/cn/nukkit/OfflinePlayer.java
+++ b/src/main/java/cn/nukkit/OfflinePlayer.java
@@ -68,7 +68,12 @@ public class OfflinePlayer implements IPlayer {
         if (uuid != null) {
             this.namedTag.putLong("UUIDMost", uuid.getMostSignificantBits());
             this.namedTag.putLong("UUIDLeast", uuid.getLeastSignificantBits());
-        } else {
+        }
+
+        if (name != null) {
+            // The caller asked for this exact name, so answer with it. The name stored in the
+            // saved data belongs to the last session and goes stale as soon as the player renames
+            // their account, which silently made whitelist, op and ban act on the previous name.
             this.namedTag.putString("NameTag", name);
         }
     }


### PR DESCRIPTION
`Server#getOfflinePlayer(name)` resolves the UUID through the name lookup database and then hands
the UUID to `OfflinePlayer`, which reads `NameTag` out of the saved player data. That tag is
written by the last session, so it goes stale the moment the account is renamed: whitelist, op,
ban and unban all keep operating on the previous name while the console reports the name that was
typed.

Keep the requested name on the tag instead.

Compiles on current master; verified in game — after a rename, `whitelist add <new name>` now
whitelists the account the operator meant.