### PR TITLE
item: let custom items work without experiment mode

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -3433,7 +3433,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                             Set<Entry<String, CustomItemDefinition>> itemDefinitions = Item.getCustomItemDefinition().entrySet();
                             List<ItemComponentPacket.ItemDefinition> entries = new ArrayList<>(vanillaItems.size() + itemDefinitions.size());
                             entries.addAll(vanillaItems);
-                            if (this.server.enableExperimentMode && !itemDefinitions.isEmpty()) {
+                            if (!itemDefinitions.isEmpty()) {
                                 for (Entry<String, CustomItemDefinition> entry : itemDefinitions) {
                                     try {
                                         Item item = Item.fromString(entry.getKey());
@@ -3452,7 +3452,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                             }
                             itemComponentPacket.setEntries(entries);
                         } else {
-                            if (this.server.enableExperimentMode && !Item.getCustomItemDefinition().isEmpty()) {
+                            if (!Item.getCustomItemDefinition().isEmpty()) {
                                 HashMap<String, CustomItemDefinition> itemDefinition = Item.getCustomItemDefinition();
                                 List<ItemComponentPacket.ItemDefinition> entries = new ArrayList<>(itemDefinition.size());
                                 int i = 0;

--- a/src/main/java/cn/nukkit/item/Item.java
+++ b/src/main/java/cn/nukkit/item/Item.java
@@ -953,11 +953,6 @@ public class Item implements Cloneable, BlockID, ItemID, ItemNamespaceId, Protoc
     }
 
     public static OK<?> registerCustomItem(@NotNull Class<? extends CustomItem> clazz, boolean addCreativeItem) {
-        if (!Server.getInstance().enableExperimentMode) {
-            Server.getInstance().getLogger().warning("The server does not have the experiment mode feature enabled. Unable to register the custom item!");
-            return new OK<>(false, "The server does not have the experiment mode feature enabled. Unable to register the custom item!");
-        }
-
         CustomItem customItem;
         Supplier<Item> supplier;
 

--- a/src/main/java/cn/nukkit/item/RuntimeItemMapping.java
+++ b/src/main/java/cn/nukkit/item/RuntimeItemMapping.java
@@ -247,9 +247,6 @@ public class RuntimeItemMapping {
     synchronized boolean registerCustomItem(CustomItem customItem) {
         int runtimeId = CustomItemDefinition.getRuntimeId(customItem.getNamespaceId());
         String namespaceId = customItem.getNamespaceId();
-        if (!Server.getInstance().enableExperimentMode) {
-            return false;
-        }
         if (!this.customItems.contains(namespaceId)) { //多个版本共用一个RuntimeItemMapping时，重复不返回false
             this.customItems.add(namespaceId);
 
@@ -270,7 +267,7 @@ public class RuntimeItemMapping {
 
     synchronized void deleteCustomItem(CustomItem customItem) {
         String namespaceId = customItem.getNamespaceId();
-        if (!Server.getInstance().enableExperimentMode && !this.customItems.contains(namespaceId)) {
+        if (!this.customItems.contains(namespaceId)) {
             return;
         }
         this.customItems.remove(namespaceId);
@@ -299,7 +296,7 @@ public class RuntimeItemMapping {
         BinaryStream paletteBuffer = new BinaryStream();
         int size = 0;
         for (RuntimeEntry entry : this.itemPaletteEntries) {
-            if (entry.isCustomItem() && (!Server.getInstance().enableExperimentMode || protocolId < ProtocolInfo.v1_16_100)) {
+            if (entry.isCustomItem() && protocolId < ProtocolInfo.v1_16_100) {
                 break;
             }
             size++;
@@ -307,7 +304,7 @@ public class RuntimeItemMapping {
         paletteBuffer.putUnsignedVarInt(size);
         for (RuntimeEntry entry : this.itemPaletteEntries) {
             if (entry.isCustomItem()) {
-                if (Server.getInstance().enableExperimentMode && protocolId >= ProtocolInfo.v1_16_100) {
+                if (protocolId >= ProtocolInfo.v1_16_100) {
                     paletteBuffer.putString(entry.getIdentifier());
                     paletteBuffer.putLShort(entry.getRuntimeId());
                     var def = Item.getCustomItemDefinition(entry.getIdentifier());


### PR DESCRIPTION
### Problem

Custom items are gated on `enable-experiment-mode` in four places: the registry
(`Item#registerCustomItem`), the runtime mapping (`RuntimeItemMapping#registerCustomItem` and
`#generatePalette`) and the login sequence that fills `ItemComponentPacket`.

That switch does much more than custom items: with it on, the server mixes the enabled experiment
toggles into `ResourcePackStackPacket`, the client re-validates the whole pack stack against them
and rejects packs that do not declare the same experiments. On a server whose resource pack is
mandatory that is a closed door — so the switch stays off, and with it off custom items cannot
exist at all.

### Fix

Custom items need no client-side experiment on a modern client: it draws them from the resource
pack (`item_texture.json` plus the attachable) as soon as the definition reaches it in
`ItemComponentPacket`. Gate the four places on whether any custom item is registered, and keep the
pre-1.16.100 protocols out of the custom item palette where the packet does not exist.

Compiles on current master; running in production with custom items and a mandatory pack on
1.20 … 1.26.45.