### PR TITLE
player: refuse a stale flight request instead of kicking for it

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -4248,7 +4248,12 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
 
                     if (authPacket.getInputData().contains(AuthInputAction.START_FLYING)) {
                         if (!server.getAllowFlight() && !this.getAdventureSettings().get(Type.ALLOW_FLIGHT)) {
-                            this.kick(PlayerKickEvent.Reason.FLYING_DISABLED, "Flying is not enabled on this server");
+                            // Refused, never punished: the client keeps asking to fly for a while
+                            // after the server has taken the permission away (game mode change, a
+                            // plugin revoking flight), and a stale request is not a cheat. Resending
+                            // the adventure settings puts the client back on the ground; someone who
+                            // really rises without permission still meets the movement check.
+                            this.needSendAdventureSettings = true;
                             break;
                         }
                         PlayerToggleFlightEvent playerToggleFlightEvent = new PlayerToggleFlightEvent(this, true);
@@ -4562,7 +4567,8 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                     case PlayerActionPacket.ACTION_START_FLYING:
                         if (this.isMovementServerAuthoritative() || this.isLockMovementInput() || protocol < ProtocolInfo.v1_20_30_24) break;
                         if (!server.getAllowFlight() && !this.getAdventureSettings().get(Type.ALLOW_FLIGHT)) {
-                            this.kick(PlayerKickEvent.Reason.FLYING_DISABLED, "Flying is not enabled on this server");
+                            // Refused, not punished: see START_FLYING above.
+                            this.needSendAdventureSettings = true;
                             break;
                         }
                         PlayerToggleFlightEvent playerToggleFlightEvent = new PlayerToggleFlightEvent(this, true);

--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -4248,11 +4248,8 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
 
                     if (authPacket.getInputData().contains(AuthInputAction.START_FLYING)) {
                         if (!server.getAllowFlight() && !this.getAdventureSettings().get(Type.ALLOW_FLIGHT)) {
-                            // Refused, never punished: the client keeps asking to fly for a while
-                            // after the server has taken the permission away (game mode change, a
-                            // plugin revoking flight), and a stale request is not a cheat. Resending
-                            // the adventure settings puts the client back on the ground; someone who
-                            // really rises without permission still meets the movement check.
+                            // Stale request: the client keeps asking after permission is revoked; refuse and
+                            // resync, real flight is still caught by the movement check
                             this.needSendAdventureSettings = true;
                             break;
                         }
@@ -4567,7 +4564,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                     case PlayerActionPacket.ACTION_START_FLYING:
                         if (this.isMovementServerAuthoritative() || this.isLockMovementInput() || protocol < ProtocolInfo.v1_20_30_24) break;
                         if (!server.getAllowFlight() && !this.getAdventureSettings().get(Type.ALLOW_FLIGHT)) {
-                            // Refused, not punished: see START_FLYING above.
+                            // Stale request, handled as START_FLYING above
                             this.needSendAdventureSettings = true;
                             break;
                         }


### PR DESCRIPTION
A client keeps asking for flight for a while after the server has taken the permission away: a
game mode switch, a plugin revoking a fly command, a world change. The request is stale, not a
cheat, yet the core answers it with a kick when `allow-flight` is off — so a player who had just
been moved out of creative is thrown off the server for pressing jump twice.

This is the same punishment-for-a-desync as the elytra glide (#862), and it is removed the same
way: resending the adventure settings resyncs the client and leaves it on the ground. A player who
really rises without permission is still caught by the ordinary movement check, which kicks for
the flight itself and not for asking about it.

Both call sites are covered: the auth-input `START_FLYING` path and the legacy
`PlayerActionPacket.ACTION_START_FLYING` one.

Compiles on current master; verified in game on 1.20 … 1.26.45.