### PR TITLE
network: allow an intentionally blank sub-motd

### DIFF
--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -2069,9 +2069,9 @@ public class Server {
     }
 
     public String getSubMotd() {
-        String sub = this.getPropertyString("sub-motd", "Powered by Nukkit-MOT");
-        if (sub.isEmpty()) sub = "Powered by Nukkit";
-        return sub;
+        // An empty value is an explicit choice: the second Bedrock server-list line is left out.
+        // Substituting a default here made that choice unreachable.
+        return this.getPropertyString("sub-motd", "Powered by Nukkit-MOT");
     }
 
     public boolean getForceResources() {

--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -2069,8 +2069,6 @@ public class Server {
     }
 
     public String getSubMotd() {
-        // An empty value is an explicit choice: the second Bedrock server-list line is left out.
-        // Substituting a default here made that choice unreachable.
         return this.getPropertyString("sub-motd", "Powered by Nukkit-MOT");
     }
 


### PR DESCRIPTION
An administrator can intentionally leave the second Bedrock server-list line empty. The fallback in `Server#getSubMotd` turned that explicit choice back into a default string, so there was no supported way to remove the line.

An unset property still gets the default; only an explicitly empty one is now honoured.

Compiles on current master.