### PR TITLE
player: refuse an elytra-less glide instead of kicking for it

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -4141,10 +4141,10 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                     if (chestplate == null || chestplate.getId() != ItemID.ELYTRA || chestplate.getDamage() >= chestplate.getMaxDurability()) {
                         withoutElytra = true;
                     }
-                    if (withoutElytra && !server.getAllowFlight()) {
-                        this.kick(PlayerKickEvent.Reason.FLYING_DISABLED, MSG_FLYING_NOT_ENABLED, true);
-                        return;
-                    }
+                    // A glide request without elytra is refused, never punished: the client asks
+                    // for it whenever the player double taps jump, which happens all the time when
+                    // a plugin takes the elytra off. Cancelling resyncs the client, and a player who
+                    // keeps rising without wings is still caught by the movement check below.
                     PlayerToggleGlideEvent playerToggleGlideEvent = new PlayerToggleGlideEvent(this, true);
                     if (this.riding != null || this.sleeping != null || withoutElytra) {
                         playerToggleGlideEvent.setCancelled(true);
@@ -4458,10 +4458,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                         if (chestplate == null || chestplate.getId() != ItemID.ELYTRA || chestplate.getDamage() >= chestplate.getMaxDurability()) {
                             withoutElytra = true;
                         }
-                        if (withoutElytra && !server.getAllowFlight()) {
-                            this.kick(PlayerKickEvent.Reason.FLYING_DISABLED, MSG_FLYING_NOT_ENABLED, true);
-                            return;
-                        }
+                        // Refused, not punished: see ACTION_START_GLIDING above.
                         PlayerToggleGlideEvent playerToggleGlideEvent = new PlayerToggleGlideEvent(this, true);
                         if (this.riding != null || this.sleeping != null || withoutElytra) {
                             playerToggleGlideEvent.setCancelled(true);


### PR DESCRIPTION
### Problem

A client sends `START_GLIDING` whenever the player double-taps jump, and it does so even when
there are no wings on — the check for elytra lives on the server. With `allow-flight` off the core
answers that request with a kick, so a player whose elytra had just been taken off (by a plugin,
by durability, or by any inventory move) is disconnected for pressing jump twice.

We hit this in combat: a plugin moves the elytra into a backpack when a fight starts, the player
keeps tapping jump to escape, and the third tap throws them off the server with "flying is not
enabled here".

### Fix

Refuse the request instead of kicking. Both call sites already cancel `PlayerToggleGlideEvent`
when the wings are missing, which resyncs the client and leaves `isGliding` false — so a player
who really does rise without wings still meets the ordinary movement check that kicks for flying.
Only the punishment for a legitimate key press is gone.

Compiles on current master; verified in game on 1.20 … 1.26.45 clients.