### PR TITLE
fix(entity): keep player death drops in a compact pile

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -6824,7 +6824,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
             if (!ev.getKeepInventory() && this.level.getGameRules().getBoolean(GameRule.DO_ENTITY_DROPS)) {
                 for (Item item : ev.getDrops()) {
                     if (!item.hasEnchantment(Enchantment.ID_VANISHING_CURSE)) {
-                        this.level.dropItem(this, item, null, true, 40);
+                        this.dropDeathItem(item);
                     }
                 }
 
@@ -6905,6 +6905,16 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                 this.dataPacket(healthPk);
             }
         }
+    }
+
+    /**
+     * Drops one inventory stack with the regular compact item motion.
+     *
+     * <p>The wide-scatter variant is for visibly throwing items and sends a death inventory far
+     * across a PvP arena. The longer death pickup delay stays unchanged; only travel is compact.
+     */
+    void dropDeathItem(Item item) {
+        this.getLevel().dropItem(this, item, null, false, 40);
     }
 
     protected boolean handleRespawnRequest() {

--- a/src/test/java/cn/nukkit/PlayerDeathDropTest.java
+++ b/src/test/java/cn/nukkit/PlayerDeathDropTest.java
@@ -1,0 +1,28 @@
+package cn.nukkit;
+
+import cn.nukkit.item.Item;
+import cn.nukkit.level.Level;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class PlayerDeathDropTest {
+
+    @Test
+    void deathDropsUseCompactMotionAndKeepTheirPickupDelay() {
+        Player player = mock(Player.class, CALLS_REAL_METHODS);
+        Level level = mock(Level.class);
+        Item item = mock(Item.class);
+        doReturn(level).when(player).getLevel();
+
+        player.dropDeathItem(item);
+
+        verify(level).dropItem(same(player), same(item), isNull(), eq(false), eq(40));
+    }
+}


### PR DESCRIPTION
Player death used Level.dropItem with wideScatter enabled, giving every inventory stack up to 0.5 horizontal velocity. The live PocketMine server uses the regular compact motion (each horizontal component within 0.1), so Nukkit scattered a kill across much more of a PvP arena.

Use regular item motion for player death while preserving the existing 40-tick pickup delay and public pickup rules. A focused test locks both the compact flag and the unchanged delay.

### Tests

`PlayerDeathDropTest` locks the compact motion flag and the unchanged 40-tick pickup delay.
