### PR TITLE
generator: let a server read how many objects a count populator places

### DIFF
--- a/src/main/java/cn/nukkit/level/generator/populator/type/PopulatorCount.java
+++ b/src/main/java/cn/nukkit/level/generator/populator/type/PopulatorCount.java
@@ -23,6 +23,26 @@ public abstract class PopulatorCount extends Populator {
         this.baseAmount = baseAmount;
     }
 
+    /**
+     * How many objects this populator always places in a chunk.
+     *
+     * <p>Without a getter the amount can only ever be overwritten, never adjusted: a server that
+     * wants half the trees of a biome has no way to learn how many that biome asked for.
+     */
+    public final int getBaseAmount() {
+        return this.baseAmount;
+    }
+
+    /**
+     * The exclusive upper bound of the extra amount rolled on top of {@link #getBaseAmount()}.
+     *
+     * <p>Note that {@link #setRandomAmount(int)} stores its argument plus one, so this returns
+     * the bound handed to the random source rather than the value that was passed in.
+     */
+    public final int getRandomAmount() {
+        return this.randomAmount;
+    }
+
     @Override
     public final void populate(ChunkManager level, int chunkX, int chunkZ, NukkitRandom random, FullChunk chunk) {
         int count = baseAmount + random.nextBoundedInt(randomAmount);

--- a/src/main/java/cn/nukkit/level/generator/populator/type/PopulatorCount.java
+++ b/src/main/java/cn/nukkit/level/generator/populator/type/PopulatorCount.java
@@ -25,9 +25,6 @@ public abstract class PopulatorCount extends Populator {
 
     /**
      * How many objects this populator always places in a chunk.
-     *
-     * <p>Without a getter the amount can only ever be overwritten, never adjusted: a server that
-     * wants half the trees of a biome has no way to learn how many that biome asked for.
      */
     public final int getBaseAmount() {
         return this.baseAmount;


### PR DESCRIPTION
The amount a biome asks for can only be overwritten, never adjusted: there is no
way to read it back. A server that wants, say, half the trees of the vanilla
forest therefore has to hardcode a number per biome and drift away from upstream
the moment those numbers change.

Both fields already exist and are only missing their getters.
