### PR TITLE
player: replace fully transparent skins with Steve

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -969,6 +969,9 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
 
     @Override
     public void setSkin(Skin skin) {
+        if (skin.isFullyTransparent()) {
+            skin = Skin.NO_PERSONA_SKIN;
+        }
         Skin previousSkin = this.getSkin();
         super.setSkin(skin);
         if (!this.spawned) {

--- a/src/main/java/cn/nukkit/entity/data/Skin.java
+++ b/src/main/java/cn/nukkit/entity/data/Skin.java
@@ -99,6 +99,23 @@ public class Skin {
         return isValidSkin(doNotLimitSkinGeometry) && isValidResourcePatch();
     }
 
+    /**
+     * Returns whether every pixel in this skin is completely transparent.
+     * Empty and malformed images are left to the regular skin validation path.
+     */
+    public boolean isFullyTransparent() {
+        byte[] data = getSkinData().data;
+        if (data.length < PIXEL_SIZE || data.length % PIXEL_SIZE != 0) {
+            return false;
+        }
+        for (int alpha = PIXEL_SIZE - 1; alpha < data.length; alpha += PIXEL_SIZE) {
+            if (data[alpha] != 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     private boolean isValidSkin() {
         return isValidSkin(Server.getInstance().doNotLimitSkinGeometry);
     }

--- a/src/test/java/cn/nukkit/PlayerSkinLifecycleTest.java
+++ b/src/test/java/cn/nukkit/PlayerSkinLifecycleTest.java
@@ -2,6 +2,7 @@ package cn.nukkit;
 
 import cn.nukkit.entity.data.Skin;
 import cn.nukkit.inventory.PlayerOffhandInventory;
+import cn.nukkit.network.process.processor.common.PlayerSkinProcessor;
 import cn.nukkit.network.SourceInterface;
 import cn.nukkit.network.protocol.*;
 import cn.nukkit.network.session.NetworkPlayerSession;
@@ -34,6 +35,38 @@ class PlayerSkinLifecycleTest {
                 any(UUID.class), any(Player.class));
         doCallRealMethod().when(this.server).removePlayerListData(
                 any(UUID.class), any(Player[].class));
+    }
+
+    @Test
+    void preSpawnFullyTransparentSkinFallsBackToSteve() {
+        RecordingPlayer subject = newPlayer(GameVersion.V1_21_124, "old-skin");
+        subject.spawned = false;
+
+        subject.setSkin(fullyTransparentSkin("transparent-login"));
+
+        assertSame(Skin.NO_PERSONA_SKIN, subject.getSkin());
+        assertTrue(subject.sentPackets.isEmpty());
+    }
+
+    @Test
+    void playerSkinPacketFullyTransparentSkinFallsBackToSteve() {
+        RecordingPlayer subject = newPlayer(GameVersion.V1_21_124, "old-skin");
+        PlayerSkinPacket packet = new PlayerSkinPacket();
+        packet.skin = fullyTransparentSkin("transparent-change");
+
+        PlayerSkinProcessor.INSTANCE.handle(new PlayerHandle(subject), packet);
+
+        assertSame(Skin.NO_PERSONA_SKIN, subject.getSkin());
+    }
+
+    @Test
+    void skinWithOneOpaquePixelIsPreserved() {
+        RecordingPlayer subject = newPlayer(GameVersion.V1_21_124, "old-skin");
+        Skin visible = validSkin("visible-skin");
+
+        subject.setSkin(visible);
+
+        assertSame(visible, subject.getSkin());
     }
 
     @Test
@@ -517,8 +550,16 @@ class PlayerSkinLifecycleTest {
     private static Skin validSkin(String skinId) {
         Skin skin = new Skin();
         skin.setSkinId(skinId);
-        skin.setSkinData(new byte[Skin.SINGLE_SKIN_SIZE]);
+        byte[] skinData = new byte[Skin.SINGLE_SKIN_SIZE];
+        skinData[3] = (byte) 0xff;
+        skin.setSkinData(skinData);
         skin.setGeometryName("geometry.humanoid.custom");
+        return skin;
+    }
+
+    private static Skin fullyTransparentSkin(String skinId) {
+        Skin skin = validSkin(skinId);
+        skin.setSkinData(new byte[Skin.SINGLE_SKIN_SIZE]);
         return skin;
     }
 


### PR DESCRIPTION
Route every player skin assignment through one alpha scan. A skin whose every pixel has zero alpha is replaced with the built-in Steve skin before login or runtime propagation; a skin with any visible pixel remains unchanged.

Add regression coverage for pre-spawn login assignment and PlayerSkinPacket changes.

### Tests

`PlayerSkinLifecycleTest` covers the pre-spawn login assignment and the runtime `PlayerSkinPacket` path.
