### PR TITLE
fix(player): let a server keep the session that is already playing

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -3157,6 +3157,14 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
         for (Player p : new ArrayList<>(this.server.playerList.values())) {
             if (p != this && p.username != null) {
                 if (p.username.equalsIgnoreCase(this.username) || this.getUniqueId().equals(p.getUniqueId())) {
+                    if (this.server.isDuplicateLoginKeepingExistingSession()) {
+                        // The session that is already in the world stays, and the newcomer is the
+                        // one that is refused: closing the older session hands the world to
+                        // whoever knocks last, so a player carrying loot loses it to a stranger
+                        // reusing the nickname. A stale session still times out by itself.
+                        this.close("", "disconnectionScreen.loggedinOtherLocation");
+                        return;
+                    }
                     p.close("", "disconnectionScreen.loggedinOtherLocation");
                     break;
                 }

--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -330,6 +330,12 @@ public class Server {
      * Xbox authentication enabled.
      */
     public boolean xboxAuth;
+
+    /**
+     * When true a duplicate login refuses the newcomer instead of closing the session that is
+     * already in the world. Defaults to false, the historical behaviour.
+     */
+    private boolean keepExistingSessionOnDuplicateLogin;
     /**
      * Spawn eggs enabled.
      */
@@ -3175,6 +3181,10 @@ public class Server {
      * @param name player name
      * @return is whitelisted or whitelist is not enabled
      */
+    public boolean isDuplicateLoginKeepingExistingSession() {
+        return this.keepExistingSessionOnDuplicateLogin;
+    }
+
     public boolean isWhitelisted(String name) {
         return !this.hasWhitelist() || this.operators.exists(name, true) || this.whitelist.exists(name, true);
     }
@@ -3645,6 +3655,7 @@ public class Server {
         this.flyChecks = this.getPropertyBoolean("allow-flight", false);
         this.spawnRadius = this.getPropertyInt("spawn-protection", 10);
         this.xboxAuth = this.getPropertyBoolean("xbox-auth", true);
+        this.keepExistingSessionOnDuplicateLogin = this.getPropertyBoolean("keep-existing-session-on-duplicate-login", false);
         this.encryptionEnabled = this.getPropertyBoolean("encryption", true);
         if (!this.encryptionEnabled) {
             log.warn("Encryption is not enabled. For better security, it's recommended to enable it if you don't use a proxy software.");
@@ -3866,6 +3877,7 @@ public class Server {
             put("white-list", false);
             put("whitelist-reason", "§cServer is white-listed");
             put("xbox-auth", true);
+            put("keep-existing-session-on-duplicate-login", false);
             put("encryption", true);
 
             put("force-resources", false);


### PR DESCRIPTION
On a duplicate login the core closes the session that is already in the world and lets the
newcomer in. That hands the world to whoever knocks last: a player carrying loot loses it to a
stranger reusing the nickname, and the owner of the nickname cannot tell an attack from a glitch.

Add `keep-existing-session-on-duplicate-login` to `server.properties`, **false by default**, so
nothing changes for existing servers. With it on the newcomer is refused instead: the one who is
playing keeps playing, and a stale session still times out by itself.

Compiles on current master; running in production with the option on.