### PR TITLE
fix(entity): keep skin NPCs visible on modern Bedrock clients

### DIFF
--- a/src/main/java/cn/nukkit/entity/EntityHuman.java
+++ b/src/main/java/cn/nukkit/entity/EntityHuman.java
@@ -322,8 +322,7 @@ public class EntityHuman extends EntityHumanType {
                 throw new IllegalStateException(this.getClass().getSimpleName() + " must have a valid skin set");
             }
 
-            boolean retainNpcListEntry = !(this instanceof Player)
-                    && PlayerEntitySkinSender.requiresRetainedEntry(player);
+            boolean retainNpcListEntry = !(this instanceof Player);
             if (this instanceof Player) {
                 if (!player.sentSkins.contains(this.uuid)) {
                     this.server.updatePlayerListData(
@@ -331,8 +330,13 @@ public class EntityHuman extends EntityHumanType {
                             new Player[]{player});
                 }
             } else if (retainNpcListEntry) {
-                if (!PlayerEntitySkinSender.sendInitialSkinIfAbsent(
-                        player, this.uuid, this.getId(), this.getName(), this.getSkin(), "")) {
+                // The ADD entry always carries the blank placeholder skin. Modern Bedrock rejects a
+                // player-list entry that holds a full persona skin, and a rejected entry leaves the
+                // AddPlayerPacket below with nothing to draw: the doll vanishes completely instead
+                // of falling back to the default look. The real skin follows the spawn packet.
+                boolean registered = PlayerEntitySkinSender.sendInitialSkinIfAbsent(
+                        player, this.uuid, this.getId(), this.getName(), this.getSkin(), "");
+                if (!registered) {
                     this.hasSpawned.remove(player.getLoaderId());
                     return;
                 }
@@ -360,6 +364,13 @@ public class EntityHuman extends EntityHumanType {
             pk.metadata = this.dataProperties.clone();
             player.dataPacket(pk);
 
+            if (retainNpcListEntry) {
+                // Repaint the doll now that the entity exists. Sent before AddPlayerPacket, this
+                // skin update is dropped by international clients, which is why dolls used to stand
+                // as the default player until the entry itself carried the skin.
+                PlayerEntitySkinSender.sendSkinAfterSpawn(player, this.uuid, this.getSkin());
+            }
+
             if (playerInventory != null) {
                 if (this instanceof Player) {
                     playerInventory.sendArmorContents(player);
@@ -378,7 +389,7 @@ public class EntityHuman extends EntityHumanType {
                 player.dataPacket(pkk);
             }
 
-            // V860 分支由 PlayerEntitySkinSender 延迟移除，其余非 Player 实体立即移除。
+            // PlayerEntitySkinSender delays removal for every skin-bearing non-player entity.
             if (!(this instanceof Player) && !retainNpcListEntry) {
                 this.server.removePlayerListData(this.uuid, player);
             }
@@ -388,7 +399,6 @@ public class EntityHuman extends EntityHumanType {
     @Override
     public void despawnFrom(Player player) {
         boolean removeRetainedNpcEntry = !(this instanceof Player)
-                && PlayerEntitySkinSender.requiresRetainedEntry(player)
                 && this.hasSpawned.containsKey(player.getLoaderId());
         super.despawnFrom(player);
         if (removeRetainedNpcEntry) {

--- a/src/main/java/cn/nukkit/network/protocol/PlayerEntitySkinSender.java
+++ b/src/main/java/cn/nukkit/network/protocol/PlayerEntitySkinSender.java
@@ -89,6 +89,61 @@ public final class PlayerEntitySkinSender {
     }
 
     /**
+     * Registers a player-like entity for a client that applies the skin straight from the
+     * player-list entry: ADD carries the real skin, and the entry is removed after
+     * {@link #DELAYED_REMOVE_TICKS}.
+     * <p>
+     * The V860 handshake cannot be used here: its ADD entry carries a blank skin and relies on a
+     * follow-up {@link PlayerSkinPacket}, which international clients ignore for an entity that has
+     * not spawned yet, leaving the doll with the default player skin.
+     */
+    public static boolean sendSkinnedEntryIfAbsent(Player viewer, UUID uuid, long entityId,
+                                                   String name, Skin skin, String xboxUserId) {
+        Objects.requireNonNull(viewer, "viewer");
+        Objects.requireNonNull(uuid, "uuid");
+        Objects.requireNonNull(skin, "skin");
+
+        if (!viewer.sentSkins.add(uuid)) {
+            return true;
+        }
+
+        PlayerListPacket add = new PlayerListPacket();
+        add.type = PlayerListPacket.TYPE_ADD;
+        add.entries = new PlayerListPacket.Entry[]{
+                new PlayerListPacket.Entry(uuid, entityId, name, skin, xboxUserId)
+        };
+        if (!viewer.dataPacket(add)) {
+            unregister(viewer, uuid);
+            return false;
+        }
+
+        currentGeneration(viewer, uuid).incrementAndGet();
+        scheduleDelayedRemove(viewer, uuid);
+        return true;
+    }
+
+    /**
+     * Sends the real skin of a player-like entity right after its spawn packet.
+     * <p>
+     * The player-list entry only reserves the identity; the client applies a skin to an entity it
+     * already knows about, so this update has to travel after AddPlayerPacket.
+     */
+    public static void sendSkinAfterSpawn(Player viewer, UUID uuid, Skin skin) {
+        Objects.requireNonNull(viewer, "viewer");
+        Objects.requireNonNull(uuid, "uuid");
+        if (skin == null || !skin.isValid()) {
+            return;
+        }
+
+        PlayerSkinPacket update = new PlayerSkinPacket();
+        update.uuid = uuid;
+        update.skin = skin;
+        update.newSkinName = skin.getSkinId();
+        update.oldSkinName = "";
+        viewer.dataPacket(update);
+    }
+
+    /**
      * 以 REMOVE → ADD 原子顺序替换已注册的 V860 玩家列表项。
      * <p>
      * Replaces a registered V860 player-list entry using the safe REMOVE → ADD order.


### PR DESCRIPTION
### Problem

A non-player `EntityHuman` (statue, world bot, clone) is announced with a temporary player-list
entry, spawned with `AddPlayerPacket` and then removed from the list again. Two parts of that
dance break on recent international clients:

1. **Removing the temporary entry in the same tick as `AddPlayer` disconnects them.** NetEase
   clients already went through a guarded five-tick removal path; international ones did not.
2. **A full persona skin inside the ADD entry is rejected by 1.26.x**, and a rejected entry leaves
   `AddPlayerPacket` with no identity to draw — the doll disappears entirely instead of standing
   with the default look.

### Fix

Every non-player `EntityHuman` takes the delayed removal path (real `Player` skin handling is
unchanged), the ADD entry carries the blank placeholder skin for every client, and the real skin
is sent right **after** `AddPlayerPacket` — the point where the client has an entity to repaint.
A `PlayerSkinPacket` that arrives before the spawn is dropped by the client, which is why the
order matters.

Compiles on current master; verified in game on 1.20 … 1.26.45: NPCs are visible and wear their
own skin on both halves of that range.