### PR TITLE
perf(skin): cache Skin content fingerprint

### DIFF
--- a/src/main/java/cn/nukkit/entity/data/Skin.java
+++ b/src/main/java/cn/nukkit/entity/data/Skin.java
@@ -88,6 +88,9 @@ public class Skin {
     @OnlyNetEase
     private byte[] bloomData;
 
+    /** 内容指纹缓存（getContentFingerprint 惰性计算；影响摘要的 setter 负责清除）。 */
+    private volatile String cachedFingerprint;
+
     public boolean isValid() {
         return isValid(Server.getInstance().doNotLimitSkinGeometry);
     }
@@ -150,6 +153,7 @@ public class Skin {
             return;
         }
         this.skinId = skinId;
+        this.cachedFingerprint = null;
     }
 
     public void generateSkinId(String name) {
@@ -168,14 +172,17 @@ public class Skin {
     public void setSkinData(SerializedImage skinData) {
         Objects.requireNonNull(skinData, "skinData");
         this.skinData = skinData;
+        this.cachedFingerprint = null;
     }
 
     public void setSkinResourcePatch(String skinResourcePatch) {
         if (skinResourcePatch == null || skinResourcePatch.trim().isEmpty()) {
             this.skinResourcePatch = GEOMETRY_CUSTOM;
+            this.cachedFingerprint = null;
             return;
         }
         this.skinResourcePatch = skinResourcePatch;
+        this.cachedFingerprint = null;
     }
 
     public void setGeometryName(String geometryName) {
@@ -215,6 +222,7 @@ public class Skin {
             capeId = null;
         }
         this.capeId = capeId;
+        this.cachedFingerprint = null;
     }
 
     public void setCapeData(byte[] capeData) {
@@ -231,6 +239,7 @@ public class Skin {
     public void setCapeData(SerializedImage capeData) {
         Objects.requireNonNull(capeData, "capeData");
         this.capeData = capeData;
+        this.cachedFingerprint = null;
     }
 
     public String getGeometryData() {
@@ -245,6 +254,7 @@ public class Skin {
         if (!geometryData.equals(this.geometryData)) {
             if (Server.getInstance().doNotLimitSkinGeometry || geometryData.getBytes().length < MAX_DATA_SIZE) {
                 this.geometryData = geometryData;
+                this.cachedFingerprint = null;
             }
         }
     }
@@ -410,8 +420,14 @@ public class Skin {
      * <p>
      * SHA-256 fingerprint over the skin payload that affects client rendering; tells whether two
      * deliveries carry the same skin.
+     * <p>
+     * 结果缓存：指纹在热路径被反复计算（一次换装事件的准入/等待/信任比对，广播时每个观察者
+     * 一次，4D 皮肤数百 KB 全量哈希会阻塞主线程）。影响摘要的六个 setter 会清除缓存。
      */
     public String getContentFingerprint() {
+        if (cachedFingerprint != null) {
+            return cachedFingerprint;
+        }
         MessageDigest digest;
         try {
             digest = MessageDigest.getInstance("SHA-256");
@@ -424,7 +440,8 @@ public class Skin {
         updateFingerprint(digest, this.getCapeId());
         updateFingerprint(digest, this.getSkinData());
         updateFingerprint(digest, this.getCapeData());
-        return HexFormat.of().formatHex(digest.digest());
+        cachedFingerprint = HexFormat.of().formatHex(digest.digest());
+        return cachedFingerprint;
     }
 
     private static void updateFingerprint(MessageDigest digest, String value) {

--- a/src/main/java/cn/nukkit/entity/data/Skin.java
+++ b/src/main/java/cn/nukkit/entity/data/Skin.java
@@ -159,6 +159,7 @@ public class Skin {
     public void generateSkinId(String name) {
         byte[] data = Binary.appendBytes(getSkinData().data, getSkinResourcePatch().getBytes(StandardCharsets.UTF_8));
         this.skinId = UUID.nameUUIDFromBytes(data) + "." + name;
+        this.cachedFingerprint = null;
     }
 
     public void setSkinData(byte[] skinData) {
@@ -191,12 +192,10 @@ public class Skin {
             this.isLegacySlim = true;
         }
 
-        if (geometryName.trim().isEmpty()) {
-            this.skinResourcePatch = GEOMETRY_CUSTOM;
-            return;
-        }
-
-        this.skinResourcePatch = "{\"geometry\" : {\"default\" : \"" + geometryName + "\"}}";
+        // 经 setSkinResourcePatch 落盘以继承指纹缓存失效（skinResourcePatch 是被哈希字段）
+        setSkinResourcePatch(geometryName.trim().isEmpty()
+                ? null
+                : "{\"geometry\" : {\"default\" : \"" + geometryName + "\"}}");
     }
 
     public String getSkinResourcePatch() {
@@ -422,11 +421,16 @@ public class Skin {
      * deliveries carry the same skin.
      * <p>
      * 结果缓存：指纹在热路径被反复计算（一次换装事件的准入/等待/信任比对，广播时每个观察者
-     * 一次，4D 皮肤数百 KB 全量哈希会阻塞主线程）。影响摘要的六个 setter 会清除缓存。
+     * 一次，4D 皮肤数百 KB 全量哈希会阻塞主线程）。影响摘要的 setter 负责清除缓存；
+     * {@code generateSkinId} 内部改写 skinId 时同样清除。
+     * <p>
+     * 契约：{@link SerializedImage#data} 按引用共享（与协议层一致），指纹假设字节在计入摘要后
+     * 不被原地改写——需要换内容请走 setter 使缓存失效。
      */
     public String getContentFingerprint() {
-        if (cachedFingerprint != null) {
-            return cachedFingerprint;
+        String cached = this.cachedFingerprint;
+        if (cached != null) {
+            return cached;
         }
         MessageDigest digest;
         try {
@@ -440,8 +444,9 @@ public class Skin {
         updateFingerprint(digest, this.getCapeId());
         updateFingerprint(digest, this.getSkinData());
         updateFingerprint(digest, this.getCapeData());
-        cachedFingerprint = HexFormat.of().formatHex(digest.digest());
-        return cachedFingerprint;
+        cached = HexFormat.of().formatHex(digest.digest());
+        this.cachedFingerprint = cached;
+        return cached;
     }
 
     private static void updateFingerprint(MessageDigest digest, String value) {


### PR DESCRIPTION
Add a volatile cachedFingerprint to Skin and lazily compute the SHA-256 content fingerprint in getContentFingerprint. Invalidate the cache in setters that affect the fingerprint (skinId, skinData, skinResourcePatch, capeId, capeData and geometryData) so changes recompute correctly. This avoids repeated expensive hashing of large skin payloads on hot paths and reduces main-thread stalls.