### PR TITLE
fix(network): never block the address of a player who already logged in

### DIFF
--- a/src/main/java/cn/nukkit/network/session/RakNetPlayerSession.java
+++ b/src/main/java/cn/nukkit/network/session/RakNetPlayerSession.java
@@ -577,8 +577,10 @@ public class RakNetPlayerSession extends SimpleChannelInboundHandler<RakMessage>
                     this.player
             );
             if (!result.success()) {
-                log.warn("[{}] Failed to decode batch packet ({} bytes, prefixed, raknetProtocol={}, legacyFallback={})",
-                        this.playerLabel(), packetBuffer.length, this.channel.config().getProtocolVersion(),
+                log.warn("[{}] Failed to decode batch packet ({} bytes, prefixed, prefix=0x{}, compressionIn={}, raknetProtocol={}, legacyFallback={})",
+                        this.playerLabel(), packetBuffer.length,
+                        packetBuffer.length > 0 ? Integer.toHexString(packetBuffer[0] & 0xFF) : "-",
+                        this.compressionIn, this.channel.config().getProtocolVersion(),
                         this.state.getSecurity().isLegacyInboundGraceWindow());
                 return false;
             }
@@ -656,10 +658,20 @@ public class RakNetPlayerSession extends SimpleChannelInboundHandler<RakMessage>
         return nowNanos - childChannelAcceptedNanos >= TimeUnit.MILLISECONDS.toNanos(timeoutMillis);
     }
 
+    /**
+     * Whether one malformed batch justifies blocking the whole address for a minute.
+     *
+     * <p>The block exists to stop a flood that never becomes a player: something sends a login
+     * packet and then garbage. A session that already reached {@link SessionLoginPhase#LOGGED_IN}
+     * is a real player who passed login, resource packs and spawn, so a single undecodable batch
+     * from it is a bug on one of the two sides, not an attack. Blocking that address kicks the
+     * player and then keeps him out for sixty seconds, which reads as a ban he cannot explain.
+     */
     static boolean shouldBlockAddressAfterMalformed(SessionLoginPhase phase, InetAddress address) {
         return address != null
                 && !address.isSiteLocalAddress()
-                && phase.ordinal() >= SessionLoginPhase.LOGIN_RECEIVED.ordinal();
+                && phase.ordinal() >= SessionLoginPhase.LOGIN_RECEIVED.ordinal()
+                && phase.ordinal() < SessionLoginPhase.LOGGED_IN.ordinal();
     }
 
     record InboundBatchDecodeResult(boolean success, CompressionProvider compression, boolean prefixed, List<DataPacket> packets) {

--- a/src/test/java/cn/nukkit/network/session/RakNetPlayerSessionTest.java
+++ b/src/test/java/cn/nukkit/network/session/RakNetPlayerSessionTest.java
@@ -308,7 +308,9 @@ class RakNetPlayerSessionTest {
         assertFalse(RakNetPlayerSession.shouldBlockAddressAfterMalformed(SessionLoginPhase.CONNECTED, address));
         assertFalse(RakNetPlayerSession.shouldBlockAddressAfterMalformed(SessionLoginPhase.NETWORK_SETTINGS_NEGOTIATED, address));
         assertTrue(RakNetPlayerSession.shouldBlockAddressAfterMalformed(SessionLoginPhase.LOGIN_RECEIVED, address));
-        assertTrue(RakNetPlayerSession.shouldBlockAddressAfterMalformed(SessionLoginPhase.LOGGED_IN, address));
+        assertTrue(RakNetPlayerSession.shouldBlockAddressAfterMalformed(SessionLoginPhase.RESOURCE_PACK, address));
+        assertFalse(RakNetPlayerSession.shouldBlockAddressAfterMalformed(SessionLoginPhase.LOGGED_IN, address));
+        assertFalse(RakNetPlayerSession.shouldBlockAddressAfterMalformed(SessionLoginPhase.DISCONNECTED, address));
     }
 
     @Test


### PR DESCRIPTION
A single undecodable batch from a session kicked the player and then blocked his address for sixty
seconds. The block is meant for floods that never become players, so it now stops at `LOGGED_IN`:
a session that passed login, resource packs and spawn is a real player, and one bad batch there is
a bug, not an attack. He reconnects immediately instead of waiting out a ban he was never told
about.

The prefixed-batch warning also carries the compression prefix byte and the negotiated inbound
compression now, so the decode failure itself can be chased on the default debug level.

### Tests

`RakNetPlayerSessionTest`. Green on current master.