### PR TITLE
player: keep pre-login level changes packet-free

### DIFF
--- a/src/main/java/cn/nukkit/entity/Entity.java
+++ b/src/main/java/cn/nukkit/entity/Entity.java
@@ -2719,7 +2719,7 @@ public abstract class Entity extends Location implements Metadatable {
         this.level.addEntity(this);
         this.chunk = null;
 
-        if (this instanceof Player) {
+        if (this instanceof Player player && player.isOnline()) {
             this.afterSwitchLevel();
         }
         return true;
@@ -3102,7 +3102,7 @@ public abstract class Entity extends Location implements Metadatable {
                 this.z = pos.z;
 
                 // Dimension change
-                if (this instanceof Player player && newLevel.getDimension() != oldLevel.getDimension()) {
+                if (this instanceof Player player && player.isOnline() && newLevel.getDimension() != oldLevel.getDimension()) {
                     player.setDimension(newLevel.getDimension());
                 }
 


### PR DESCRIPTION
PlayerLoginEvent runs before StartGame, which makes it the only safe hook for
moving a player away from a saved position that crashes their client. A level
change from that hook currently calls Player.afterSwitchLevel and emits spawn,
time, weather and gamerule packets before StartGame. Crossing dimensions also
emits ChangeDimension. Besides being useless, that packet order is invalid for
clients which have not entered the world yet.

Keep the server-side level and position change, but defer all client-facing
level-change packets until the player is actually online. StartGame is built
after PlayerLoginEvent and therefore reads the relocated level and coordinates.
