### PR TITLE
generator: honor the layer a populator writes into

### DIFF
--- a/src/main/java/cn/nukkit/level/generator/SimpleChunkManager.java
+++ b/src/main/java/cn/nukkit/level/generator/SimpleChunkManager.java
@@ -65,7 +65,7 @@ public abstract class SimpleChunkManager implements ChunkManager {
 
         FullChunk chunk = this.getChunk(x >> 4, z >> 4);
         if (chunk != null) {
-            return chunk.setBlock(x & 0xf, y, z & 0xf, id, data);
+            return chunk.setBlockAtLayer(x & 0xf, y, z & 0xf, layer, id, data);
         }
         return false;
     }


### PR DESCRIPTION
SimpleChunkManager.setBlockAtLayer accepted a layer argument and silently
dropped it: every write went to layer 0. A populator that placed a block
and then cleared layer 1 (to strip water) erased its own block instead -
the layer-1 air landed in layer 0 on top of it. No warning was logged;
the block was simply gone before the chunk was ever saved.

Route the write through FullChunk.setBlockAtLayer, which honors layers.
