### PR TITLE
generator: look up block flags by id so custom blocks cannot crash population

### DIFF
--- a/src/main/java/cn/nukkit/level/generator/object/mushroom/BigMushroom.java
+++ b/src/main/java/cn/nukkit/level/generator/object/mushroom/BigMushroom.java
@@ -174,7 +174,7 @@ public class BigMushroom extends BasicGenerator {
                                 if (position.getY() >= position.getY() + i - 1 || meta != ALL_INSIDE) {
                                     Vector3 blockPos = new Vector3(l1, l2, i2);
 
-                                    if (!Block.solid[level.getBlockIdAt(blockPos.getFloorX(), blockPos.getFloorY(), blockPos.getFloorZ())]) {
+                                    if (!Block.isBlockSolidById(level.getBlockIdAt(blockPos.getFloorX(), blockPos.getFloorY(), blockPos.getFloorZ()))) {
                                         mushroom.setDamage(meta);
                                         this.setBlockAndNotifyAdequately(level, blockPos, mushroom);
                                     }
@@ -187,7 +187,7 @@ public class BigMushroom extends BasicGenerator {
                         Vector3 pos = position.up(i3);
                         int id = level.getBlockIdAt(pos.getFloorX(), pos.getFloorY(), pos.getFloorZ());
 
-                        if (!Block.solid[id]) {
+                        if (!Block.isBlockSolidById(id)) {
                             mushroom.setDamage(STEM);
                             this.setBlockAndNotifyAdequately(level, pos, mushroom);
                         }

--- a/src/main/java/cn/nukkit/level/generator/object/tree/ObjectBigSpruceTree.java
+++ b/src/main/java/cn/nukkit/level/generator/object/tree/ObjectBigSpruceTree.java
@@ -116,7 +116,7 @@ public class ObjectBigSpruceTree extends ObjectSpruceTree {
                         }
                     }
 
-                    if (!isTrunk && !Block.solid[level.getBlockIdAt(xx, yyy, zz)]) {
+                    if (!isTrunk && !Block.isBlockSolidById(level.getBlockIdAt(xx, yyy, zz))) {
                         level.setBlockAt(xx, yyy, zz, this.getLeafBlock(), this.getType());
                     }
                 }
@@ -152,7 +152,7 @@ public class ObjectBigSpruceTree extends ObjectSpruceTree {
                         continue;
                     }
 
-                    if (!Block.solid[level.getBlockIdAt(xx, yyy, zz)]) {
+                    if (!Block.isBlockSolidById(level.getBlockIdAt(xx, yyy, zz))) {
                         level.setBlockAt(xx, yyy, zz, this.getLeafBlock(), this.getType());
                     }
                 }

--- a/src/main/java/cn/nukkit/level/generator/object/tree/ObjectNetherTree.java
+++ b/src/main/java/cn/nukkit/level/generator/object/tree/ObjectNetherTree.java
@@ -42,7 +42,7 @@ public abstract class ObjectNetherTree extends ObjectTree {
                     if (xOff == mid && zOff == mid && random.nextBoundedInt(2) == 0) {
                         continue;
                     }
-                    if (!Block.solid[level.getBlockIdAt(xx, yy, zz)]) {
+                    if (!Block.isBlockSolidById(level.getBlockIdAt(xx, yy, zz))) {
                         if (random.nextBoundedInt(20) == 0) {
                             level.setBlockAt(xx, yy, zz, Block.SHROOMLIGHT);
                         } else {
@@ -59,7 +59,7 @@ public abstract class ObjectNetherTree extends ObjectTree {
                     if (xOff == mid && zOff == mid && random.nextBoundedInt(2) == 0) {
                         continue;
                     }
-                    if (!Block.solid[level.getBlockIdAt(xx, yy, zz)]) {
+                    if (!Block.isBlockSolidById(level.getBlockIdAt(xx, yy, zz))) {
                         if (random.nextBoundedInt(20) == 0) {
                             level.setBlockAt(xx, yy, zz, Block.SHROOMLIGHT);
                         } else {
@@ -77,10 +77,10 @@ public abstract class ObjectNetherTree extends ObjectTree {
 
             for (int xx = x - mid; xx <= x + mid; xx++) {
                 for (int zz = z - mid; zz <= z + mid; zz += mid * 2) {
-                    if (!Block.solid[level.getBlockIdAt(xx, yy, zz)]) {
+                    if (!Block.isBlockSolidById(level.getBlockIdAt(xx, yy, zz))) {
                         if (random.nextBoundedInt(3) == 0) {
                             for (int i = 0; i < random.nextBoundedInt(5); i++) {
-                                if (!Block.solid[level.getBlockIdAt(xx, yy - i, zz)]) {
+                                if (!Block.isBlockSolidById(level.getBlockIdAt(xx, yy - i, zz))) {
                                     level.setBlockAt(xx, yy - i, zz, getLeafBlock());
                                 }
                             }
@@ -91,10 +91,10 @@ public abstract class ObjectNetherTree extends ObjectTree {
 
             for (int zz = z - mid; zz <= z + mid; zz++) {
                 for (int xx = x - mid; xx <= x + mid; xx += mid * 2) {
-                    if (!Block.solid[level.getBlockIdAt(xx, yy, zz)]) {
+                    if (!Block.isBlockSolidById(level.getBlockIdAt(xx, yy, zz))) {
                         if (random.nextBoundedInt(3) == 0) {
                             for (int i = 0; i < random.nextBoundedInt(4); i++) {
-                                if (!Block.solid[level.getBlockIdAt(xx, yy - i, zz)]) {
+                                if (!Block.isBlockSolidById(level.getBlockIdAt(xx, yy - i, zz))) {
                                     level.setBlockAt(xx, yy - i, zz, getLeafBlock());
                                 }
                             }
@@ -110,7 +110,7 @@ public abstract class ObjectNetherTree extends ObjectTree {
                 if (checkY(level, y1)) {
                     continue;
                 }
-                if (!Block.solid[level.getBlockIdAt(xCanopy, y1, zCanopy)]) {
+                if (!Block.isBlockSolidById(level.getBlockIdAt(xCanopy, y1, zCanopy))) {
                     level.setBlockAt(xCanopy, y1, zCanopy, getLeafBlock());
                 }
             }

--- a/src/main/java/cn/nukkit/level/generator/object/tree/ObjectTree.java
+++ b/src/main/java/cn/nukkit/level/generator/object/tree/ObjectTree.java
@@ -111,7 +111,7 @@ public abstract class ObjectTree {
                     if (xOff == mid && zOff == mid && (yOff == 0 || random.nextBoundedInt(2) == 0)) {
                         continue;
                     }
-                    if (!Block.solid[level.getBlockIdAt(xx, yy, zz)]) {
+                    if (!Block.isBlockSolidById(level.getBlockIdAt(xx, yy, zz))) {
                         level.setBlockAt(xx, yy, zz, this.getLeafBlock(), this.getType());
                     }
                 }

--- a/src/main/java/cn/nukkit/level/generator/populator/overworld/PopulatorDungeon.java
+++ b/src/main/java/cn/nukkit/level/generator/populator/overworld/PopulatorDungeon.java
@@ -50,7 +50,7 @@ public class PopulatorDungeon extends Populator {
                         final int tz = z + dz;
 
                         final int id = level.getBlockIdAt(tx, ty, tz);
-                        final boolean isSolid = Block.solid[id];
+                        final boolean isSolid = Block.isBlockSolidById(id);
 
                         if ((dy == -1 || dy == 4) && !isSolid) {
                             continue chance;
@@ -76,9 +76,9 @@ public class PopulatorDungeon extends Populator {
                                 if (id != BlockID.CHEST) {
                                     level.setBlockAt(tx, ty, tz, BlockID.AIR);
                                 }
-                            } else if (ty >= 0 && !Block.solid[level.getBlockIdAt(tx, ty - 1, tz)]) {
+                            } else if (ty >= 0 && !Block.isBlockSolidById(level.getBlockIdAt(tx, ty - 1, tz))) {
                                 level.setBlockAt(tx, ty, tz, BlockID.AIR);
-                            } else if (Block.solid[id] && id != BlockID.CHEST) {
+                            } else if (Block.isBlockSolidById(id) && id != BlockID.CHEST) {
                                 if (dy == -1 && random.nextBoundedInt(4) != 0) {
                                     level.setBlockAt(tx, ty, tz, BlockID.MOSS_STONE);
                                 } else {
@@ -97,16 +97,16 @@ public class PopulatorDungeon extends Populator {
                         if (level.getBlockIdAt(tx, y, tz) == BlockID.AIR) {
                             int n = 0;
 
-                            if (Block.solid[level.getBlockIdAt(tx - 1, y, tz)]) {
+                            if (Block.isBlockSolidById(level.getBlockIdAt(tx - 1, y, tz))) {
                                 ++n;
                             }
-                            if (Block.solid[level.getBlockIdAt(tx + 1, y, tz)]) {
+                            if (Block.isBlockSolidById(level.getBlockIdAt(tx + 1, y, tz))) {
                                 ++n;
                             }
-                            if (Block.solid[level.getBlockIdAt(tx, y, tz - 1)]) {
+                            if (Block.isBlockSolidById(level.getBlockIdAt(tx, y, tz - 1))) {
                                 ++n;
                             }
-                            if (Block.solid[level.getBlockIdAt(tx, y, tz + 1)]) {
+                            if (Block.isBlockSolidById(level.getBlockIdAt(tx, y, tz + 1))) {
                                 ++n;
                             }
 

--- a/src/main/java/cn/nukkit/level/generator/structure/MineshaftPieces.java
+++ b/src/main/java/cn/nukkit/level/generator/structure/MineshaftPieces.java
@@ -424,7 +424,7 @@ public final class MineshaftPieces {
                 for (int z = 0; z <= z1; ++z) {
                     final BlockState block = getBlock(level, 1, -1, z, boundingBox);
                     final int id = level.getBlockIdAt(getWorldX(1, z), getWorldY(-1), getWorldZ(1, z));
-                    if (!block.equals(BlockState.AIR) && Block.solid[id] && !Block.transparent[id]) {
+                    if (!block.equals(BlockState.AIR) && Block.isBlockSolidById(id) && !Block.isBlockTransparentById(id)) {
                         maybeGenerateBlock(level, boundingBox, random, isInterior(level, 1, 0, z, boundingBox) ? 70 : 90, 1, 0, z, RAIL__NS);
                     }
                 }

--- a/src/main/java/cn/nukkit/level/generator/structure/StructureBuilder.java
+++ b/src/main/java/cn/nukkit/level/generator/structure/StructureBuilder.java
@@ -79,7 +79,7 @@ public class StructureBuilder {
     public void setBlockDownward(final BlockVector3 pos, final int id, final int meta) {
         final BlockVector3 vec = translate(pos);
         int y = vec.y;
-        while (y > 1 && !Block.solid[level.getBlockIdAt(vec.x, y, vec.z)]) {
+        while (y > 1 && !Block.isBlockSolidById(level.getBlockIdAt(vec.x, y, vec.z))) {
             level.setBlockAt(vec.x, y, vec.z, id, meta);
             y--;
         }

--- a/src/main/java/cn/nukkit/level/generator/structure/VillagePieces.java
+++ b/src/main/java/cn/nukkit/level/generator/structure/VillagePieces.java
@@ -285,7 +285,7 @@ public final class VillagePieces {
                             final int cz = z & 0xf;
                             int y = chunk.getHighestBlockAt(cx, cz);
                             int id = chunk.getBlockId(cx, y, cz);
-                            while (Block.transparent[id] && y > 63 + 1 - 1 + yOffset) {
+                            while (Block.isBlockTransparentById(id) && y > 63 + 1 - 1 + yOffset) {
                                 id = chunk.getBlockId(cx, --y, cz);
                             }
                             sum += Math.max(y, 63 + 1 - 1 + yOffset);
@@ -1726,7 +1726,7 @@ public final class VillagePieces {
 							final int cz = z & 0xf;
 							int y = chunk.getHighestBlockAt(cx, cz);
 							int id = chunk.getBlockId(cx, y, cz);
-							while (Block.transparent[id] && y > 63 - 1 + yOffset) {
+							while (Block.isBlockTransparentById(id) && y > 63 - 1 + yOffset) {
 								id = chunk.getBlockId(cx, --y, cz);
 							}
 							vec.y = y;


### PR DESCRIPTION
`Block.solid` and `Block.transparent` are plain arrays sized `MAX_BLOCK_ID`
(2048). Custom blocks live above `CustomBlockManager.LOWEST_CUSTOM_BLOCK_ID`
(10000) and are kept in the manager instead, which is why `Block` already
exposes `isBlockSolidById` / `isBlockTransparentById` for exactly this case.

Generators still indexed the raw arrays. The moment a populator reads a
neighbour cell that holds a custom block, the read throws
`ArrayIndexOutOfBoundsException: Index 10023 out of bounds for length 2048`
inside the asynchronous `PopulationTask`. The chunk is then never marked
populated, so it is never sent to the client: the player teleported there
keeps `teleportPosition` set, movement stays locked, the world around them
stays empty, and the vanilla air-time check eventually kicks them with
"Flying is not enabled on this server". Nothing in the server log points at
the chunk.

Every generator read now goes through the id-aware accessors, which return
the manager-cached flag for custom ids and the array value for vanilla ones.
Behaviour for vanilla blocks is unchanged.
