### PR TITLE
item: refuse a runtime item mapping asked for before init instead of caching an empty one

### DIFF
--- a/src/main/java/cn/nukkit/item/RuntimeItems.java
+++ b/src/main/java/cn/nukkit/item/RuntimeItems.java
@@ -39,6 +39,15 @@ public class RuntimeItems {
     private static boolean initialized;
 
     private static RuntimeItemMapping of(GameVersion anchor) {
+        if (!initialized) {
+            // 懒加载会把当时的 mappingEntries 永久缓存：init() 之前调用则缓存空表，
+            // 此后每个物品都查不到，且再无第二次机会。
+            //
+            // A lazily built mapping caches whatever mappingEntries held at that moment, so a
+            // call made before init() caches an EMPTY table: every item lookup misses from then
+            // on, and nothing ever rebuilds it. Fail loudly instead of poisoning the cache.
+            throw new IllegalStateException("RuntimeItems are not initialized yet");
+        }
         return MAPPINGS.computeIfAbsent(anchor, gv -> new RuntimeItemMapping(mappingEntries, gv));
     }
 


### PR DESCRIPTION
Upstream made the runtime item mappings lazy: of(anchor) builds a
RuntimeItemMapping out of the mappingEntries map and caches it forever. The
entries themselves are filled by init(), and nothing stops of() from running
first. A single call made before init() therefore caches a mapping built from an
EMPTY table, and from that moment every lookup misses: even a vanilla diamond
answers "Unknown legacy2Runtime mapping: id=264 meta=0". Nothing rebuilds the
cached mapping, so the whole process stays broken.

The old eager VALUES field could not do this: it was assigned inside init(),
after the entries were read.

Refuse the call instead of caching the damage. A server always initializes the
items long before anything asks for a mapping, so the guard only fires where the
order is genuinely wrong and turns silent breakage into an immediate, named
failure.

Upstream candidate.
