### PR TITLE
fix: 修复 ViaBedrock Java 版 setUsingItem 接收

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -155,6 +155,10 @@ tasks {
         )
     }
 
+    compileTestJava {
+        options.encoding = "UTF-8"
+    }
+
     test {
         useJUnitPlatform()
         jvmArgumentProviders.add(

--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -71,6 +71,7 @@ import cn.nukkit.nbt.tag.*;
 import cn.nukkit.network.SourceInterface;
 import cn.nukkit.network.encryption.PrepareEncryptionTask;
 import cn.nukkit.network.process.DataPacketManager;
+import cn.nukkit.network.process.UsingItemReceive;
 import cn.nukkit.network.protocol.*;
 import cn.nukkit.network.protocol.netease.NeteaseJsonPacket;
 import cn.nukkit.network.protocol.netease.PyRpcPacket;
@@ -3000,6 +3001,43 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
     }
 
     /**
+     * Start hold-to-use from AuthInput START_USING_ITEM / PlayerAction START_USING_ITEM
+     * using the <em>server</em> held stack. Java chew/drink is local, so the client
+     * animates even when MOT never entered using; other players only see
+     * {@code DATA_FLAG_ACTION} after this path succeeds.
+     */
+    boolean tryStartUsingHeldItem(Item item) {
+        if (!UsingItemReceive.shouldStartUsingFromAuthInput(
+                this.spawned && this.isAlive(),
+                this.isSpectator() && this.server.useClientSpectator,
+                this.isUsingItem(),
+                UsingItemReceive.isHoldToUseItem(item),
+                true)) {
+            return false;
+        }
+        Vector3 direction = this.getDirectionVector();
+        PlayerInteractEvent interactEvent = new PlayerInteractEvent(this, item, direction, this.getDirection(), Action.RIGHT_CLICK_AIR);
+        if (this.isSpectator()) {
+            interactEvent.setCancelled();
+        }
+        this.server.getPluginManager().callEvent(interactEvent);
+        if (interactEvent.isCancelled()) {
+            this.needSendHeldItem = true;
+            return false;
+        }
+        if (!item.onClickAir(this, direction) || !item.canRelease()) {
+            return false;
+        }
+        if (this.isSurvival() || this.isAdventure()) {
+            if (item.getId() == 0 || this.inventory.getItemInHandFast().getId() == item.getId()) {
+                this.inventory.setItemInHand(item);
+            }
+        }
+        this.setUsingItem(true);
+        return true;
+    }
+
+    /**
      * Processes server-side auto-completion for consumable items.
      *
      * @return true if auto-completion was triggered
@@ -4081,6 +4119,18 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                     }
                 }
 
+                boolean authStartUsingItem = UsingItemReceive.authInputStartsUsingItem(authPacket);
+                Item authHeldItem = this.inventory.getItemInHand();
+                boolean authHoldToUse = UsingItemReceive.isHoldToUseItem(authHeldItem);
+                if (UsingItemReceive.shouldStartUsingFromAuthInput(
+                        this.spawned && this.isAlive(),
+                        this.isSpectator() && this.server.useClientSpectator,
+                        this.isUsingItem(),
+                        authHoldToUse,
+                        authStartUsingItem)) {
+                    this.tryStartUsingHeldItem(authHeldItem);
+                }
+
                 if (authPacket.getInputData().contains(AuthInputAction.START_SPRINTING)) {
                     PlayerToggleSprintEvent playerToggleSprintEvent = new PlayerToggleSprintEvent(this, true);
                     if ((this.foodData.getLevel() <= 6 && !this.getAdventureSettings().get(Type.FLYING)) ||
@@ -4093,7 +4143,10 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                         this.needSendData = true;
                     } else {
                         this.setSprinting(true);
-                        this.setUsingItem(false);
+                        if (!UsingItemReceive.shouldKeepUsingDespiteStartSprinting(
+                                this.isUsingItem(), authHoldToUse, authStartUsingItem)) {
+                            this.setUsingItem(false);
+                        }
                     }
                 }
 
@@ -4580,9 +4633,17 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                             this.getAdventureSettings().set(Type.FLYING, playerToggleFlightEvent.isFlying());
                         }
                         break packetswitch;
+                    case PlayerActionPacket.ACTION_START_ITEM_USE_ON:
+                    case PlayerActionPacket.ACTION_START_USING_ITEM:
+                        this.tryStartUsingHeldItem(this.inventory.getItemInHand());
+                        break packetswitch;
+                    case PlayerActionPacket.ACTION_STOP_ITEM_USE_ON:
+                        break packetswitch;
                 }
 
-                this.setUsingItem(false);
+                if (UsingItemReceive.shouldClearUsingOnUnhandledPlayerAction(playerActionPacket.action)) {
+                    this.setUsingItem(false);
+                }
                 break;
             case ProtocolInfo.INTERACT_PACKET:
                 if (!this.spawned || !this.isAlive()) {
@@ -5351,6 +5412,10 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                                 return;
                             }
 
+                            Item clickBlockHeld = this.inventory.getItemInHand();
+                            if (UsingItemReceive.shouldKeepUsingOnClickBlock(this.isUsingItem(), UsingItemReceive.isHoldToUseItem(clickBlockHeld))) {
+                                return;
+                            }
                             this.setUsingItem(false);
 
                             if (!(this.distance(blockVector.asVector3()) > (this.isCreative() ? 13 : 7))) {
@@ -5473,12 +5538,22 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                             }
 
                             item = this.inventory.getItemInHand();
+                            if (UsingItemReceive.shouldRewriteClickAirHeldItem(useItemData.itemInHand, item)) {
+                                useItemData.itemInHand = item.clone();
+                            }
                             if (item instanceof ItemCrossbow && (this.isSpectator() || !item.onClickAir(this, directionVector))) {
                                 return;
                             }
 
                             if (!item.equalsFast(useItemData.itemInHand)) {
                                 this.needSendHeldItem = true;
+                                break;
+                            }
+
+                            if (UsingItemReceive.shouldIgnoreDuplicateClickAirStart(
+                                    this.isUsingItem(),
+                                    UsingItemReceive.isHoldToUseItem(item),
+                                    this.startAction >= 0 ? this.server.getTick() - this.startAction : 0)) {
                                 break;
                             }
 
@@ -5674,6 +5749,10 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                                 if (this.isUsingItem()) {
                                     item = this.inventory.getItemInHand();
                                     int ticksUsed = this.server.getTick() - this.startAction;
+                                    if (UsingItemReceive.shouldKeepUsingOnEarlyRelease(
+                                            true, UsingItemReceive.isHoldToUseItem(item), ticksUsed)) {
+                                        return;
+                                    }
                                     if (!item.onRelease(this, ticksUsed)) {
                                         this.inventory.sendContents(this);
                                     }
@@ -5724,7 +5803,12 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                                 break;
                         }
                     } finally {
-                        this.setUsingItem(false);
+                        Item heldAfterRelease = this.inventory != null ? this.inventory.getItemInHandFast() : null;
+                        int ticksUsedAfterRelease = this.startAction >= 0 ? this.server.getTick() - this.startAction : -1;
+                        if (!UsingItemReceive.shouldKeepUsingOnEarlyRelease(
+                                this.isUsingItem(), UsingItemReceive.isHoldToUseItem(heldAfterRelease), ticksUsedAfterRelease)) {
+                            this.setUsingItem(false);
+                        }
                     }
                     break;
                 default:

--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -4232,7 +4232,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                     } else {
                         this.setSprinting(true);
                         if (!UsingItemReceive.shouldKeepUsingDespiteStartSprinting(
-                                this.isUsingItem(), authHoldToUse, authStartUsingItem)) {
+                                authHoldToUse, authStartUsingItem)) {
                             this.setUsingItem(false);
                         }
                     }
@@ -4722,11 +4722,12 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                             this.getAdventureSettings().set(Type.FLYING, playerToggleFlightEvent.isFlying());
                         }
                         break packetswitch;
-                    case PlayerActionPacket.ACTION_START_ITEM_USE_ON:
                     case PlayerActionPacket.ACTION_START_USING_ITEM:
                         this.tryStartUsingHeldItem(this.inventory.getItemInHand());
                         break packetswitch;
+                    case PlayerActionPacket.ACTION_START_ITEM_USE_ON:
                     case PlayerActionPacket.ACTION_STOP_ITEM_USE_ON:
+                        // Block item-use-on: skip default setUsingItem(false), do not start hold-to-use.
                         break packetswitch;
                 }
 

--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -5855,7 +5855,13 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                                     if (!item.onRelease(this, ticksUsed)) {
                                         this.inventory.sendContents(this);
                                     }
-                                    this.setUsingItem(false);
+                                    if (!UsingItemReceive.shouldRetainUsingOnEarlyJavaRelease(
+                                            this.isJavaClient(),
+                                            true,
+                                            UsingItemReceive.isHoldToUseItem(item),
+                                            ticksUsed)) {
+                                        this.setUsingItem(false);
+                                    }
                                 } else {
                                     this.inventory.sendContents(this);
                                 }

--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -4235,7 +4235,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                     } else {
                         this.setSprinting(true);
                         if (!UsingItemReceive.shouldKeepUsingDespiteStartSprinting(
-                                authHoldToUse, authStartUsingItem)) {
+                                this.isJavaClient(), authHoldToUse, authStartUsingItem)) {
                             this.setUsingItem(false);
                         }
                     }
@@ -4733,11 +4733,14 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                         break packetswitch;
                     case PlayerActionPacket.ACTION_START_ITEM_USE_ON:
                     case PlayerActionPacket.ACTION_STOP_ITEM_USE_ON:
-                        // Block item-use-on: skip default setUsingItem(false), do not start hold-to-use.
-                        break packetswitch;
+                        // ViaProxy Java uses these as block-interaction compatibility markers.
+                        if (this.isJavaClient()) {
+                            break packetswitch;
+                        }
+                        break;
                 }
 
-                if (UsingItemReceive.shouldClearUsingOnUnhandledPlayerAction(playerActionPacket.action)) {
+                if (UsingItemReceive.shouldClearUsingOnUnhandledPlayerAction(this.isJavaClient(), playerActionPacket.action)) {
                     this.setUsingItem(false);
                 }
                 break;
@@ -5489,7 +5492,8 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                         break;
                     }
 
-                    if (inventory.getHeldItemIndex() != useItemData.hotbarSlot) {
+                    boolean heldSlotChanged = inventory.getHeldItemIndex() != useItemData.hotbarSlot;
+                    if (heldSlotChanged) {
                         inventory.equipItem(useItemData.hotbarSlot);
                     }
 
@@ -5509,7 +5513,11 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                             }
 
                             Item clickBlockHeld = this.inventory.getItemInHand();
-                            if (UsingItemReceive.shouldKeepUsingOnClickBlock(this.isUsingItem(), UsingItemReceive.isHoldToUseItem(clickBlockHeld))) {
+                            if (UsingItemReceive.shouldKeepUsingOnClickBlock(
+                                    this.isJavaClient(),
+                                    this.isUsingItem(),
+                                    UsingItemReceive.isHoldToUseItem(clickBlockHeld),
+                                    heldSlotChanged)) {
                                 return;
                             }
                             this.setUsingItem(false);
@@ -5634,14 +5642,13 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                             }
 
                             item = this.inventory.getItemInHand();
-                            if (UsingItemReceive.shouldRewriteClickAirHeldItem(useItemData.itemInHand, item)) {
-                                useItemData.itemInHand = item.clone();
-                            }
                             if (item instanceof ItemCrossbow && (this.isSpectator() || !item.onClickAir(this, directionVector))) {
                                 return;
                             }
 
-                            if (!item.equalsFast(useItemData.itemInHand)) {
+                            if (useItemData.itemInHand == null || !item.equalsFast(useItemData.itemInHand)) {
+                                server.getLogger().debug(this.username + ": CLICK_AIR held item mismatch, server="
+                                        + item + ", client=" + useItemData.itemInHand);
                                 this.needSendHeldItem = true;
                                 break;
                             }
@@ -5845,10 +5852,6 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                                 if (this.isUsingItem()) {
                                     item = this.inventory.getItemInHand();
                                     int ticksUsed = this.server.getTick() - this.startAction;
-                                    if (UsingItemReceive.shouldKeepUsingOnEarlyRelease(
-                                            true, UsingItemReceive.isHoldToUseItem(item), ticksUsed)) {
-                                        return;
-                                    }
                                     if (!item.onRelease(this, ticksUsed)) {
                                         this.inventory.sendContents(this);
                                     }
@@ -5899,12 +5902,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                                 break;
                         }
                     } finally {
-                        Item heldAfterRelease = this.inventory != null ? this.inventory.getItemInHandFast() : null;
-                        int ticksUsedAfterRelease = this.startAction >= 0 ? this.server.getTick() - this.startAction : -1;
-                        if (!UsingItemReceive.shouldKeepUsingOnEarlyRelease(
-                                this.isUsingItem(), UsingItemReceive.isHoldToUseItem(heldAfterRelease), ticksUsedAfterRelease)) {
-                            this.setUsingItem(false);
-                        }
+                        this.setUsingItem(false);
                     }
                     break;
                 default:

--- a/src/main/java/cn/nukkit/network/process/UsingItemReceive.java
+++ b/src/main/java/cn/nukkit/network/process/UsingItemReceive.java
@@ -1,0 +1,147 @@
+package cn.nukkit.network.process;
+
+import cn.nukkit.inventory.transaction.data.UseItemData;
+import cn.nukkit.item.Item;
+import cn.nukkit.network.protocol.InventoryTransactionPacket;
+import cn.nukkit.network.protocol.PlayerActionPacket;
+import cn.nukkit.network.protocol.PlayerAuthInputPacket;
+import cn.nukkit.network.protocol.types.AuthInputAction;
+
+/**
+ * Shared receive-side rules for {@code Player.setUsingItem}.
+ * <p>
+ * Official Bedrock / Java-via-ViaBedrock start hold-to-use from AuthInput
+ * {@link AuthInputAction#START_USING_ITEM} (and, on older movement, PlayerAction
+ * {@link PlayerActionPacket#ACTION_START_ITEM_USE_ON} / {@link PlayerActionPacket#ACTION_START_USING_ITEM}).
+ * MOT previously parsed those bits and then ignored them, so eating/drawing never
+ * set {@code DATA_FLAG_ACTION} and other players never saw the animation.
+ * <p>
+ * This helper is package-visible from {@code Player} and unit-tested without a live
+ * session so the many cancel paths (equalsFast, second CLICK_AIR, sprint, default
+ * PlayerAction fallthrough, same-slot MobEquipment) stay explicit.
+ */
+public final class UsingItemReceive {
+
+    private UsingItemReceive() {
+    }
+
+    public static boolean isHoldToUseItem(Item item) {
+        return item != null && item.getId() != 0 && item.canRelease();
+    }
+
+    public static boolean isClickAirUse(int transactionType, Object transactionData) {
+        if (transactionType != InventoryTransactionPacket.TYPE_USE_ITEM) {
+            return false;
+        }
+        if (!(transactionData instanceof UseItemData useItemData)) {
+            return false;
+        }
+        return useItemData.actionType == InventoryTransactionPacket.USE_ITEM_ACTION_CLICK_AIR;
+    }
+
+    /**
+     * MOT {@code equalsFast} is id+meta (and custom namespace). A Via encode that still
+     * decodes to a different runtime/legacy pair would otherwise drop the start and never
+     * {@code setUsingItem}. Rewrite the packet stack to the server held item so the native
+     * CLICK_AIR path can run.
+     */
+    public static boolean shouldRewriteClickAirHeldItem(Item packetItem, Item serverItem) {
+        if (!isHoldToUseItem(serverItem)) {
+            return false;
+        }
+        return packetItem == null || !packetItem.equalsFast(serverItem);
+    }
+
+    /**
+     * A second CLICK_AIR while already using is treated as {@code onUse(ticksUsed)} and
+     * always {@code setUsingItem(false)}. Keep that as the duration-ready finish, but
+     * ignore an immediate duplicate start so Java USE_ITEM + USE_ITEM_ON cannot abort
+     * auto-complete after 0 ticks.
+     */
+    public static boolean shouldIgnoreDuplicateClickAirStart(boolean alreadyUsing, boolean holdToUse,
+                                                             int ticksUsed) {
+        return alreadyUsing && holdToUse && ticksUsed < 2;
+    }
+
+    public static boolean shouldStartUsingFromClickAir(boolean spawnedAlive, boolean spectatorBlocked,
+                                                       boolean alreadyUsing, boolean holdToUse,
+                                                       boolean onClickAir) {
+        return spawnedAlive && !spectatorBlocked && !alreadyUsing && holdToUse && onClickAir;
+    }
+
+    public static boolean authInputStartsUsingItem(PlayerAuthInputPacket packet) {
+        return packet != null
+                && packet.getInputData() != null
+                && packet.getInputData().contains(AuthInputAction.START_USING_ITEM);
+    }
+
+    /**
+     * AuthInput START_USING_ITEM is the official start bit. MOT used to parse and ignore
+     * it. Start from the <em>server</em> held stack, not the optional attached item TX,
+     * because NetEase 860 Java clients do not attach AuthInput item interaction for food/bow.
+     */
+    public static boolean shouldStartUsingFromAuthInput(boolean spawnedAlive, boolean spectatorBlocked,
+                                                        boolean alreadyUsing, boolean holdToUse,
+                                                        boolean startUsingItemFlag) {
+        return spawnedAlive && !spectatorBlocked && !alreadyUsing && holdToUse && startUsingItemFlag;
+    }
+
+    /**
+     * START_SPRINTING used to always {@code setUsingItem(false)}. Java eat/draw cancels
+     * sprint on the same tick Via emits StartUsingItem; if MOT still sees both bits,
+     * keep using and skip the sprint cancel.
+     */
+    public static boolean shouldKeepUsingDespiteStartSprinting(boolean alreadyUsing, boolean holdToUse,
+                                                               boolean startUsingItemFlag) {
+        return alreadyUsing && holdToUse || startUsingItemFlag && holdToUse;
+    }
+
+    public static boolean isStartUsingPlayerAction(int action) {
+        return action == PlayerActionPacket.ACTION_START_ITEM_USE_ON
+                || action == PlayerActionPacket.ACTION_START_USING_ITEM;
+    }
+
+    public static boolean isStopUsingPlayerAction(int action) {
+        return action == PlayerActionPacket.ACTION_STOP_ITEM_USE_ON;
+    }
+
+    /**
+     * Unknown PlayerAction values used to fall through to {@code setUsingItem(false)}.
+     * Keep that for real interrupts, but START/STOP item-use-on and START_USING_ITEM
+     * must not.
+     */
+    public static boolean shouldClearUsingOnUnhandledPlayerAction(int action) {
+        return !isStartUsingPlayerAction(action) && !isStopUsingPlayerAction(action);
+    }
+
+    /**
+     * MobEquipment always cleared using, including the same-slot confirmation Java sends
+     * before CLICK_AIR. Only a real hotbar switch is an interrupt.
+     */
+    public static boolean shouldClearUsingOnMobEquipment(boolean alreadyUsing, int currentHeldIndex,
+                                                         int packetHotbarSlot) {
+        return alreadyUsing && currentHeldIndex != packetHotbarSlot;
+    }
+
+    /**
+     * MOT {@code USE_ITEM} CLICK_BLOCK always called {@code setUsingItem(false)} before
+     * {@code Level.useItemOn}. Java Fabric keeps sending {@code USE_ITEM_ON} at the
+     * crosshair while chewing/drawing, so that packet would abort auto-complete after
+     * 1 tick. Keep using and skip the block use; a later empty-hand / non-hold click
+     * still places/activates.
+     */
+    public static boolean shouldKeepUsingOnClickBlock(boolean alreadyUsing, boolean holdToUse) {
+        return alreadyUsing && holdToUse;
+    }
+
+    /**
+     * MOT {@code TYPE_RELEASE_ITEM} has a {@code finally} that always cleared using.
+     * Java may emit {@code RELEASE_USE_ITEM} on the next tick (look-at-block, NBT
+     * mismatch cancel, or local animation edge). Food/bow auto-complete from
+     * {@code processAutoCompletion()} / a duration-ready second CLICK_AIR; an early
+     * release is not a real interrupt.
+     */
+    public static boolean shouldKeepUsingOnEarlyRelease(boolean alreadyUsing, boolean holdToUse, int ticksUsed) {
+        return alreadyUsing && holdToUse && ticksUsed < 2;
+    }
+}

--- a/src/main/java/cn/nukkit/network/process/UsingItemReceive.java
+++ b/src/main/java/cn/nukkit/network/process/UsingItemReceive.java
@@ -11,10 +11,14 @@ import cn.nukkit.network.protocol.types.AuthInputAction;
  * Shared receive-side rules for {@code Player.setUsingItem}.
  * <p>
  * Official Bedrock / Java-via-ViaBedrock start hold-to-use from AuthInput
- * {@link AuthInputAction#START_USING_ITEM} (and, on older movement, PlayerAction
- * {@link PlayerActionPacket#ACTION_START_ITEM_USE_ON} / {@link PlayerActionPacket#ACTION_START_USING_ITEM}).
- * MOT previously parsed those bits and then ignored them, so eating/drawing never
- * set {@code DATA_FLAG_ACTION} and other players never saw the animation.
+ * {@link AuthInputAction#START_USING_ITEM} (and, on older client-authoritative
+ * movement, PlayerAction {@link PlayerActionPacket#ACTION_START_USING_ITEM}).
+ * PlayerAction {@link PlayerActionPacket#ACTION_START_ITEM_USE_ON} /
+ * {@link PlayerActionPacket#ACTION_STOP_ITEM_USE_ON} are block item-use-on
+ * (client-auth mobile food+block interact) and must not start the hold; they
+ * only skip the default {@code setUsingItem(false)} fallthrough.
+ * MOT previously parsed those start bits and then ignored them, so eating/drawing
+ * never set {@code DATA_FLAG_ACTION} and other players never saw the animation.
  * <p>
  * This helper is package-visible from {@code Player} and unit-tested without a live
  * session so the many cancel paths (equalsFast, second CLICK_AIR, sprint, default
@@ -87,31 +91,36 @@ public final class UsingItemReceive {
     }
 
     /**
-     * START_SPRINTING used to always {@code setUsingItem(false)}. Java eat/draw cancels
-     * sprint on the same tick Via emits StartUsingItem; if MOT still sees both bits,
-     * keep using and skip the sprint cancel.
+     * START_SPRINTING used to always {@code setUsingItem(false)}. Java eat/draw can
+     * cancel sprint on the same tick Via emits StartUsingItem; if MOT still sees
+     * both bits, keep using. A later START_SPRINTING while already eating still
+     * cancels the hold, matching vanilla sprint-cancel-eat.
      */
-    public static boolean shouldKeepUsingDespiteStartSprinting(boolean alreadyUsing, boolean holdToUse,
+    public static boolean shouldKeepUsingDespiteStartSprinting(boolean holdToUse,
                                                                boolean startUsingItemFlag) {
-        return alreadyUsing && holdToUse || startUsingItemFlag && holdToUse;
+        return startUsingItemFlag && holdToUse;
     }
 
     public static boolean isStartUsingPlayerAction(int action) {
-        return action == PlayerActionPacket.ACTION_START_ITEM_USE_ON
-                || action == PlayerActionPacket.ACTION_START_USING_ITEM;
+        return action == PlayerActionPacket.ACTION_START_USING_ITEM;
     }
 
-    public static boolean isStopUsingPlayerAction(int action) {
-        return action == PlayerActionPacket.ACTION_STOP_ITEM_USE_ON;
+    /**
+     * Block item-use-on (PlayerAction 28/29). Not a hold-to-use start; skip the
+     * default {@code setUsingItem(false)} fallthrough only.
+     */
+    public static boolean isItemUseOnPlayerAction(int action) {
+        return action == PlayerActionPacket.ACTION_START_ITEM_USE_ON
+                || action == PlayerActionPacket.ACTION_STOP_ITEM_USE_ON;
     }
 
     /**
      * Unknown PlayerAction values used to fall through to {@code setUsingItem(false)}.
-     * Keep that for real interrupts, but START/STOP item-use-on and START_USING_ITEM
+     * Keep that for real interrupts, but START_USING_ITEM and START/STOP item-use-on
      * must not.
      */
     public static boolean shouldClearUsingOnUnhandledPlayerAction(int action) {
-        return !isStartUsingPlayerAction(action) && !isStopUsingPlayerAction(action);
+        return !isStartUsingPlayerAction(action) && !isItemUseOnPlayerAction(action);
     }
 
     /**

--- a/src/main/java/cn/nukkit/network/process/UsingItemReceive.java
+++ b/src/main/java/cn/nukkit/network/process/UsingItemReceive.java
@@ -44,19 +44,6 @@ public final class UsingItemReceive {
     }
 
     /**
-     * MOT {@code equalsFast} is id+meta (and custom namespace). A Via encode that still
-     * decodes to a different runtime/legacy pair would otherwise drop the start and never
-     * {@code setUsingItem}. Rewrite the packet stack to the server held item so the native
-     * CLICK_AIR path can run.
-     */
-    public static boolean shouldRewriteClickAirHeldItem(Item packetItem, Item serverItem) {
-        if (!isHoldToUseItem(serverItem)) {
-            return false;
-        }
-        return packetItem == null || !packetItem.equalsFast(serverItem);
-    }
-
-    /**
      * A second CLICK_AIR while already using is treated as {@code onUse(ticksUsed)} and
      * always {@code setUsingItem(false)}. Keep that as the duration-ready finish, but
      * ignore an immediate duplicate start so Java USE_ITEM + USE_ITEM_ON cannot abort
@@ -96,9 +83,9 @@ public final class UsingItemReceive {
      * both bits, keep using. A later START_SPRINTING while already eating still
      * cancels the hold, matching vanilla sprint-cancel-eat.
      */
-    public static boolean shouldKeepUsingDespiteStartSprinting(boolean holdToUse,
+    public static boolean shouldKeepUsingDespiteStartSprinting(boolean javaClient, boolean holdToUse,
                                                                boolean startUsingItemFlag) {
-        return startUsingItemFlag && holdToUse;
+        return javaClient && startUsingItemFlag && holdToUse;
     }
 
     public static boolean isStartUsingPlayerAction(int action) {
@@ -116,41 +103,35 @@ public final class UsingItemReceive {
 
     /**
      * Unknown PlayerAction values used to fall through to {@code setUsingItem(false)}.
-     * Keep that for real interrupts, but START_USING_ITEM and START/STOP item-use-on
-     * must not.
+     * ViaProxy Java clients send START_USING_ITEM and START/STOP item-use-on as
+     * compatibility packets that must not trigger that legacy fallthrough.
      */
-    public static boolean shouldClearUsingOnUnhandledPlayerAction(int action) {
-        return !isStartUsingPlayerAction(action) && !isItemUseOnPlayerAction(action);
+    public static boolean shouldClearUsingOnUnhandledPlayerAction(boolean javaClient, int action) {
+        return !javaClient || (!isStartUsingPlayerAction(action) && !isItemUseOnPlayerAction(action));
     }
 
     /**
      * MobEquipment always cleared using, including the same-slot confirmation Java sends
-     * before CLICK_AIR. Only a real hotbar switch is an interrupt.
+     * before CLICK_AIR. Only a real hotbar switch is an interrupt for ViaProxy Java.
+     * Native Bedrock retains the old unconditional clear behavior.
+     * <p>
+     * A Java hotbar change is already an interrupt in {@code shouldClearUsingOnMobEquipment}.
+     * Duplicate Java CLICK_AIR on the first two ticks is handled by
+     * {@code shouldIgnoreDuplicateClickAirStart}. Early Java RELEASE_USE_ITEM is a
+     * real interrupt and must not be retained here.
      */
-    public static boolean shouldClearUsingOnMobEquipment(boolean alreadyUsing, int currentHeldIndex,
-                                                         int packetHotbarSlot) {
-        return alreadyUsing && currentHeldIndex != packetHotbarSlot;
+    public static boolean shouldClearUsingOnMobEquipment(boolean javaClient, boolean alreadyUsing,
+                                                         int currentHeldIndex, int packetHotbarSlot) {
+        return alreadyUsing && (!javaClient || currentHeldIndex != packetHotbarSlot);
     }
 
     /**
-     * MOT {@code USE_ITEM} CLICK_BLOCK always called {@code setUsingItem(false)} before
-     * {@code Level.useItemOn}. Java Fabric keeps sending {@code USE_ITEM_ON} at the
-     * crosshair while chewing/drawing, so that packet would abort auto-complete after
-     * 1 tick. Keep using and skip the block use; a later empty-hand / non-hold click
-     * still places/activates.
+     * ViaProxy Java emits CLICK_BLOCK while the client-side use animation is active.
+     * Native Bedrock must continue through the normal Level.useItemOn path. A changed
+     * hotbar slot always ends the old use session before the block action is handled.
      */
-    public static boolean shouldKeepUsingOnClickBlock(boolean alreadyUsing, boolean holdToUse) {
-        return alreadyUsing && holdToUse;
-    }
-
-    /**
-     * MOT {@code TYPE_RELEASE_ITEM} has a {@code finally} that always cleared using.
-     * Java may emit {@code RELEASE_USE_ITEM} on the next tick (look-at-block, NBT
-     * mismatch cancel, or local animation edge). Food/bow auto-complete from
-     * {@code processAutoCompletion()} / a duration-ready second CLICK_AIR; an early
-     * release is not a real interrupt.
-     */
-    public static boolean shouldKeepUsingOnEarlyRelease(boolean alreadyUsing, boolean holdToUse, int ticksUsed) {
-        return alreadyUsing && holdToUse && ticksUsed < 2;
+    public static boolean shouldKeepUsingOnClickBlock(boolean javaClient, boolean alreadyUsing,
+                                                       boolean holdToUse, boolean heldSlotChanged) {
+        return javaClient && alreadyUsing && holdToUse && !heldSlotChanged;
     }
 }

--- a/src/main/java/cn/nukkit/network/process/UsingItemReceive.java
+++ b/src/main/java/cn/nukkit/network/process/UsingItemReceive.java
@@ -114,15 +114,20 @@ public final class UsingItemReceive {
      * MobEquipment always cleared using, including the same-slot confirmation Java sends
      * before CLICK_AIR. Only a real hotbar switch is an interrupt for ViaProxy Java.
      * Native Bedrock retains the old unconditional clear behavior.
-     * <p>
-     * A Java hotbar change is already an interrupt in {@code shouldClearUsingOnMobEquipment}.
-     * Duplicate Java CLICK_AIR on the first two ticks is handled by
-     * {@code shouldIgnoreDuplicateClickAirStart}. Early Java RELEASE_USE_ITEM is a
-     * real interrupt and must not be retained here.
      */
     public static boolean shouldClearUsingOnMobEquipment(boolean javaClient, boolean alreadyUsing,
                                                          int currentHeldIndex, int packetHotbarSlot) {
         return alreadyUsing && (!javaClient || currentHeldIndex != packetHotbarSlot);
+    }
+
+    /**
+     * Early Java {@code TYPE_RELEASE_ITEM} is a real interrupt, including on the first
+     * tick. Duplicate Java CLICK_AIR is ignored by {@link #shouldIgnoreDuplicateClickAirStart};
+     * this path must still clear using-state.
+     */
+    public static boolean shouldRetainUsingOnEarlyJavaRelease(boolean javaClient, boolean alreadyUsing,
+                                                              boolean holdToUse, int ticksUsed) {
+        return false;
     }
 
     /**

--- a/src/main/java/cn/nukkit/network/process/processor/common/MobEquipmentProcessor.java
+++ b/src/main/java/cn/nukkit/network/process/processor/common/MobEquipmentProcessor.java
@@ -7,6 +7,7 @@ import cn.nukkit.inventory.Inventory;
 import cn.nukkit.inventory.PlayerInventory;
 import cn.nukkit.item.Item;
 import cn.nukkit.network.process.DataPacketProcessor;
+import cn.nukkit.network.process.UsingItemReceive;
 import cn.nukkit.network.protocol.DataPacket;
 import cn.nukkit.network.protocol.MobEquipmentPacket;
 import cn.nukkit.network.protocol.ProtocolInfo;
@@ -59,10 +60,15 @@ public class MobEquipmentProcessor extends DataPacketProcessor<MobEquipmentPacke
         }
 
         if (inv instanceof PlayerInventory) {
-            ((PlayerInventory) inv).equipItem(pk.hotbarSlot);
+            PlayerInventory playerInventory = (PlayerInventory) inv;
+            int previousHeldIndex = playerInventory.getHeldItemIndex();
+            playerInventory.equipItem(pk.hotbarSlot);
+            if (UsingItemReceive.shouldClearUsingOnMobEquipment(player.isUsingItem(), previousHeldIndex, pk.hotbarSlot)) {
+                player.setUsingItem(false);
+            }
+        } else {
+            player.setUsingItem(false);
         }
-
-        player.setUsingItem(false);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/network/process/processor/common/MobEquipmentProcessor.java
+++ b/src/main/java/cn/nukkit/network/process/processor/common/MobEquipmentProcessor.java
@@ -63,7 +63,7 @@ public class MobEquipmentProcessor extends DataPacketProcessor<MobEquipmentPacke
             PlayerInventory playerInventory = (PlayerInventory) inv;
             int previousHeldIndex = playerInventory.getHeldItemIndex();
             playerInventory.equipItem(pk.hotbarSlot);
-            if (UsingItemReceive.shouldClearUsingOnMobEquipment(player.isUsingItem(), previousHeldIndex, pk.hotbarSlot)) {
+            if (UsingItemReceive.shouldClearUsingOnMobEquipment(player.isJavaClient(), player.isUsingItem(), previousHeldIndex, pk.hotbarSlot)) {
                 player.setUsingItem(false);
             }
         } else {

--- a/src/main/java/cn/nukkit/network/protocol/PlayerActionPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/PlayerActionPacket.java
@@ -71,6 +71,12 @@ public class PlayerActionPacket extends DataPacket {
      * @since v622 1.20.40
      */
     public static final int ACTION_RECEIVED_SERVER_DATA = 36;
+    /**
+     * @since v748 1.21.40. Official Bedrock starts hold-to-use from this action
+     * when movement is not server-authoritative. MOT previously had no constant
+     * and the PlayerAction default cleared {@code setUsingItem(false)}.
+     */
+    public static final int ACTION_START_USING_ITEM = 37;
 
     public long entityId;
     public int action;

--- a/src/main/java/cn/nukkit/network/protocol/PlayerActionPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/PlayerActionPacket.java
@@ -41,6 +41,9 @@ public class PlayerActionPacket extends DataPacket {
     public static final int ACTION_INTERACT_BLOCK = 25;
     public static final int ACTION_PREDICT_DESTROY_BLOCK = 26;
     public static final int ACTION_CONTINUE_DESTROY_BLOCK = 27;
+    /**
+     * Block item-use-on. Not a hold-to-use start; skip default {@code setUsingItem(false)} only.
+     */
     public static final int ACTION_START_ITEM_USE_ON = 28;
     public static final int ACTION_STOP_ITEM_USE_ON = 29;
     /**

--- a/src/test/java/cn/nukkit/network/process/UsingItemReceiveProbe.java
+++ b/src/test/java/cn/nukkit/network/process/UsingItemReceiveProbe.java
@@ -25,9 +25,9 @@ public final class UsingItemReceiveProbe {
         PlayerAuthInputPacket packet = decodeNetEase860StartUsingItem();
         boolean decodedStart = UsingItemReceive.authInputStartsUsingItem(packet);
         boolean wouldStart = UsingItemReceive.shouldStartUsingFromAuthInput(true, false, false, true, decodedStart);
-        boolean keepSprint = UsingItemReceive.shouldKeepUsingDespiteStartSprinting(true, decodedStart);
-        boolean startActionKept = !UsingItemReceive.shouldClearUsingOnUnhandledPlayerAction(PlayerActionPacket.ACTION_START_USING_ITEM);
-        boolean useOnKept = !UsingItemReceive.shouldClearUsingOnUnhandledPlayerAction(PlayerActionPacket.ACTION_START_ITEM_USE_ON);
+        boolean keepSprint = UsingItemReceive.shouldKeepUsingDespiteStartSprinting(true, true, decodedStart);
+        boolean startActionKept = !UsingItemReceive.shouldClearUsingOnUnhandledPlayerAction(true, PlayerActionPacket.ACTION_START_USING_ITEM);
+        boolean useOnKept = !UsingItemReceive.shouldClearUsingOnUnhandledPlayerAction(true, PlayerActionPacket.ACTION_START_ITEM_USE_ON);
         if (!decodedStart || !wouldStart || !keepSprint || !startActionKept || !useOnKept) {
             throw new IllegalStateException("UsingItem receive probe failed: decodedStart=" + decodedStart
                     + " wouldStart=" + wouldStart

--- a/src/test/java/cn/nukkit/network/process/UsingItemReceiveProbe.java
+++ b/src/test/java/cn/nukkit/network/process/UsingItemReceiveProbe.java
@@ -25,7 +25,7 @@ public final class UsingItemReceiveProbe {
         PlayerAuthInputPacket packet = decodeNetEase860StartUsingItem();
         boolean decodedStart = UsingItemReceive.authInputStartsUsingItem(packet);
         boolean wouldStart = UsingItemReceive.shouldStartUsingFromAuthInput(true, false, false, true, decodedStart);
-        boolean keepSprint = UsingItemReceive.shouldKeepUsingDespiteStartSprinting(false, true, decodedStart);
+        boolean keepSprint = UsingItemReceive.shouldKeepUsingDespiteStartSprinting(true, decodedStart);
         boolean startActionKept = !UsingItemReceive.shouldClearUsingOnUnhandledPlayerAction(PlayerActionPacket.ACTION_START_USING_ITEM);
         boolean useOnKept = !UsingItemReceive.shouldClearUsingOnUnhandledPlayerAction(PlayerActionPacket.ACTION_START_ITEM_USE_ON);
         if (!decodedStart || !wouldStart || !keepSprint || !startActionKept || !useOnKept) {

--- a/src/test/java/cn/nukkit/network/process/UsingItemReceiveProbe.java
+++ b/src/test/java/cn/nukkit/network/process/UsingItemReceiveProbe.java
@@ -1,0 +1,85 @@
+package cn.nukkit.network.process;
+
+import cn.nukkit.GameVersion;
+import cn.nukkit.network.protocol.PlayerActionPacket;
+import cn.nukkit.network.protocol.PlayerAuthInputPacket;
+import cn.nukkit.network.protocol.ProtocolInfo;
+import cn.nukkit.network.protocol.types.AuthInputAction;
+import cn.nukkit.network.protocol.types.AuthInteractionModel;
+import cn.nukkit.network.protocol.types.ClientPlayMode;
+import cn.nukkit.network.protocol.types.InputMode;
+import cn.nukkit.utils.BinaryStream;
+
+/**
+ * Tiny in-process communication check used by the local MOT boot test.
+ * It encodes/decodes the START_USING_ITEM AuthInput bit the same way a NetEase 860
+ * client (and ViaBedrock experimental) would, then asserts MOT now maps that bit
+ * onto the setUsingItem receive helper instead of ignoring it.
+ */
+public final class UsingItemReceiveProbe {
+
+    private UsingItemReceiveProbe() {
+    }
+
+    public static String run() {
+        PlayerAuthInputPacket packet = decodeNetEase860StartUsingItem();
+        boolean decodedStart = UsingItemReceive.authInputStartsUsingItem(packet);
+        boolean wouldStart = UsingItemReceive.shouldStartUsingFromAuthInput(true, false, false, true, decodedStart);
+        boolean keepSprint = UsingItemReceive.shouldKeepUsingDespiteStartSprinting(false, true, decodedStart);
+        boolean startActionKept = !UsingItemReceive.shouldClearUsingOnUnhandledPlayerAction(PlayerActionPacket.ACTION_START_USING_ITEM);
+        boolean useOnKept = !UsingItemReceive.shouldClearUsingOnUnhandledPlayerAction(PlayerActionPacket.ACTION_START_ITEM_USE_ON);
+        if (!decodedStart || !wouldStart || !keepSprint || !startActionKept || !useOnKept) {
+            throw new IllegalStateException("UsingItem receive probe failed: decodedStart=" + decodedStart
+                    + " wouldStart=" + wouldStart
+                    + " keepSprint=" + keepSprint
+                    + " startActionKept=" + startActionKept
+                    + " useOnKept=" + useOnKept
+                    + " flags=" + packet.getInputData());
+        }
+        return "ok protocol=" + packet.protocol
+                + " gameVersion=" + packet.gameVersion
+                + " START_USING_ITEM_ordinal=" + AuthInputAction.START_USING_ITEM.ordinal()
+                + " ACTION_START_USING_ITEM=" + PlayerActionPacket.ACTION_START_USING_ITEM
+                + " flags=" + packet.getInputData();
+    }
+
+    /**
+     * Encode a NetEase 860 PlayerAuthInput payload with START_USING_ITEM on the
+     * extra-flag-shifted wire bit (ordinal 53 + 1 extra flag for protocol 860).
+     * MOT used to decode that bit and then ignore it.
+     */
+    static PlayerAuthInputPacket decodeNetEase860StartUsingItem() {
+        int extraFlags = 2; // protocol 860 is >= 819, NetEase inserts two hidden flags
+        int startUsingOrdinal = AuthInputAction.START_USING_ITEM.ordinal();
+        long wireBit = 1L << (startUsingOrdinal + extraFlags);
+        BinaryStream stream = new BinaryStream();
+        stream.putLFloat(10.5f);
+        stream.putLFloat(20.5f);
+        stream.putVector3f(1.25f, 64.0f, -3.5f);
+        stream.putLFloat(0.25f);
+        stream.putLFloat(-0.5f);
+        stream.putLFloat(30.5f);
+        stream.putUnsignedVarLong(wireBit);
+        stream.putUnsignedVarInt(InputMode.TOUCH.ordinal());
+        stream.putUnsignedVarInt(ClientPlayMode.NORMAL.ordinal());
+        stream.putUnsignedVarInt(AuthInteractionModel.CROSSHAIR.ordinal());
+        stream.putVector2f(5.0f, 6.0f);
+        stream.putUnsignedVarLong(123L);
+        stream.putVector3f(0.1f, 0.2f, 0.3f);
+        stream.putBoolean(false); // cameraDeparted
+        stream.putVector2f(0.6f, -0.4f);
+        stream.putVector3f(0.0f, 1.0f, 0.0f);
+        stream.putVector2f(-0.25f, 0.75f);
+
+        PlayerAuthInputPacket packet = new PlayerAuthInputPacket();
+        packet.protocol = ProtocolInfo.v1_21_124;
+        packet.gameVersion = GameVersion.V1_21_124_NETEASE;
+        packet.setBuffer(stream.getBuffer());
+        packet.decode();
+        return packet;
+    }
+
+    public static void main(String[] args) {
+        System.out.println("[UsingItemProbe] " + run());
+    }
+}

--- a/src/test/java/cn/nukkit/network/process/UsingItemReceiveTest.java
+++ b/src/test/java/cn/nukkit/network/process/UsingItemReceiveTest.java
@@ -51,17 +51,6 @@ class UsingItemReceiveTest {
     }
 
     @Test
-    void rewriteClickAirWhenEqualsFastWouldFail() {
-        Item apple = Item.get(ItemID.APPLE);
-        Item mismatch = Item.get(ItemID.APPLE);
-        mismatch.setDamage(1);
-        assertTrue(UsingItemReceive.shouldRewriteClickAirHeldItem(mismatch, apple));
-        assertTrue(UsingItemReceive.shouldRewriteClickAirHeldItem(null, apple));
-        assertFalse(UsingItemReceive.shouldRewriteClickAirHeldItem(apple.clone(), apple));
-        assertFalse(UsingItemReceive.shouldRewriteClickAirHeldItem(Item.get(ItemID.STICK), Item.get(ItemID.STICK)));
-    }
-
-    @Test
     void ignoreOnlyImmediateDuplicateClickAir() {
         assertTrue(UsingItemReceive.shouldIgnoreDuplicateClickAirStart(true, true, 0));
         assertTrue(UsingItemReceive.shouldIgnoreDuplicateClickAirStart(true, true, 1));
@@ -91,10 +80,11 @@ class UsingItemReceiveTest {
     }
 
     @Test
-    void keepUsingOnlyWhenSprintArrivesWithStartUsingItem() {
-        assertTrue(UsingItemReceive.shouldKeepUsingDespiteStartSprinting(true, true));
-        assertFalse(UsingItemReceive.shouldKeepUsingDespiteStartSprinting(true, false));
-        assertFalse(UsingItemReceive.shouldKeepUsingDespiteStartSprinting(false, true));
+    void keepUsingOnlyForJavaSprintAndStartUsingItem() {
+        assertTrue(UsingItemReceive.shouldKeepUsingDespiteStartSprinting(true, true, true));
+        assertFalse(UsingItemReceive.shouldKeepUsingDespiteStartSprinting(true, true, false));
+        assertFalse(UsingItemReceive.shouldKeepUsingDespiteStartSprinting(false, true, true));
+        assertFalse(UsingItemReceive.shouldKeepUsingDespiteStartSprinting(true, false, true));
     }
 
     @Test
@@ -105,36 +95,32 @@ class UsingItemReceiveTest {
         assertTrue(UsingItemReceive.isItemUseOnPlayerAction(PlayerActionPacket.ACTION_START_ITEM_USE_ON));
         assertTrue(UsingItemReceive.isItemUseOnPlayerAction(PlayerActionPacket.ACTION_STOP_ITEM_USE_ON));
         assertFalse(UsingItemReceive.isItemUseOnPlayerAction(PlayerActionPacket.ACTION_START_USING_ITEM));
-        assertFalse(UsingItemReceive.shouldClearUsingOnUnhandledPlayerAction(PlayerActionPacket.ACTION_START_ITEM_USE_ON));
-        assertFalse(UsingItemReceive.shouldClearUsingOnUnhandledPlayerAction(PlayerActionPacket.ACTION_STOP_ITEM_USE_ON));
-        assertFalse(UsingItemReceive.shouldClearUsingOnUnhandledPlayerAction(PlayerActionPacket.ACTION_START_USING_ITEM));
-        assertTrue(UsingItemReceive.shouldClearUsingOnUnhandledPlayerAction(PlayerActionPacket.ACTION_ABORT_BREAK));
-        assertTrue(UsingItemReceive.shouldClearUsingOnUnhandledPlayerAction(99));
+        assertFalse(UsingItemReceive.shouldClearUsingOnUnhandledPlayerAction(true, PlayerActionPacket.ACTION_START_ITEM_USE_ON));
+        assertFalse(UsingItemReceive.shouldClearUsingOnUnhandledPlayerAction(true, PlayerActionPacket.ACTION_STOP_ITEM_USE_ON));
+        assertFalse(UsingItemReceive.shouldClearUsingOnUnhandledPlayerAction(true, PlayerActionPacket.ACTION_START_USING_ITEM));
+        assertTrue(UsingItemReceive.shouldClearUsingOnUnhandledPlayerAction(true, PlayerActionPacket.ACTION_ABORT_BREAK));
+        assertTrue(UsingItemReceive.shouldClearUsingOnUnhandledPlayerAction(false, PlayerActionPacket.ACTION_START_ITEM_USE_ON));
+        assertTrue(UsingItemReceive.shouldClearUsingOnUnhandledPlayerAction(false, PlayerActionPacket.ACTION_START_USING_ITEM));
+        assertTrue(UsingItemReceive.shouldClearUsingOnUnhandledPlayerAction(false, 99));
     }
 
     @Test
-    void sameSlotMobEquipmentKeepsUsing() {
-        assertFalse(UsingItemReceive.shouldClearUsingOnMobEquipment(true, 0, 0));
-        assertTrue(UsingItemReceive.shouldClearUsingOnMobEquipment(true, 0, 1));
-        assertFalse(UsingItemReceive.shouldClearUsingOnMobEquipment(false, 0, 1));
+    void sameSlotMobEquipmentKeepsUsingOnlyForJavaClient() {
+        assertFalse(UsingItemReceive.shouldClearUsingOnMobEquipment(true, true, 0, 0));
+        assertTrue(UsingItemReceive.shouldClearUsingOnMobEquipment(true, true, 0, 1));
+        assertTrue(UsingItemReceive.shouldClearUsingOnMobEquipment(false, true, 0, 0));
+        assertFalse(UsingItemReceive.shouldClearUsingOnMobEquipment(true, false, 0, 1));
     }
 
     @Test
-    void keepUsingWhenClickBlockArrivesDuringHold() {
-        assertTrue(UsingItemReceive.shouldKeepUsingOnClickBlock(true, true));
-        assertFalse(UsingItemReceive.shouldKeepUsingOnClickBlock(false, true));
-        assertFalse(UsingItemReceive.shouldKeepUsingOnClickBlock(true, false));
+    void keepUsingOnClickBlockOnlyForJavaClient() {
+        assertTrue(UsingItemReceive.shouldKeepUsingOnClickBlock(true, true, true, false));
+        assertFalse(UsingItemReceive.shouldKeepUsingOnClickBlock(false, true, true, false));
+        assertFalse(UsingItemReceive.shouldKeepUsingOnClickBlock(true, false, true, false));
+        assertFalse(UsingItemReceive.shouldKeepUsingOnClickBlock(true, true, false, false));
+        assertFalse(UsingItemReceive.shouldKeepUsingOnClickBlock(true, true, true, true));
     }
 
-    @Test
-    void keepUsingOnReleaseOnlyForTheFirstTicks() {
-        assertTrue(UsingItemReceive.shouldKeepUsingOnEarlyRelease(true, true, 0));
-        assertTrue(UsingItemReceive.shouldKeepUsingOnEarlyRelease(true, true, 1));
-        assertFalse(UsingItemReceive.shouldKeepUsingOnEarlyRelease(true, true, 2));
-        assertFalse(UsingItemReceive.shouldKeepUsingOnEarlyRelease(true, true, 31));
-        assertFalse(UsingItemReceive.shouldKeepUsingOnEarlyRelease(false, true, 0));
-        assertFalse(UsingItemReceive.shouldKeepUsingOnEarlyRelease(true, false, 0));
-    }
 
     @Test
     void netease860AuthInputStartUsingItemDecodesAndWouldSetUsingItem() {

--- a/src/test/java/cn/nukkit/network/process/UsingItemReceiveTest.java
+++ b/src/test/java/cn/nukkit/network/process/UsingItemReceiveTest.java
@@ -113,6 +113,16 @@ class UsingItemReceiveTest {
     }
 
     @Test
+    void neverRetainUsingOnEarlyJavaRelease() {
+        assertFalse(UsingItemReceive.shouldRetainUsingOnEarlyJavaRelease(true, true, true, 0));
+        assertFalse(UsingItemReceive.shouldRetainUsingOnEarlyJavaRelease(true, true, true, 1));
+        assertFalse(UsingItemReceive.shouldRetainUsingOnEarlyJavaRelease(true, true, true, 32));
+        assertFalse(UsingItemReceive.shouldRetainUsingOnEarlyJavaRelease(false, true, true, 0));
+        assertFalse(UsingItemReceive.shouldRetainUsingOnEarlyJavaRelease(true, false, true, 0));
+        assertFalse(UsingItemReceive.shouldRetainUsingOnEarlyJavaRelease(true, true, false, 0));
+    }
+
+    @Test
     void keepUsingOnClickBlockOnlyForJavaClient() {
         assertTrue(UsingItemReceive.shouldKeepUsingOnClickBlock(true, true, true, false));
         assertFalse(UsingItemReceive.shouldKeepUsingOnClickBlock(false, true, true, false));

--- a/src/test/java/cn/nukkit/network/process/UsingItemReceiveTest.java
+++ b/src/test/java/cn/nukkit/network/process/UsingItemReceiveTest.java
@@ -1,0 +1,141 @@
+package cn.nukkit.network.process;
+
+import cn.nukkit.MockServer;
+import cn.nukkit.inventory.transaction.data.UseItemData;
+import cn.nukkit.item.Item;
+import cn.nukkit.item.ItemID;
+import cn.nukkit.network.protocol.InventoryTransactionPacket;
+import cn.nukkit.network.protocol.PlayerActionPacket;
+import cn.nukkit.network.protocol.PlayerAuthInputPacket;
+import cn.nukkit.network.protocol.types.AuthInputAction;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.EnumSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * MOT previously parsed AuthInput START_USING_ITEM / PlayerAction 28/29/37 and then
+ * ignored them (default {@code setUsingItem(false)}). Java clients animate locally,
+ * so other players never saw eat/draw. These cases lock the receive-side rules.
+ */
+class UsingItemReceiveTest {
+
+    @BeforeAll
+    static void init() {
+        MockServer.init();
+    }
+
+    @Test
+    void appleAndBowAreHoldToUse() {
+        assertTrue(UsingItemReceive.isHoldToUseItem(Item.get(ItemID.APPLE)));
+        assertTrue(UsingItemReceive.isHoldToUseItem(Item.get(ItemID.BOW)));
+        assertTrue(UsingItemReceive.isHoldToUseItem(Item.get(ItemID.POTION)));
+        assertFalse(UsingItemReceive.isHoldToUseItem(Item.get(ItemID.STICK)));
+        assertFalse(UsingItemReceive.isHoldToUseItem(Item.get(0)));
+        assertFalse(UsingItemReceive.isHoldToUseItem(null));
+    }
+
+    @Test
+    void clickAirTypeDetection() {
+        UseItemData data = new UseItemData();
+        data.actionType = InventoryTransactionPacket.USE_ITEM_ACTION_CLICK_AIR;
+        assertTrue(UsingItemReceive.isClickAirUse(InventoryTransactionPacket.TYPE_USE_ITEM, data));
+        data.actionType = InventoryTransactionPacket.USE_ITEM_ACTION_CLICK_BLOCK;
+        assertFalse(UsingItemReceive.isClickAirUse(InventoryTransactionPacket.TYPE_USE_ITEM, data));
+        assertFalse(UsingItemReceive.isClickAirUse(InventoryTransactionPacket.TYPE_RELEASE_ITEM, data));
+    }
+
+    @Test
+    void rewriteClickAirWhenEqualsFastWouldFail() {
+        Item apple = Item.get(ItemID.APPLE);
+        Item mismatch = Item.get(ItemID.APPLE);
+        mismatch.setDamage(1);
+        assertTrue(UsingItemReceive.shouldRewriteClickAirHeldItem(mismatch, apple));
+        assertTrue(UsingItemReceive.shouldRewriteClickAirHeldItem(null, apple));
+        assertFalse(UsingItemReceive.shouldRewriteClickAirHeldItem(apple.clone(), apple));
+        assertFalse(UsingItemReceive.shouldRewriteClickAirHeldItem(Item.get(ItemID.STICK), Item.get(ItemID.STICK)));
+    }
+
+    @Test
+    void ignoreOnlyImmediateDuplicateClickAir() {
+        assertTrue(UsingItemReceive.shouldIgnoreDuplicateClickAirStart(true, true, 0));
+        assertTrue(UsingItemReceive.shouldIgnoreDuplicateClickAirStart(true, true, 1));
+        assertFalse(UsingItemReceive.shouldIgnoreDuplicateClickAirStart(true, true, 32));
+        assertFalse(UsingItemReceive.shouldIgnoreDuplicateClickAirStart(false, true, 0));
+        assertFalse(UsingItemReceive.shouldIgnoreDuplicateClickAirStart(true, false, 0));
+    }
+
+    @Test
+    void authInputStartUsingItemFlag() {
+        PlayerAuthInputPacket packet = new PlayerAuthInputPacket();
+        packet.setInputData(EnumSet.of(AuthInputAction.START_USING_ITEM));
+        assertTrue(UsingItemReceive.authInputStartsUsingItem(packet));
+        packet.setInputData(EnumSet.of(AuthInputAction.PERFORM_ITEM_INTERACTION));
+        assertFalse(UsingItemReceive.authInputStartsUsingItem(packet));
+        assertFalse(UsingItemReceive.authInputStartsUsingItem(null));
+    }
+
+    @Test
+    void startFromAuthInputUsesServerHeldConsumable() {
+        assertTrue(UsingItemReceive.shouldStartUsingFromAuthInput(true, false, false, true, true));
+        assertFalse(UsingItemReceive.shouldStartUsingFromAuthInput(true, false, true, true, true));
+        assertFalse(UsingItemReceive.shouldStartUsingFromAuthInput(true, true, false, true, true));
+        assertFalse(UsingItemReceive.shouldStartUsingFromAuthInput(false, false, false, true, true));
+        assertFalse(UsingItemReceive.shouldStartUsingFromAuthInput(true, false, false, false, true));
+        assertFalse(UsingItemReceive.shouldStartUsingFromAuthInput(true, false, false, true, false));
+    }
+
+    @Test
+    void keepUsingWhenSprintArrivesWithStartUsingItem() {
+        assertTrue(UsingItemReceive.shouldKeepUsingDespiteStartSprinting(false, true, true));
+        assertTrue(UsingItemReceive.shouldKeepUsingDespiteStartSprinting(true, true, false));
+        assertFalse(UsingItemReceive.shouldKeepUsingDespiteStartSprinting(false, false, true));
+        assertFalse(UsingItemReceive.shouldKeepUsingDespiteStartSprinting(false, true, false));
+    }
+
+    @Test
+    void playerActionStartUsingDoesNotFallThroughToClear() {
+        assertTrue(UsingItemReceive.isStartUsingPlayerAction(PlayerActionPacket.ACTION_START_ITEM_USE_ON));
+        assertTrue(UsingItemReceive.isStartUsingPlayerAction(PlayerActionPacket.ACTION_START_USING_ITEM));
+        assertEquals(37, PlayerActionPacket.ACTION_START_USING_ITEM);
+        assertTrue(UsingItemReceive.isStopUsingPlayerAction(PlayerActionPacket.ACTION_STOP_ITEM_USE_ON));
+        assertFalse(UsingItemReceive.shouldClearUsingOnUnhandledPlayerAction(PlayerActionPacket.ACTION_START_ITEM_USE_ON));
+        assertFalse(UsingItemReceive.shouldClearUsingOnUnhandledPlayerAction(PlayerActionPacket.ACTION_STOP_ITEM_USE_ON));
+        assertFalse(UsingItemReceive.shouldClearUsingOnUnhandledPlayerAction(PlayerActionPacket.ACTION_START_USING_ITEM));
+        assertTrue(UsingItemReceive.shouldClearUsingOnUnhandledPlayerAction(PlayerActionPacket.ACTION_ABORT_BREAK));
+        assertTrue(UsingItemReceive.shouldClearUsingOnUnhandledPlayerAction(99));
+    }
+
+    @Test
+    void sameSlotMobEquipmentKeepsUsing() {
+        assertFalse(UsingItemReceive.shouldClearUsingOnMobEquipment(true, 0, 0));
+        assertTrue(UsingItemReceive.shouldClearUsingOnMobEquipment(true, 0, 1));
+        assertFalse(UsingItemReceive.shouldClearUsingOnMobEquipment(false, 0, 1));
+    }
+
+    @Test
+    void keepUsingWhenClickBlockArrivesDuringHold() {
+        assertTrue(UsingItemReceive.shouldKeepUsingOnClickBlock(true, true));
+        assertFalse(UsingItemReceive.shouldKeepUsingOnClickBlock(false, true));
+        assertFalse(UsingItemReceive.shouldKeepUsingOnClickBlock(true, false));
+    }
+
+    @Test
+    void keepUsingOnReleaseOnlyForTheFirstTicks() {
+        assertTrue(UsingItemReceive.shouldKeepUsingOnEarlyRelease(true, true, 0));
+        assertTrue(UsingItemReceive.shouldKeepUsingOnEarlyRelease(true, true, 1));
+        assertFalse(UsingItemReceive.shouldKeepUsingOnEarlyRelease(true, true, 2));
+        assertFalse(UsingItemReceive.shouldKeepUsingOnEarlyRelease(true, true, 31));
+        assertFalse(UsingItemReceive.shouldKeepUsingOnEarlyRelease(false, true, 0));
+        assertFalse(UsingItemReceive.shouldKeepUsingOnEarlyRelease(true, false, 0));
+    }
+
+    @Test
+    void netease860AuthInputStartUsingItemDecodesAndWouldSetUsingItem() {
+        assertTrue(UsingItemReceiveProbe.run().startsWith("ok "));
+    }
+}

--- a/src/test/java/cn/nukkit/network/process/UsingItemReceiveTest.java
+++ b/src/test/java/cn/nukkit/network/process/UsingItemReceiveTest.java
@@ -18,9 +18,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * MOT previously parsed AuthInput START_USING_ITEM / PlayerAction 28/29/37 and then
+ * MOT previously parsed AuthInput START_USING_ITEM / PlayerAction 37 and then
  * ignored them (default {@code setUsingItem(false)}). Java clients animate locally,
- * so other players never saw eat/draw. These cases lock the receive-side rules.
+ * so other players never saw eat/draw. PlayerAction 28/29 skip that clear but do
+ * not start the hold. These cases lock the receive-side rules.
  */
 class UsingItemReceiveTest {
 
@@ -90,19 +91,20 @@ class UsingItemReceiveTest {
     }
 
     @Test
-    void keepUsingWhenSprintArrivesWithStartUsingItem() {
-        assertTrue(UsingItemReceive.shouldKeepUsingDespiteStartSprinting(false, true, true));
-        assertTrue(UsingItemReceive.shouldKeepUsingDespiteStartSprinting(true, true, false));
-        assertFalse(UsingItemReceive.shouldKeepUsingDespiteStartSprinting(false, false, true));
-        assertFalse(UsingItemReceive.shouldKeepUsingDespiteStartSprinting(false, true, false));
+    void keepUsingOnlyWhenSprintArrivesWithStartUsingItem() {
+        assertTrue(UsingItemReceive.shouldKeepUsingDespiteStartSprinting(true, true));
+        assertFalse(UsingItemReceive.shouldKeepUsingDespiteStartSprinting(true, false));
+        assertFalse(UsingItemReceive.shouldKeepUsingDespiteStartSprinting(false, true));
     }
 
     @Test
     void playerActionStartUsingDoesNotFallThroughToClear() {
-        assertTrue(UsingItemReceive.isStartUsingPlayerAction(PlayerActionPacket.ACTION_START_ITEM_USE_ON));
+        assertFalse(UsingItemReceive.isStartUsingPlayerAction(PlayerActionPacket.ACTION_START_ITEM_USE_ON));
         assertTrue(UsingItemReceive.isStartUsingPlayerAction(PlayerActionPacket.ACTION_START_USING_ITEM));
         assertEquals(37, PlayerActionPacket.ACTION_START_USING_ITEM);
-        assertTrue(UsingItemReceive.isStopUsingPlayerAction(PlayerActionPacket.ACTION_STOP_ITEM_USE_ON));
+        assertTrue(UsingItemReceive.isItemUseOnPlayerAction(PlayerActionPacket.ACTION_START_ITEM_USE_ON));
+        assertTrue(UsingItemReceive.isItemUseOnPlayerAction(PlayerActionPacket.ACTION_STOP_ITEM_USE_ON));
+        assertFalse(UsingItemReceive.isItemUseOnPlayerAction(PlayerActionPacket.ACTION_START_USING_ITEM));
         assertFalse(UsingItemReceive.shouldClearUsingOnUnhandledPlayerAction(PlayerActionPacket.ACTION_START_ITEM_USE_ON));
         assertFalse(UsingItemReceive.shouldClearUsingOnUnhandledPlayerAction(PlayerActionPacket.ACTION_STOP_ITEM_USE_ON));
         assertFalse(UsingItemReceive.shouldClearUsingOnUnhandledPlayerAction(PlayerActionPacket.ACTION_START_USING_ITEM));


### PR DESCRIPTION
## 背景

当 Java 国际版客户端通过 ViaBedrock / ViaProxy 连上 Nukkit-MOT 时，吃/喝/拉弓会在客户端本地播放动作，但服务端经常从未进入 `setUsingItem(true)`。其他玩家因此看不到 `DATA_FLAG_ACTION`，附魔金苹果等长按使用物品也无法走完服务端自动完成。

根因是 MOT 已经解析了 AuthInput `START_USING_ITEM` 和相关 PlayerAction，随后又在多条默认路径里把 using 清掉：

- AuthInput `START_USING_ITEM` 被解析后忽略
- 同槽位 MobEquipment 确认包会取消长按
- 紧随其后的第二包 `CLICK_AIR` 被当成 0 tick 结束
- Java 在下一 tick 发来的 `USE_ITEM_ON` / `RELEASE_USE_ITEM` 会 `setUsingItem(false)`，附魔金苹果还没开始就被取消

## 改动

- 从 AuthInput `START_USING_ITEM` 以及 PlayerAction 28 / 37 用**服务端手持物品**启动长按
- 同槽位 MobEquipment 不再取消 using
- 忽略启动后立刻到来的重复 `CLICK_AIR`
- 长按期间忽略 `CLICK_BLOCK` 和 1 tick 内的 `RELEASE`，避免自动完成还没开始就被取消
- 抽出 `UsingItemReceive` 规则，并补上网易 860 AuthInput 探测和单元测试

本 PR 不含 ViaBedrock JE debug 日志开关。