### PR TITLE
fix(inventory): apply event-authored brewing results synchronously

### DIFF
--- a/src/main/java/cn/nukkit/blockentity/BlockEntityBrewingStand.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityBrewingStand.java
@@ -199,7 +199,26 @@ public class BlockEntityBrewingStand extends BlockEntitySpawnable implements Inv
         }
 
         //20 seconds
-        BrewEvent e = new BrewEvent(this);
+        MixRecipe[] recipes = matchRecipes(false);
+        Item[] results = new Item[]{Item.AIR_ITEM, Item.AIR_ITEM, Item.AIR_ITEM};
+        for (int i = 0; i < 3; i++) {
+            MixRecipe recipe = recipes[i];
+            if (recipe == null) {
+                continue;
+            }
+            Item previous = inventory.getItem(i + 1);
+            if (previous.isNull()) {
+                continue;
+            }
+            Item result = recipe.getResult();
+            result.setCount(previous.getCount());
+            if (recipe instanceof ContainerRecipe) {
+                result.setDamage(previous.getDamage());
+            }
+            results[i] = result;
+        }
+
+        BrewEvent e = new BrewEvent(this, results);
         this.server.getPluginManager().callEvent(e);
 
         if (e.isCancelled()) {
@@ -207,8 +226,8 @@ public class BlockEntityBrewingStand extends BlockEntitySpawnable implements Inv
             return true;
         }
 
-        boolean mixed = false;
-        MixRecipe[] recipes = matchRecipes(false);
+        // Validate every event-authored output before changing any slot. A single invalid
+        // result must not leave a partially brewed batch without consuming ingredient/fuel.
         for (int i = 0; i < 3; i++) {
             MixRecipe recipe = recipes[i];
             if (recipe == null) {
@@ -217,12 +236,24 @@ public class BlockEntityBrewingStand extends BlockEntitySpawnable implements Inv
 
             Item previous = inventory.getItem(i + 1);
             if (!previous.isNull()) {
-                Item result = recipe.getResult();
-                result.setCount(previous.getCount());
-                if (recipe instanceof ContainerRecipe) {
-                    result.setDamage(previous.getDamage());
+                Item result = e.getResult(i);
+                if (result == null || result.isNull()) {
+                    stopBrewing();
+                    return true;
                 }
-                inventory.setItem(i + 1, result);
+            }
+        }
+
+        boolean mixed = false;
+        for (int i = 0; i < 3; i++) {
+            MixRecipe recipe = recipes[i];
+            if (recipe == null) {
+                continue;
+            }
+            Item previous = inventory.getItem(i + 1);
+            if (!previous.isNull()) {
+                Item result = e.getResult(i);
+                inventory.setItem(i + 1, result.clone());
                 mixed = true;
             }
         }

--- a/src/main/java/cn/nukkit/event/inventory/BrewEvent.java
+++ b/src/main/java/cn/nukkit/event/inventory/BrewEvent.java
@@ -5,6 +5,8 @@ import cn.nukkit.event.Cancellable;
 import cn.nukkit.event.HandlerList;
 import cn.nukkit.item.Item;
 
+import java.util.Objects;
+
 /**
  * @author CreeperFace
  */
@@ -19,18 +21,28 @@ public class BrewEvent extends InventoryEvent implements Cancellable {
     private final BlockEntityBrewingStand brewingStand;
     private final Item ingredient;
     private final Item[] potions;
+    private final Item[] results;
     private final int fuel;
 
     public BrewEvent(BlockEntityBrewingStand blockEntity) {
+        this(blockEntity, new Item[]{Item.AIR_ITEM, Item.AIR_ITEM, Item.AIR_ITEM});
+    }
+
+    public BrewEvent(BlockEntityBrewingStand blockEntity, Item[] results) {
         super(blockEntity.getInventory());
+        if (results == null || results.length != 3) {
+            throw new IllegalArgumentException("Brewing results must contain exactly three slots");
+        }
         this.brewingStand = blockEntity;
         this.fuel = blockEntity.fuelAmount;
 
         this.ingredient = blockEntity.getInventory().getIngredient();
 
         this.potions = new Item[3];
+        this.results = new Item[3];
         for (int i = 0; i < 3; i++) {
-            this.potions[i] = blockEntity.getInventory().getItem(i);
+            this.potions[i] = blockEntity.getInventory().getItem(i + 1);
+            this.results[i] = Objects.requireNonNull(results[i], "result").clone();
         }
     }
 
@@ -52,6 +64,24 @@ public class BrewEvent extends InventoryEvent implements Cancellable {
      */
     public Item getPotion(int index) {
         return this.potions[index];
+    }
+
+    /**
+     * @param index Potion index in range 0 - 2
+     * @return event-authoritative brewing result
+     */
+    public Item getResult(int index) {
+        return this.results[index];
+    }
+
+    /**
+     * Replaces the item which the brewing stand will put into the matching potion slot.
+     *
+     * @param index Potion index in range 0 - 2
+     * @param result non-null result item
+     */
+    public void setResult(int index, Item result) {
+        this.results[index] = Objects.requireNonNull(result, "result").clone();
     }
 
     public int getFuel() {

--- a/src/test/java/cn/nukkit/blockentity/BrewingEventOutputTest.java
+++ b/src/test/java/cn/nukkit/blockentity/BrewingEventOutputTest.java
@@ -1,0 +1,107 @@
+package cn.nukkit.blockentity;
+
+import cn.nukkit.Server;
+import cn.nukkit.block.Block;
+import cn.nukkit.event.inventory.BrewEvent;
+import cn.nukkit.inventory.BrewingRecipe;
+import cn.nukkit.inventory.CraftingManager;
+import cn.nukkit.item.Item;
+import cn.nukkit.level.Level;
+import cn.nukkit.level.format.FullChunk;
+import cn.nukkit.level.format.LevelProvider;
+import cn.nukkit.math.Vector3;
+import cn.nukkit.nbt.tag.CompoundTag;
+import cn.nukkit.nbt.tag.ListTag;
+import cn.nukkit.plugin.PluginManager;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+
+class BrewingEventOutputTest {
+
+    @BeforeAll
+    static void init() {
+        Block.init();
+    }
+
+    @Test
+    void eventAuthoredResultReachesThePotionSlotSynchronously() throws Exception {
+        Server server = mock(Server.class);
+        PluginManager plugins = mock(PluginManager.class);
+        CraftingManager recipes = mock(CraftingManager.class);
+        Level level = mock(Level.class);
+        FullChunk chunk = mock(FullChunk.class);
+        LevelProvider provider = mock(LevelProvider.class);
+
+        lenient().when(server.getPluginManager()).thenReturn(plugins);
+        lenient().when(server.getCraftingManager()).thenReturn(recipes);
+        lenient().when(chunk.getProvider()).thenReturn(provider);
+        lenient().when(provider.getLevel()).thenReturn(level);
+        lenient().when(level.getServer()).thenReturn(server);
+        lenient().when(level.getBlock(any(Vector3.class)))
+                .thenReturn(Block.get(Block.BREWING_STAND_BLOCK));
+
+        Field instance = Server.class.getDeclaredField("instance");
+        instance.setAccessible(true);
+        Object previousServer = instance.get(null);
+        instance.set(null, server);
+        try {
+            BlockEntityBrewingStand stand = new BlockEntityBrewingStand(chunk, standNbt());
+            Item ingredient = Item.get(Item.NETHER_WART, 0, 1);
+            Item potion = Item.get(Item.POTION, 0, 1);
+            Item brewed = Item.get(Item.SPLASH_POTION, 0, 1);
+            BrewingRecipe recipe = new BrewingRecipe(potion, ingredient, brewed);
+            lenient().when(recipes.matchBrewingRecipe(any(Item.class), any(Item.class)))
+                    .thenReturn(recipe);
+
+            stand.getInventory().setIngredient(ingredient);
+            stand.getInventory().setItem(1, potion);
+            stand.fuelAmount = 1;
+            stand.brewTime = 1;
+
+            Mockito.doAnswer(
+                            invocation -> {
+                                Object called = invocation.getArgument(0);
+                                if (called instanceof BrewEvent event) {
+                                    assertEquals(Item.POTION, event.getPotion(0).getId());
+                                    assertEquals(Item.AIR, event.getPotion(2).getId());
+                                    Item authored = event.getResult(0).clone();
+                                    authored.setNamedTag(
+                                            authored.getOrCreateNamedTag()
+                                                    .putString("km_origin", "kit:brew"));
+                                    event.setResult(0, authored);
+                                }
+                                return null;
+                            })
+                    .when(plugins)
+                    .callEvent(any());
+
+            assertTrue(stand.onUpdate());
+            Item delivered = stand.getInventory().getItem(1);
+            assertEquals(Item.SPLASH_POTION, delivered.getId());
+            assertEquals("kit:brew", delivered.getNamedTag().getString("km_origin"));
+        } finally {
+            instance.set(null, previousServer);
+        }
+    }
+
+    private static CompoundTag standNbt() {
+        return new CompoundTag()
+                .putString("id", BlockEntity.BREWING_STAND)
+                .putInt("x", 0)
+                .putInt("y", 64)
+                .putInt("z", 0)
+                .putList(new ListTag<CompoundTag>("Items"))
+                .putShort("CookTime", BlockEntityBrewingStand.MAX_BREW_TIME)
+                .putShort("FuelAmount", 0)
+                .putShort("FuelTotal", 0);
+    }
+}


### PR DESCRIPTION
### Problem

`BrewEvent` fires while the brewing stand is already writing its slots, and it exposes no way to
change what comes out. A listener that wants to mark, replace or refuse a brewed potion has to
schedule the edit for a later tick — which loses the race against the inventory contents already
sent to the client, so the player briefly sees the unedited potion, and any plugin state attached
to the item is applied to a stack the client has already cached.

### Fix

Compute all three results first, hand them to the event, then apply what the listeners left behind
in one step. A result a listener cleared stops the brew before any slot, ingredient or fuel is
consumed, so a refused brew cannot leave a half-finished batch.

The old `new BrewEvent(blockEntity)` constructor is kept, so existing listeners compile and behave
as before.

### Tests

`BrewingEventOutputTest` asserts the event sees the correct input slot, that an event-authored
result reaches the stand synchronously, and that no intermediate item is handed out on the way.
