### PR TITLE
block: pour what the bucket in a dispenser actually holds

### DIFF
--- a/src/main/java/cn/nukkit/dispenser/BucketDispenseBehavior.java
+++ b/src/main/java/cn/nukkit/dispenser/BucketDispenseBehavior.java
@@ -4,6 +4,7 @@ import cn.nukkit.block.Block;
 import cn.nukkit.block.BlockDispenser;
 import cn.nukkit.block.BlockID;
 import cn.nukkit.block.BlockLiquid;
+import cn.nukkit.block.BlockPowderSnow;
 import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemBucket;
 import cn.nukkit.item.ItemID;
@@ -19,10 +20,13 @@ public class BucketDispenseBehavior extends DefaultDispenseBehavior {
         Block target = block.getSide(face);
 
         if (item.getDamage() > 0) {
-            if (target.canBeFlowedInto()) {
-                Block replace = Block.get(ItemBucket.getDamageByTarget(item.getDamage()));
+            if (target.canBeFlowedInto() && isPlaceableContent(item.getDamage())) {
+                // getDamageByTarget() translates a BLOCK id into a bucket damage, so feeding it a
+                // bucket damage answers with whatever bucket happens to carry that number: a powder
+                // snow bucket (11) came back as a lava bucket (10) and the dispenser poured lava.
+                Block replace = Block.get(ItemBucket.getBlockByDamage(item.getDamage()));
 
-                if (replace instanceof BlockLiquid) {
+                if (replace instanceof BlockLiquid || replace instanceof BlockPowderSnow) {
                     block.level.setBlock(target, replace);
                     return Item.get(ItemID.BUCKET);
                 }
@@ -33,5 +37,14 @@ public class BucketDispenseBehavior extends DefaultDispenseBehavior {
         }
 
         return super.dispense(block, face, item);
+    }
+
+    private static boolean isPlaceableContent(int damage) {
+        // A bucket that carries a creature (fish, axolotl, tadpole) also maps to water, and placing
+        // that water here would swallow the creature. Such a bucket keeps falling through to the
+        // default behavior, which throws the bucket itself out intact.
+        return damage == ItemBucket.WATER_BUCKET
+                || damage == ItemBucket.LAVA_BUCKET
+                || damage == ItemBucket.POWDER_SNOW_BUCKET;
     }
 }


### PR DESCRIPTION
A dispenser translated the bucket it fires with getDamageByTarget(), which
maps a BLOCK id to a bucket damage, not the other way round. Fed a bucket
damage it answers with whatever bucket shares that number, so a powder snow
bucket (11) came back as a lava bucket (10): the dispenser poured lava and
kept no snow at all. Water (8) and lava (10) survived only because their
bucket damage and their block id happen to be the same number.

Read the content with getBlockByDamage(), which is the inverse the class
already provides, and place it when it is a liquid or powder snow. A bucket
holding a creature is left to the default behavior: it maps to water too, and
placing that water would swallow the fish, the axolotl or the tadpole inside.
