### PR TITLE
fix(inventory): decode a stack request the way the live network sends it

### DIFF
--- a/src/main/java/cn/nukkit/network/protocol/types/inventory/ContainerSlotType.java
+++ b/src/main/java/cn/nukkit/network/protocol/types/inventory/ContainerSlotType.java
@@ -75,7 +75,10 @@ public enum ContainerSlotType {
     /**
      * @since v712
      */
-    DYNAMIC_CONTAINER(63);
+    DYNAMIC_CONTAINER(63),
+    RECIPE_FOOD_CONTAINER(64),
+    RECIPE_BLOCKS_CONTAINER(65),
+    RECIPE_FURNACE_ITEMS_CONTAINER(66);
 
     private final int id;
     private static final Int2ObjectArrayMap<ContainerSlotType> VALUES = new Int2ObjectArrayMap<>();
@@ -101,6 +104,9 @@ public enum ContainerSlotType {
             return this.id + 1;
         }
         int protocol = gameVersion.getProtocol();
+        if (this.id > DYNAMIC_CONTAINER.id && protocol < ProtocolInfo.v1_21_20) {
+            throw new IllegalArgumentException("Container slot type " + this + " is not supported on protocol " + protocol);
+        }
         if (protocol >= ProtocolInfo.v1_21_20) {
             return this.id;
         }

--- a/src/main/java/cn/nukkit/utils/BinaryStream.java
+++ b/src/main/java/cn/nukkit/utils/BinaryStream.java
@@ -2566,7 +2566,12 @@ public class BinaryStream {
                 case 1: // DEFAULT
                     String idName = getString();
                     int auxValue = getVarInt();
-                    int itemId = cn.nukkit.item.Item.fromString(idName).getId();
+                    // 客户端可能发送服务端无法解析的标识符；此处返回 null 会让整批数据解码失败。
+                    // The client may name an item the server cannot resolve. Failing here fails the
+                    // whole batch, so an unknown identifier decodes as air and the request is judged
+                    // by the handler instead.
+                    cn.nukkit.item.Item descriptorItem = cn.nukkit.item.Item.fromString(idName);
+                    int itemId = descriptorItem == null ? cn.nukkit.item.Item.AIR : descriptorItem.getId();
                     descriptor = new DefaultDescriptor(itemId, auxValue);
                     break;
                 case 2: // MOLANG


### PR DESCRIPTION
Two gaps in the item stack request decoder turn a normal craft into a decode
failure, and a decode failure used to cost the player the whole session.

An ingredient descriptor that names an item the server cannot resolve went
straight into Item.fromString(...).getId(), so an identifier we do not know threw
a NullPointerException out of the decoder. An unknown identifier now decodes as
air and the request is judged by the handler, which already answers ERROR and
resynchronises the client.

The recipe book containers (64, 65, 66) were missing from ContainerSlotType, so a
slot info that names one of them left fromId() empty and the decoder threw. They
are present in the protocol fork the production network runs on. Older protocols
are untouched: their branches already reject every id above DYNAMIC_CONTAINER,
and the encoder refuses to write the new ids below v1_21_20.
