### PR TITLE
fix(entity): let custom entities work without experiment mode

### DIFF
--- a/src/main/java/cn/nukkit/entity/Entity.java
+++ b/src/main/java/cn/nukkit/entity/Entity.java
@@ -1420,7 +1420,7 @@ public abstract class Entity extends Location implements Metadatable {
         }
     }
 
-    private static int correctEntityIdentifiersProtocol(int protocolId) {
+    public static int correctEntityIdentifiersProtocol(int protocolId) {
         if (protocolId >= ProtocolInfo.v1_19_80) {
             return ProtocolInfo.v1_19_80;
         } else if (protocolId >= ProtocolInfo.v1_19_20) {

--- a/src/main/java/cn/nukkit/entity/custom/EntityManager.java
+++ b/src/main/java/cn/nukkit/entity/custom/EntityManager.java
@@ -80,7 +80,7 @@ public class EntityManager {
                     new ByteArrayInputStream(Entity.getEntityIdentifiersCache(protocol)));
             ListTag<CompoundTag> listTag = compoundTag.getList("idlist", CompoundTag.class);
             for (EntityDefinition entityDefinition : this.identifierToDefinition.values()) {
-                listTag.add(protocol <= 407 ? entityDefinition.getNetworkTagOld() : entityDefinition.getNetworkTag());
+                listTag.add(protocol <= ProtocolInfo.v1_16_0 ? entityDefinition.getNetworkTagOld() : entityDefinition.getNetworkTag());
             }
             compoundTag.putList(listTag);
             return NBTIO.writeNetwork(compoundTag);
@@ -91,22 +91,34 @@ public class EntityManager {
 
     /**
      * Vanilla identifier list of that very protocol plus every registered custom entity.
+     * <p>
+     * Any protocol version may be passed in; the legacy ({@code <= 1.16.0}) vs modern
+     * network tag format is picked automatically, and the result is cached per
+     * identifier bucket so protocols sharing a vanilla list share one cache entry.
      */
     public byte[] getNetworkTagCached(int protocol) {
-        byte[] cached = this.networkTagCache.get(protocol);
+        int cacheKey = Entity.correctEntityIdentifiersProtocol(protocol);
+        if (cacheKey == ProtocolInfo.v1_10_0 && protocol > ProtocolInfo.v1_16_0) {
+            // 408~418 (1.16.20 ~ 1.16.100 beta) share the v1_10_0 vanilla list but use
+            // the modern network tag, so they cannot reuse the <= v1_16_0 entry
+            cacheKey = ProtocolInfo.v1_16_20;
+        }
+        byte[] cached = this.networkTagCache.get(cacheKey);
         if (cached == null) {
-            cached = this.createNetworkTag(protocol);
-            this.networkTagCache.put(protocol, cached);
+            cached = this.createNetworkTag(cacheKey);
+            this.networkTagCache.put(cacheKey, cached);
         }
         return cached;
     }
 
+    @Deprecated
     public byte[] getNetworkTagCached() {
         return this.getNetworkTagCached(ProtocolInfo.CURRENT_PROTOCOL);
     }
 
+    @Deprecated
     public byte[] getNetworkTagCachedOld() {
-        return this.getNetworkTagCached(407);
+        return this.getNetworkTagCached(ProtocolInfo.v1_16_0);
     }
 
     public boolean hasCustomEntities() {

--- a/src/main/java/cn/nukkit/entity/custom/EntityManager.java
+++ b/src/main/java/cn/nukkit/entity/custom/EntityManager.java
@@ -5,7 +5,6 @@ import cn.nukkit.entity.Entity;
 import cn.nukkit.nbt.NBTIO;
 import cn.nukkit.nbt.tag.CompoundTag;
 import cn.nukkit.nbt.tag.ListTag;
-import cn.nukkit.network.protocol.AvailableEntityIdentifiersPacket;
 import cn.nukkit.network.protocol.ProtocolInfo;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
@@ -20,8 +19,7 @@ public class EntityManager {
     private final Map<String, EntityDefinition> alternateNameToDefinition = new HashMap<>();
     private final Int2ObjectMap<EntityDefinition> runtimeIdToDefinition = new Int2ObjectOpenHashMap<>();
     private final Map<String, Integer> legacy_ids = new HashMap<>();
-    private byte[] networkTagCached;
-    private byte[] networkTagCachedOld;
+    private final Int2ObjectMap<byte[]> networkTagCache = new Int2ObjectOpenHashMap<>();
 
     public static EntityManager get() {
         return ENTITY_MANAGER;
@@ -34,11 +32,6 @@ public class EntityManager {
     }
 
     public void registerDefinition(EntityDefinition entityDefinition) {
-        if (!Server.getInstance().enableExperimentMode) {
-            Server.getInstance().getLogger().warning("The server does not have the experiment mode feature enabled. Unable to register custom entity!");
-            return;
-        }
-
         if (this.identifierToDefinition.containsKey(entityDefinition.getIdentifier())) {
             throw new IllegalArgumentException("Custom entity " + entityDefinition.getIdentifier() + " was already registered");
         }
@@ -58,8 +51,7 @@ public class EntityManager {
             this.alternateNameToDefinition.put(entityDefinition.getAlternateName(), entityDefinition);
         }
 
-        this.networkTagCachedOld = null;
-        this.networkTagCached = null;
+        this.networkTagCache.clear();
     }
 
     public EntityDefinition getDefinition(String string) {
@@ -82,36 +74,39 @@ public class EntityManager {
         return entityDefinition.getRuntimeId();
     }
 
-    private void createNetworkTagCached(int protocol) {
+    private byte[] createNetworkTag(int protocol) {
         try {
-            CompoundTag compoundTag = (CompoundTag)NBTIO.readNetwork(new ByteArrayInputStream(AvailableEntityIdentifiersPacket.TAG));
+            CompoundTag compoundTag = (CompoundTag) NBTIO.readNetwork(
+                    new ByteArrayInputStream(Entity.getEntityIdentifiersCache(protocol)));
             ListTag<CompoundTag> listTag = compoundTag.getList("idlist", CompoundTag.class);
             for (EntityDefinition entityDefinition : this.identifierToDefinition.values()) {
                 listTag.add(protocol <= 407 ? entityDefinition.getNetworkTagOld() : entityDefinition.getNetworkTag());
             }
             compoundTag.putList(listTag);
-            if (protocol > 407) {
-                this.networkTagCached = NBTIO.writeNetwork(compoundTag);
-            } else {
-                this.networkTagCachedOld = NBTIO.writeNetwork(compoundTag);
-            }
-        }catch (Exception e) {
+            return NBTIO.writeNetwork(compoundTag);
+        } catch (Exception e) {
             throw new RuntimeException("Unable to init entityIdentifiers", e);
         }
     }
 
-    public byte[] getNetworkTagCached() {
-        if (this.networkTagCached == null) {
-            this.createNetworkTagCached(ProtocolInfo.CURRENT_PROTOCOL);
+    /**
+     * Vanilla identifier list of that very protocol plus every registered custom entity.
+     */
+    public byte[] getNetworkTagCached(int protocol) {
+        byte[] cached = this.networkTagCache.get(protocol);
+        if (cached == null) {
+            cached = this.createNetworkTag(protocol);
+            this.networkTagCache.put(protocol, cached);
         }
-        return this.networkTagCached;
+        return cached;
+    }
+
+    public byte[] getNetworkTagCached() {
+        return this.getNetworkTagCached(ProtocolInfo.CURRENT_PROTOCOL);
     }
 
     public byte[] getNetworkTagCachedOld() {
-        if (this.networkTagCachedOld == null) {
-            this.createNetworkTagCached(407);
-        }
-        return this.networkTagCachedOld;
+        return this.getNetworkTagCached(407);
     }
 
     public boolean hasCustomEntities() {

--- a/src/main/java/cn/nukkit/network/protocol/AvailableEntityIdentifiersPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/AvailableEntityIdentifiersPacket.java
@@ -1,7 +1,6 @@
 package cn.nukkit.network.protocol;
 
 import cn.nukkit.Nukkit;
-import cn.nukkit.Server;
 import cn.nukkit.entity.Entity;
 import cn.nukkit.entity.custom.EntityManager;
 import com.google.common.io.ByteStreams;
@@ -51,13 +50,10 @@ public class AvailableEntityIdentifiersPacket extends DataPacket {
     @Override
     public void encode() {
         this.reset();
-        if (Server.getInstance().enableExperimentMode) { //自定义实体
-            if (this.protocol <= ProtocolInfo.v1_16_0) {
-                this.put(EntityManager.get().getNetworkTagCachedOld());
-            } else {
-                this.put(EntityManager.get().getNetworkTagCached());
-            }
-        }else {
+        if (EntityManager.get().hasCustomEntities()) { // custom entities
+            this.put(EntityManager.get().getNetworkTagCached(
+                    this.protocol <= ProtocolInfo.v1_16_0 ? 407 : this.protocol));
+        } else {
             if (this.identifiers == null) {
                 this.identifiers = Entity.getEntityIdentifiersCache(this.protocol);
             }

--- a/src/main/java/cn/nukkit/network/protocol/AvailableEntityIdentifiersPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/AvailableEntityIdentifiersPacket.java
@@ -51,8 +51,7 @@ public class AvailableEntityIdentifiersPacket extends DataPacket {
     public void encode() {
         this.reset();
         if (EntityManager.get().hasCustomEntities()) { // custom entities
-            this.put(EntityManager.get().getNetworkTagCached(
-                    this.protocol <= ProtocolInfo.v1_16_0 ? 407 : this.protocol));
+            this.put(EntityManager.get().getNetworkTagCached(this.protocol));
         } else {
             if (this.identifiers == null) {
                 this.identifiers = Entity.getEntityIdentifiersCache(this.protocol);


### PR DESCRIPTION
### Problem

Registering a custom entity requires `enable-experiment-mode: true`, and that switch does much
more than custom entities: with it on, the server mixes the enabled experiment toggles into
`ResourcePackStackPacket`. The client then re-validates the whole pack stack against them and
rejects packs that do not declare the same experiments — fatal for a server whose resource pack is
mandatory. So the switch has to stay off, and with it off custom entities cannot exist at all.

### Fix

Custom entities need no client-side experiment: the client draws them from the resource pack
alone, as long as the identifier reaches it in `AvailableEntityIdentifiers`. Gate both places on
the thing that actually matters — whether any custom entity is registered — and leave the
experiment toggles out of the pack stack when none are.

The identifiers NBT is also cached per protocol instead of being rebuilt for every login.

Compiles on current master; running in production with custom entities and a mandatory pack on
1.20 … 1.26.45.