### PR TITLE
player: scale movement sanity limits for authorized flight

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -640,6 +640,27 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
         return this.adventureSettings.get(Type.ALLOW_FLIGHT);
     }
 
+    /**
+     * Scale the packet and tick movement sanity limits for an authorized player who is actually
+     * flying faster than vanilla. The limits are squared distances, so the speed ratio must be
+     * squared as well. Everyone else keeps the original limits unchanged.
+     */
+    double movementSanityLimitSquared(double vanillaLimitSquared) {
+        if (this.adventureSettings == null
+                || !this.adventureSettings.get(Type.ALLOW_FLIGHT)
+                || !this.adventureSettings.get(Type.FLYING)) {
+            return vanillaLimitSquared;
+        }
+
+        float configuredFlySpeed = this.getFlySpeed();
+        if (!Float.isFinite(configuredFlySpeed) || configuredFlySpeed <= DEFAULT_FLY_SPEED) {
+            return vanillaLimitSquared;
+        }
+
+        double speedRatio = (double) configuredFlySpeed / DEFAULT_FLY_SPEED;
+        return vanillaLimitSquared * speedRatio * speedRatio;
+    }
+
     public void setAllowModifyWorld(boolean value) {
         this.adventureSettings.set(Type.WORLD_IMMUTABLE, !value);
         this.adventureSettings.set(Type.MINE, value);
@@ -2387,9 +2408,11 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
         boolean revert = false;
 
         // Extreme distance check
-        if (distanceSquared / tickDiffSq > 225) {
+        double extremeDistanceLimitSquared = movementSanityLimitSquared(225);
+        if (distanceSquared / tickDiffSq > extremeDistanceLimitSquared) {
             revert = true;
-            server.getLogger().debug(username + ": distanceSquared=" + distanceSquared + " > 225 * tickDiffSq=" + (225 * tickDiffSq));
+            server.getLogger().debug(username + ": distanceSquared=" + distanceSquared + " > "
+                    + extremeDistanceLimitSquared + " * tickDiffSq=" + (extremeDistanceLimitSquared * tickDiffSq));
         } else {
             // Chunk generation check
             if (this.chunk == null || !this.chunk.isGenerated()) {
@@ -3984,10 +4007,11 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                     break;
                 }
 
-                if (dis > 100) {
+                double legacyMoveDistanceLimitSquared = movementSanityLimitSquared(100);
+                if (dis > legacyMoveDistanceLimitSquared) {
                     if (this.lastTeleportTick + 30 < this.server.getTick()) {
                         this.sendPosition(this.getLocation(), MovePlayerPacket.MODE_RESET);
-                        log.debug("{}: move {} > 100", username, dis);
+                        log.debug("{}: move {} > {}", username, dis, legacyMoveDistanceLimitSquared);
                     }
                     break;
                 }
@@ -4389,9 +4413,10 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                     break;
                 }
 
-                if (distSqrt > 100) {
+                double authInputDistanceLimitSquared = movementSanityLimitSquared(100);
+                if (distSqrt > authInputDistanceLimitSquared) {
                     this.sendPosition(this.getLocation(), MovePlayerPacket.MODE_RESET);
-                    log.debug("{}: move {} > 100", username, distSqrt);
+                    log.debug("{}: move {} > {}", username, distSqrt, authInputDistanceLimitSquared);
                     return;
                 }
 

--- a/src/test/java/cn/nukkit/PlayerFlightMovementLimitTest.java
+++ b/src/test/java/cn/nukkit/PlayerFlightMovementLimitTest.java
@@ -1,0 +1,63 @@
+package cn.nukkit;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Answers.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+
+class PlayerFlightMovementLimitTest {
+
+    private Player player;
+    private AdventureSettings settings;
+
+    @BeforeEach
+    void setUp() {
+        player = mock(Player.class, CALLS_REAL_METHODS);
+        settings = new AdventureSettings(player);
+        player.adventureSettings = settings;
+    }
+
+    @Test
+    void scalesSquaredLimitsForAuthorizedFastFlight() {
+        settings.set(AdventureSettings.Type.ALLOW_FLIGHT, true);
+        settings.set(AdventureSettings.Type.FLYING, true);
+        player.setFlySpeed(1.0f);
+
+        assertEquals(40_000d, player.movementSanityLimitSquared(100d), 0.01d);
+        assertEquals(90_000d, player.movementSanityLimitSquared(225d), 0.01d);
+    }
+
+    @Test
+    void permissionWithoutActiveFlightKeepsVanillaLimit() {
+        settings.set(AdventureSettings.Type.ALLOW_FLIGHT, true);
+        player.setFlySpeed(1.0f);
+
+        assertEquals(100d, player.movementSanityLimitSquared(100d), 1e-6);
+    }
+
+    @Test
+    void activeFlightWithoutPermissionKeepsVanillaLimit() {
+        settings.set(AdventureSettings.Type.FLYING, true);
+        player.setFlySpeed(1.0f);
+
+        assertEquals(100d, player.movementSanityLimitSquared(100d), 1e-6);
+    }
+
+    @Test
+    void vanillaAndInvalidSpeedsKeepVanillaLimit() {
+        settings.set(AdventureSettings.Type.ALLOW_FLIGHT, true);
+        settings.set(AdventureSettings.Type.FLYING, true);
+
+        player.setFlySpeed(Player.DEFAULT_FLY_SPEED);
+        assertEquals(100d, player.movementSanityLimitSquared(100d), 1e-6);
+
+        player.setFlySpeed(Float.POSITIVE_INFINITY);
+        assertEquals(100d, player.movementSanityLimitSquared(100d), 1e-6);
+
+        player.setFlySpeed(Float.MAX_VALUE);
+        assertTrue(Double.isFinite(player.movementSanityLimitSquared(100d)));
+    }
+}


### PR DESCRIPTION
### Problem

A player with `ALLOW_FLIGHT` and `FLYING` set and a raised fly speed moves further per packet than
two hardcoded sanity limits allow: 100 (squared distance per move packet) and 225 (squared distance
per tick). At a fly speed around 20x vanilla, normal flight trips them constantly and the player is
rubber-banded back.

Both checks run before `PlayerInvalidMoveEvent` is fired, so a plugin cannot allow the movement it
authorized itself by raising the speed in the first place.

### Fix

Scale the two limits by the square of the configured speed ratio, and only when the player is
genuinely an authorized flier: `ALLOW_FLIGHT` and `FLYING` both set and `getFlySpeed()` a finite
value above the vanilla default. A walking player, a player who may fly but is not flying, vanilla
fly speed and a non-finite multiplier all keep the original thresholds untouched.

### Tests

`PlayerFlightMovementLimitTest` covers all four cases.
