### PR TITLE
entity: stop AI mobs from jittering and pacing back and forth

### DIFF
--- a/src/main/java/cn/nukkit/entity/BaseEntity.java
+++ b/src/main/java/cn/nukkit/entity/BaseEntity.java
@@ -797,6 +797,34 @@ public abstract class BaseEntity extends EntityCreature implements EntityAgeable
         return null;
     }
 
+    /**
+     * Насколько градусов за такт разрешено поворачивать тело сущности с ИИ.
+     *
+     * <p>Мгновенный разворот на произвольный угол клиент показывает рывком: он не сглаживает
+     * поворот, а рисует то, что пришло. Живая цель поворачивается плавно сама, а вот случайная
+     * точка блуждания и узел пути меняются скачком, и каждая такая смена читалась как дёрганье.
+     */
+    private static final double MAX_BODY_TURN_PER_TICK = 30.0D;
+
+    /**
+     * Повернуть тело к заданному направлению не более чем на {@link #MAX_BODY_TURN_PER_TICK}.
+     */
+    protected void turnBodyTowards(double yaw) {
+        double delta = yaw - this.yaw;
+        while (delta < -180.0D) {
+            delta += 360.0D;
+        }
+        while (delta > 180.0D) {
+            delta -= 360.0D;
+        }
+        if (delta > MAX_BODY_TURN_PER_TICK) {
+            delta = MAX_BODY_TURN_PER_TICK;
+        } else if (delta < -MAX_BODY_TURN_PER_TICK) {
+            delta = -MAX_BODY_TURN_PER_TICK;
+        }
+        this.setBothYaw(this.yaw + delta);
+    }
+
     protected boolean isInTickingRange() {
         return this.isInTickingRange(6400); // 80 blocks
     }

--- a/src/main/java/cn/nukkit/entity/BaseEntity.java
+++ b/src/main/java/cn/nukkit/entity/BaseEntity.java
@@ -798,16 +798,13 @@ public abstract class BaseEntity extends EntityCreature implements EntityAgeable
     }
 
     /**
-     * Насколько градусов за такт разрешено поворачивать тело сущности с ИИ.
-     *
-     * <p>Мгновенный разворот на произвольный угол клиент показывает рывком: он не сглаживает
-     * поворот, а рисует то, что пришло. Живая цель поворачивается плавно сама, а вот случайная
-     * точка блуждания и узел пути меняются скачком, и каждая такая смена читалась как дёрганье.
+     * Max body yaw change per tick. Clients render yaw exactly as sent, so instant snaps
+     * to a new wander point or path node read as jitter.
      */
     private static final double MAX_BODY_TURN_PER_TICK = 30.0D;
 
     /**
-     * Повернуть тело к заданному направлению не более чем на {@link #MAX_BODY_TURN_PER_TICK}.
+     * Turns the body towards the given yaw, clamped to {@link #MAX_BODY_TURN_PER_TICK} per tick.
      */
     protected void turnBodyTowards(double yaw) {
         double delta = yaw - this.yaw;

--- a/src/main/java/cn/nukkit/entity/EntityFlying.java
+++ b/src/main/java/cn/nukkit/entity/EntityFlying.java
@@ -57,12 +57,10 @@ public abstract class EntityFlying extends BaseEntity {
 
         int x, z;
         if (this.stayTime > 0) {
-            if (Utils.rand(1, 100) > 5) {
-                return;
-            }
-            x = Utils.rand(10, 30);
-            z = Utils.rand(10, 30);
-            this.target = this.add(Utils.rand() ? x : -x, 0, Utils.rand() ? z : -z);
+            // Тот же дефект, что у ходячих: отдых с вероятностью 5% каждый такт брал новую
+            // случайную точку и разворачивал сущность в произвольную сторону. Отдых означает
+            // отдых, а новая цель выбирается, когда он кончится.
+            return;
         } else if (Utils.rand(1, 100) == 1) {
             x = Utils.rand(10, 30);
             z = Utils.rand(10, 30);
@@ -106,8 +104,8 @@ public abstract class EntityFlying extends BaseEntity {
                         this.motionY = this.getSpeed() * 0.27 * (y / diff);
                         this.motionZ = this.getSpeed() * 0.15 * (z / diff);
                     }
-                    if ((this.stayTime <= 0 || Utils.rand()) && diff != 0) {
-                        this.setBothYaw(FastMath.toDegrees(-FastMath.atan2(x / diff, z / diff)));
+                    if (this.stayTime <= 0 && diff != 0) {
+                        this.turnBodyTowards(FastMath.toDegrees(-FastMath.atan2(x / diff, z / diff)));
                     }
                     return this.followTarget;
                 }
@@ -129,8 +127,8 @@ public abstract class EntityFlying extends BaseEntity {
                         this.motionY = this.getSpeed() * 0.27 * (y / diff);
                         this.motionZ = this.getSpeed() * 0.15 * (z / diff);
                     }
-                    if ((this.stayTime <= 0 || Utils.rand()) && diff != 0) {
-                        this.setBothYaw(FastMath.toDegrees(-FastMath.atan2(x / diff, z / diff)));
+                    if (this.stayTime <= 0 && diff != 0) {
+                        this.turnBodyTowards(FastMath.toDegrees(-FastMath.atan2(x / diff, z / diff)));
                     }
                 }
             }

--- a/src/main/java/cn/nukkit/entity/EntityFlying.java
+++ b/src/main/java/cn/nukkit/entity/EntityFlying.java
@@ -57,9 +57,7 @@ public abstract class EntityFlying extends BaseEntity {
 
         int x, z;
         if (this.stayTime > 0) {
-            // Тот же дефект, что у ходячих: отдых с вероятностью 5% каждый такт брал новую
-            // случайную точку и разворачивал сущность в произвольную сторону. Отдых означает
-            // отдых, а новая цель выбирается, когда он кончится.
+            // Rest means rest; a new wander target is picked only after it ends.
             return;
         } else if (Utils.rand(1, 100) == 1) {
             x = Utils.rand(10, 30);

--- a/src/main/java/cn/nukkit/entity/EntityJumping.java
+++ b/src/main/java/cn/nukkit/entity/EntityJumping.java
@@ -66,9 +66,7 @@ public abstract class EntityJumping extends BaseEntity {
 
         int x, z;
         if (this.stayTime > 0) {
-            // Тот же дефект, что у ходячих: отдых с вероятностью 5% каждый такт брал новую
-            // случайную точку и разворачивал сущность в произвольную сторону. Отдых означает
-            // отдых, а новая цель выбирается, когда он кончится.
+            // Rest means rest; a new wander target is picked only after it ends.
             return;
         } else if (Utils.rand(1, 100) == 1) {
             x = Utils.rand(10, 30);

--- a/src/main/java/cn/nukkit/entity/EntityJumping.java
+++ b/src/main/java/cn/nukkit/entity/EntityJumping.java
@@ -66,12 +66,10 @@ public abstract class EntityJumping extends BaseEntity {
 
         int x, z;
         if (this.stayTime > 0) {
-            if (Utils.rand(1, 100) > 5) {
-                return;
-            }
-            x = Utils.rand(10, 30);
-            z = Utils.rand(10, 30);
-            this.target = this.add(Utils.rand() ? x : -x, Utils.rand(-20.0, 20.0) / 10, Utils.rand() ? z : -z);
+            // Тот же дефект, что у ходячих: отдых с вероятностью 5% каждый такт брал новую
+            // случайную точку и разворачивал сущность в произвольную сторону. Отдых означает
+            // отдых, а новая цель выбирается, когда он кончится.
+            return;
         } else if (Utils.rand(1, 100) == 1) {
             x = Utils.rand(10, 30);
             z = Utils.rand(10, 30);
@@ -144,8 +142,8 @@ public abstract class EntityJumping extends BaseEntity {
                             this.motionZ = this.getSpeed() * 0.1 * (z / diff);
                         }
                     }
-                    if ((this.stayTime <= 0 || Utils.rand()) && diff != 0) {
-                        this.setBothYaw(FastMath.toDegrees(-FastMath.atan2(x / diff, z / diff)));
+                    if (this.stayTime <= 0 && diff != 0) {
+                        this.turnBodyTowards(FastMath.toDegrees(-FastMath.atan2(x / diff, z / diff)));
                     }
                     return this.followTarget;
                 }
@@ -170,8 +168,8 @@ public abstract class EntityJumping extends BaseEntity {
                             this.motionZ = this.getSpeed() * 0.15 * (z / diff);
                         }
                     }
-                    if ((this.stayTime <= 0 || Utils.rand()) && diff != 0) {
-                        this.setBothYaw(FastMath.toDegrees(-FastMath.atan2(x / diff, z / diff)));
+                    if (this.stayTime <= 0 && diff != 0) {
+                        this.turnBodyTowards(FastMath.toDegrees(-FastMath.atan2(x / diff, z / diff)));
                     }
                 }
             }

--- a/src/main/java/cn/nukkit/entity/EntitySwimming.java
+++ b/src/main/java/cn/nukkit/entity/EntitySwimming.java
@@ -65,9 +65,7 @@ public abstract class EntitySwimming extends BaseEntity {
 
         int x, z;
         if (this.stayTime > 0) {
-            // Тот же дефект, что у ходячих: отдых с вероятностью 5% каждый такт брал новую
-            // случайную точку и разворачивал сущность в произвольную сторону. Отдых означает
-            // отдых, а новая цель выбирается, когда он кончится.
+            // Rest means rest; a new wander target is picked only after it ends.
             return;
         } else if (Utils.rand(1, 100) == 1) {
             x = Utils.rand(10, 30);

--- a/src/main/java/cn/nukkit/entity/EntitySwimming.java
+++ b/src/main/java/cn/nukkit/entity/EntitySwimming.java
@@ -65,12 +65,10 @@ public abstract class EntitySwimming extends BaseEntity {
 
         int x, z;
         if (this.stayTime > 0) {
-            if (Utils.rand(1, 100) > 5) {
-                return;
-            }
-            x = Utils.rand(10, 30);
-            z = Utils.rand(10, 30);
-            this.target = this.add(Utils.rand() ? x : -x, Utils.rand(-20.0, 20.0) / 10, Utils.rand() ? z : -z);
+            // Тот же дефект, что у ходячих: отдых с вероятностью 5% каждый такт брал новую
+            // случайную точку и разворачивал сущность в произвольную сторону. Отдых означает
+            // отдых, а новая цель выбирается, когда он кончится.
+            return;
         } else if (Utils.rand(1, 100) == 1) {
             x = Utils.rand(10, 30);
             z = Utils.rand(10, 30);
@@ -112,8 +110,8 @@ public abstract class EntitySwimming extends BaseEntity {
                         this.motionX = this.getSpeed() * 0.1 * (x / diff);
                         this.motionZ = this.getSpeed() * 0.1 * (z / diff);
                     }
-                    if ((this.stayTime <= 0 || Utils.rand()) && diff != 0) {
-                        this.setBothYaw(FastMath.toDegrees(-FastMath.atan2(x / diff, z / diff)));
+                    if (this.stayTime <= 0 && diff != 0) {
+                        this.turnBodyTowards(FastMath.toDegrees(-FastMath.atan2(x / diff, z / diff)));
                     }
                     return this.followTarget;
                 }
@@ -132,8 +130,8 @@ public abstract class EntitySwimming extends BaseEntity {
                         this.motionX = this.getSpeed() * 0.15 * (x / diff);
                         this.motionZ = this.getSpeed() * 0.15 * (z / diff);
                     }
-                    if ((this.stayTime <= 0 || Utils.rand()) && diff != 0) {
-                        this.setBothYaw(FastMath.toDegrees(-FastMath.atan2(x / diff, z / diff)));
+                    if (this.stayTime <= 0 && diff != 0) {
+                        this.turnBodyTowards(FastMath.toDegrees(-FastMath.atan2(x / diff, z / diff)));
                     }
                 }
             }

--- a/src/main/java/cn/nukkit/entity/EntityWalking.java
+++ b/src/main/java/cn/nukkit/entity/EntityWalking.java
@@ -73,13 +73,15 @@ public abstract class EntityWalking extends BaseEntity {
         }
 
         if (this.stayTime > 0) {
-            if (Utils.rand(1, 100) > 5) {
-                return;
-            }
-            this.target = this.add(Utils.rand(-30, 30), Utils.rand(-20.0, 20.0) / 10, Utils.rand(-30, 30));
+            // Отдых означает отдых. Прежний код с вероятностью 5% КАЖДЫЙ такт брал новую случайную
+            // точку в тридцати блоках: стоящая на месте сущность примерно раз в секунду
+            // разворачивалась в произвольную сторону, и со стороны это выглядело дрожью.
+            return;
         } else if (Utils.rand(1, 100) == 1) {
             this.stayTime = Utils.rand(80, 200);
-            this.target = this.add(Utils.rand(-30, 30), Utils.rand(-20.0, 20.0) / 10, Utils.rand(-30, 30));
+            int wanderX = Utils.rand(4, 10);
+            int wanderZ = Utils.rand(4, 10);
+            this.target = this.add(Utils.rand() ? wanderX : -wanderX, Utils.rand(-20.0, 20.0) / 10, Utils.rand() ? wanderZ : -wanderZ);
         } else if (this.moveTime <= 0 || this.target == null) {
             this.stayTime = 0;
             this.moveTime = Utils.rand(80, 200);
@@ -88,8 +90,10 @@ public abstract class EntityWalking extends BaseEntity {
             int attempts = 0;
             boolean inWater = true;
             while (attempts++ < 10 && inWater) {
-                tx = this.x + Utils.rand(-30, 30);
-                tz = this.z + Utils.rand(-30, 30);
+                int wanderX = Utils.rand(4, 10);
+                int wanderZ = Utils.rand(4, 10);
+                tx = this.x + (Utils.rand() ? wanderX : -wanderX);
+                tz = this.z + (Utils.rand() ? wanderZ : -wanderZ);
                 int txFloor = NukkitMath.floorDouble(tx);
                 int tzFloor = NukkitMath.floorDouble(tz);
                 inWater = Block.isWater(level.getBlockIdAt(chunk, txFloor, level.getHighestBlockAt(txFloor, tzFloor), tzFloor));
@@ -149,10 +153,11 @@ public abstract class EntityWalking extends BaseEntity {
 
         if (!isImmobile()) {
             if (this.age % 10 == 0 && this.route != null && !this.route.isSearching()) {
+                // Только запуск поиска. Прежний код тут же брал следующий узел, а поиск идёт в
+                // другом потоке и начинает с обнуления списка: сущность получала узел свежего
+                // пути под номером один, то есть точку рядом с собой, и раз в десять тактов
+                // отворачивала назад. Это и был бег туда-сюда.
                 RouteFinderThreadPool.executeRouteFinderThread(new RouteFinderSearchTask(this.route));
-                if (this.route.hasNext()) {
-                    this.target = this.route.next();
-                }
             }
 
             if (this.isKnockback()) {
@@ -207,7 +212,7 @@ public abstract class EntityWalking extends BaseEntity {
                             this.motionZ = this.getSpeed() * moveMultiplier * 0.1 * (z / diff);
                         }
                     }
-                    if (this.noRotateTicks <= 0 && (this.passengers.isEmpty() || this instanceof EntityLlama || this instanceof EntityPig) && (this.stayTime <= 0 || Utils.rand()) && diff != 0) {
+                    if (this.noRotateTicks <= 0 && (this.passengers.isEmpty() || this instanceof EntityLlama || this instanceof EntityPig) && this.stayTime <= 0 && diff != 0) {
                         this.lookAt(this.followTarget);
                     }
                 }
@@ -246,8 +251,8 @@ public abstract class EntityWalking extends BaseEntity {
                             this.motionZ = this.getSpeed() * moveMultiplier * 0.15 * (z / diff);
                         }
                     }
-                    if (this.noRotateTicks <= 0 && !distance && (this.passengers.isEmpty() || this instanceof EntityLlama || this instanceof EntityPig) && (this.stayTime <= 0 || Utils.rand()) && diff > 0.001) {
-                        this.setBothYaw(FastMath.toDegrees(-FastMath.atan2(x / diff, z / diff)));
+                    if (this.noRotateTicks <= 0 && !distance && (this.passengers.isEmpty() || this instanceof EntityLlama || this instanceof EntityPig) && this.stayTime <= 0 && diff > 0.001) {
+                        this.turnBodyTowards(FastMath.toDegrees(-FastMath.atan2(x / diff, z / diff)));
                     }
                 }
             }
@@ -292,7 +297,7 @@ public abstract class EntityWalking extends BaseEntity {
 
             this.updateMovement();
 
-            if (this.route != null) {
+            if (this.route != null && !this.route.isSearching()) {
                 if (this.route.hasCurrentNode() && this.route.hasArrivedNode(this)) {
                     if (this.route.hasNext()) {
                         this.target = this.route.next();

--- a/src/main/java/cn/nukkit/entity/EntityWalking.java
+++ b/src/main/java/cn/nukkit/entity/EntityWalking.java
@@ -73,9 +73,7 @@ public abstract class EntityWalking extends BaseEntity {
         }
 
         if (this.stayTime > 0) {
-            // Отдых означает отдых. Прежний код с вероятностью 5% КАЖДЫЙ такт брал новую случайную
-            // точку в тридцати блоках: стоящая на месте сущность примерно раз в секунду
-            // разворачивалась в произвольную сторону, и со стороны это выглядело дрожью.
+            // Rest means rest; the old 5%-per-tick re-roll made standing entities twitch their facing.
             return;
         } else if (Utils.rand(1, 100) == 1) {
             this.stayTime = Utils.rand(80, 200);
@@ -153,10 +151,8 @@ public abstract class EntityWalking extends BaseEntity {
 
         if (!isImmobile()) {
             if (this.age % 10 == 0 && this.route != null && !this.route.isSearching()) {
-                // Только запуск поиска. Прежний код тут же брал следующий узел, а поиск идёт в
-                // другом потоке и начинает с обнуления списка: сущность получала узел свежего
-                // пути под номером один, то есть точку рядом с собой, и раз в десять тактов
-                // отворачивала назад. Это и был бег туда-сюда.
+                // Only start the search: reading next() here raced with the async rebuild and
+                // returned the fresh path's first node, a point right beside the entity.
                 RouteFinderThreadPool.executeRouteFinderThread(new RouteFinderSearchTask(this.route));
             }
 

--- a/src/main/java/cn/nukkit/entity/route/RouteFinder.java
+++ b/src/main/java/cn/nukkit/entity/route/RouteFinder.java
@@ -113,10 +113,8 @@ public abstract class RouteFinder {
             if (node != null) {
                 Vector3 cur = node.getVector3();
                 if (cur != null && this.hasNext()) {
-                    // Точное равенство координат не наступает никогда: узел стоит в целочисленной
-                    // клетке, а сущность движется дробными шагами и останавливается рядом. Из-за
-                    // этого путь никогда не переключался на следующий узел здесь, и единственным
-                    // способом сдвинуться оставался повторный поиск раз в десять тактов.
+                    // Exact equality never happens (nodes are grid-aligned, entity coords are
+                    // fractional), so node advancement never fired. Accept arrival within 1 block.
                     double dx = vec.getX() - cur.getX();
                     double dz = vec.getZ() - cur.getZ();
                     return dx * dx + dz * dz < 1.0D;

--- a/src/main/java/cn/nukkit/entity/route/RouteFinder.java
+++ b/src/main/java/cn/nukkit/entity/route/RouteFinder.java
@@ -113,7 +113,13 @@ public abstract class RouteFinder {
             if (node != null) {
                 Vector3 cur = node.getVector3();
                 if (cur != null && this.hasNext()) {
-                    return vec.getX() == cur.getX() && vec.getZ() == cur.getZ();
+                    // Точное равенство координат не наступает никогда: узел стоит в целочисленной
+                    // клетке, а сущность движется дробными шагами и останавливается рядом. Из-за
+                    // этого путь никогда не переключался на следующий узел здесь, и единственным
+                    // способом сдвинуться оставался повторный поиск раз в десять тактов.
+                    double dx = vec.getX() - cur.getX();
+                    double dz = vec.getZ() - cur.getZ();
+                    return dx * dx + dz * dz < 1.0D;
                 }
             }
             return false;


### PR DESCRIPTION
Three defects made every AI entity twitch and pace whenever it had no
player to chase (creative, or the player too far to be targeted), and
made a chasing mob turn back on itself every ten ticks.

* checkTarget() re-rolled a random wander point with a 5% chance on
  every single tick while the entity was resting, so a standing mob
  changed facing about once a second.
* The walking wander radius was 30 blocks with no minimum distance, so
  a mob that did start moving ran across half a chunk and back.
* updateMove() consumed route.next() in the same breath as it started
  an asynchronous route search. The search resets the node list and the
  cursor first, so the entity picked up node one of a freshly built
  path - a point right next to itself - and turned around.
* hasArrivedNode() compared node coordinates for exact equality, which
  a fractionally moving entity never reaches, so the normal per-arrival
  node advance never fired at all.

Body rotation is now rate limited to 30 degrees per tick instead of
snapping, and the random coin flip that rotated a resting entity on
half of all ticks is gone.
