### PR TITLE
custom-block: translate legacy render method names for new clients

### DIFF
--- a/src/main/java/cn/nukkit/block/custom/serializer/impl/CustomBlockDefinitionSerializer843.java
+++ b/src/main/java/cn/nukkit/block/custom/serializer/impl/CustomBlockDefinitionSerializer843.java
@@ -48,6 +48,14 @@ public class CustomBlockDefinitionSerializer843 extends CustomBlockDefinitionSer
                     material.remove("face_dimming");
                     material.putByte("packed_bools", (byte) (faceDimming ? 0x1 : 0x0));
                 }
+                // 1.21.80+ material overhaul: the legacy "alpha_test" name is silently
+                // ignored by new clients and the material falls back to opaque, so every
+                // transparent texel renders black. Translate to the modern name here;
+                // older clients keep the legacy name they understand.
+                if (material.contains("render_method")
+                        && material.getString("render_method").equals("alpha_test")) {
+                    material.putString("render_method", "alpha_test_single_sided");
+                }
             }
         }
     }


### PR DESCRIPTION
Clients since the 1.21.80 material overhaul silently ignore the legacy
"alpha_test" render method name in a network-defined block: the material
falls back to opaque and every transparent texel renders as a black
pixel. No warning appears anywhere - the texture itself still applies,
so the block looks almost right and the defect surfaces only on the
first custom block with actual transparency in its texture.

Translate the render method per protocol in the definition serializer,
next to the existing face_dimming/ambient_occlusion conversions: for
1.21.110+ clients "alpha_test" becomes "alpha_test_single_sided". Old
clients keep the legacy name they understand.
