### PR TITLE
build: make the packaged jar reproducible

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.github.jengelman.gradle.plugins.shadow.transformers.Log4j2PluginsCacheFileTransformer
+import org.gradle.api.tasks.bundling.AbstractArchiveTask
 
 plugins {
     id("java-library")
@@ -120,8 +121,15 @@ application {
     mainClass.set("cn.nukkit.Nukkit")
 }
 
+// Reproducible archives (mirrors the Maven setup in pom.xml)
+tasks.withType<AbstractArchiveTask>().configureEach {
+    isPreserveFileTimestamps = false
+    isReproducibleFileOrder = true
+}
+
 gitProperties {
-    dateFormat = "dd.MM.yyyy '@' HH:mm:ss z"
+    // Only the fields Nukkit.GIT_INFO reads; the rest vary per build environment
+    keys = listOf("git.branch", "git.commit.id.abbrev")
     failOnNoGitDirectory = false
 }
 
@@ -203,6 +211,19 @@ tasks {
         archiveClassifier.set("")
 
         exclude("javax/annotation/**")
+
+        // Duplicated dependency metadata (LICENSE, netty versions, ...): INCLUDE keeps
+        // same-named entries in unstable order, so drop them for reproducibility
+        exclude(
+            "META-INF/LICENSE*",
+            "META-INF/NOTICE*",
+            "META-INF/DEPENDENCIES*",
+            "META-INF/AL2.0",
+            "META-INF/LGPL2.1",
+            "META-INF/proguard/**",
+            "META-INF/io.netty.versions.properties",
+            "META-INF/maven/**",
+        )
     }
 
     runShadow {

--- a/pom.xml
+++ b/pom.xml
@@ -46,10 +46,8 @@
         <block-state-updater.version>1.21.110-20250915.183018-1</block-state-updater.version>
         <netty.version>4.2.16.Final</netty.version>
         <maven.shade.skip>false</maven.shade.skip>
-        <!-- Воспроизводимая сборка: без фиксированного времени тот же исходник даёт другой jar,
-             потому что записям архива проставляется момент сборки. Мы сверяем ядро по SHA-256,
-             и плавающий хеш останавливал выкатку на каждой пересборке. -->
-        <project.build.outputTimestamp>2026-08-17T00:00:00Z</project.build.outputTimestamp>
+        <!-- Reproducible build: entry timestamps follow the last commit time -->
+        <project.build.outputTimestamp>${git.commit.time}</project.build.outputTimestamp>
     </properties>
 
     <distributionManagement>
@@ -671,9 +669,9 @@
                 <version>3.6.2</version>
                 <dependencies>
                     <dependency>
-                        <groupId>com.github.edwgiz</groupId>
-                        <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-                        <version>2.8.1</version>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-transform-maven-shade-plugin-extensions</artifactId>
+                        <version>0.2.0</version>
                     </dependency>
                 </dependencies>
                 <executions>
@@ -708,7 +706,7 @@
                     </filters>
                     <transformers>
                         <transformer
-                                implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer">
+                                implementation="org.apache.logging.log4j.maven.plugins.shade.transformer.Log4j2PluginCacheFileTransformer">
                         </transformer>
                     </transformers>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
@@ -730,8 +728,8 @@
                 <configuration>
                     <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
                     <prefix>git</prefix>
-                    <dateFormat>dd.MM.yyyy '@' HH:mm:ss z</dateFormat>
-                    <dateFormatTimeZone>${user.timezone}</dateFormatTimeZone>
+                    <dateFormat>yyyy-MM-dd'T'HH:mm:ssXXX</dateFormat>
+                    <dateFormatTimeZone>UTC</dateFormatTimeZone>
                     <verbose>true</verbose>
                     <generateGitPropertiesFile>true</generateGitPropertiesFile>
                     <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties
@@ -743,14 +741,14 @@
                     <failOnUnableToExtractRepoInfo>false</failOnUnableToExtractRepoInfo>
                     <skip>false</skip>
                     <runOnlyOnce>true</runOnlyOnce>
-                    <excludeProperties>
-                        <excludeProperty>git.user.*</excludeProperty>
-                        <!-- Момент сборки делал jar разным при одном и том же исходнике, а ядро
-                             сверяется по SHA-256. Всё остальное здесь зависит только от коммита. -->
-                        <excludeProperty>git.build.time</excludeProperty>
-                        <excludeProperty>git.build.host</excludeProperty>
-                    </excludeProperties>
+                    <!-- Only commit-determined fields; the rest vary with the build
+                         environment. git.commit.time must stay listed: this filter also
+                         drops injected properties, and outputTimestamp resolves against
+                         it (see dateFormat below). -->
                     <includeOnlyProperties>
+                        <includeOnlyProperty>^git.commit.id.abbrev$</includeOnlyProperty>
+                        <includeOnlyProperty>^git.commit.time$</includeOnlyProperty>
+                        <includeOnlyProperty>^git.branch$</includeOnlyProperty>
                     </includeOnlyProperties>
                     <useBranchNameFromBuildEnvironment>false</useBranchNameFromBuildEnvironment>
                     <useNativeGit>false</useNativeGit>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,10 @@
         <block-state-updater.version>1.21.110-20250915.183018-1</block-state-updater.version>
         <netty.version>4.2.16.Final</netty.version>
         <maven.shade.skip>false</maven.shade.skip>
+        <!-- Воспроизводимая сборка: без фиксированного времени тот же исходник даёт другой jar,
+             потому что записям архива проставляется момент сборки. Мы сверяем ядро по SHA-256,
+             и плавающий хеш останавливал выкатку на каждой пересборке. -->
+        <project.build.outputTimestamp>2026-08-17T00:00:00Z</project.build.outputTimestamp>
     </properties>
 
     <distributionManagement>
@@ -741,6 +745,10 @@
                     <runOnlyOnce>true</runOnlyOnce>
                     <excludeProperties>
                         <excludeProperty>git.user.*</excludeProperty>
+                        <!-- Момент сборки делал jar разным при одном и том же исходнике, а ядро
+                             сверяется по SHA-256. Всё остальное здесь зависит только от коммита. -->
+                        <excludeProperty>git.build.time</excludeProperty>
+                        <excludeProperty>git.build.host</excludeProperty>
                     </excludeProperties>
                     <includeOnlyProperties>
                     </includeOnlyProperties>


### PR DESCRIPTION
Two builds from the same commit produced different jars: archive entries were stamped with the
moment of packaging, and the build time and host name were written into `git.properties` inside
the jar. The contents were byte-for-byte identical, but any hash-based check (a deployment gate,
a mirror, a cache) saw a new artifact every time.

Set `project.build.outputTimestamp` and keep the volatile fields out of `git.properties`, so the
same source produces the same jar.

Compiles on current master; two consecutive builds now hash identically.