### PR TITLE
entity: let a server see which item breeds or tames an animal

### DIFF
--- a/src/main/java/cn/nukkit/entity/BaseEntity.java
+++ b/src/main/java/cn/nukkit/entity/BaseEntity.java
@@ -488,17 +488,11 @@ public abstract class BaseEntity extends EntityCreature implements EntityAgeable
     }
 
     /**
-     * Does feeding this item to this entity start breeding.
-     *
-     * <p>Every breeder in the tree already knows the answer and every one of them keeps it
-     * somewhere else: {@link cn.nukkit.entity.passive.EntityWalkingAnimal} exposes
-     * {@code isFeedItem}, {@link cn.nukkit.entity.mob.EntityWolf} has its own
-     * {@code isBreedingItem}, and the rabbit and the dolphin compare item ids inline inside
-     * {@code onInteract}. A server that wants to refuse breeding has nothing to ask, so it either
-     * copies those three lists and lets them drift, or refuses too late - after the food is gone.
-     *
-     * <p>One question on the common ancestor makes {@code PlayerInteractEntityEvent} enough: the
-     * intent is visible while the item is still in the player's hand.
+     * 判断手持该物品与本实体交互是否会触发繁殖（进入求爱期）。
+     * 仅回答物品是否匹配，幼年、求爱冷却等前置状态由调用方自行判断。
+     * <p>
+     * Whether interacting with this entity using the given item starts breeding (love mode).
+     * Only answers the item match; preconditions like baby or love cooldown are up to the caller.
      */
     public boolean isBreedingItem(Item item) {
         return false;

--- a/src/main/java/cn/nukkit/entity/BaseEntity.java
+++ b/src/main/java/cn/nukkit/entity/BaseEntity.java
@@ -488,6 +488,23 @@ public abstract class BaseEntity extends EntityCreature implements EntityAgeable
     }
 
     /**
+     * Does feeding this item to this entity start breeding.
+     *
+     * <p>Every breeder in the tree already knows the answer and every one of them keeps it
+     * somewhere else: {@link cn.nukkit.entity.passive.EntityWalkingAnimal} exposes
+     * {@code isFeedItem}, {@link cn.nukkit.entity.mob.EntityWolf} has its own
+     * {@code isBreedingItem}, and the rabbit and the dolphin compare item ids inline inside
+     * {@code onInteract}. A server that wants to refuse breeding has nothing to ask, so it either
+     * copies those three lists and lets them drift, or refuses too late - after the food is gone.
+     *
+     * <p>One question on the common ancestor makes {@code PlayerInteractEntityEvent} enough: the
+     * intent is visible while the item is still in the player's hand.
+     */
+    public boolean isBreedingItem(Item item) {
+        return false;
+    }
+
+    /**
      * Check if the entity can swim in the block
      *
      * @param block block id

--- a/src/main/java/cn/nukkit/entity/EntityTameable.java
+++ b/src/main/java/cn/nukkit/entity/EntityTameable.java
@@ -26,13 +26,10 @@ public interface EntityTameable {
     void setSitting(boolean sitting);
 
     /**
-     * Does using this item on this entity tame it.
-     *
-     * <p>The item lives inside {@code onInteract} of every tameable entity, so a server can only
-     * learn that a wild animal has just become a pet after it already happened. Asking here lets
-     * it decide while the item is still in the player's hand, the same way
-     * {@code BaseEntity#isBreedingItem} does for breeding. Whether the entity is free to be tamed
-     * at all - it has no owner, it is not angry - stays with the caller.
+     * 判断该物品是否为本实体的驯服物品；是否满足驯服前提（无主人、未愤怒等）由调用方判断。
+     * <p>
+     * Whether using this item tames this entity. Taming preconditions (no owner, not angry)
+     * are up to the caller.
      */
     default boolean isTamingItem(Item item) {
         return false;

--- a/src/main/java/cn/nukkit/entity/EntityTameable.java
+++ b/src/main/java/cn/nukkit/entity/EntityTameable.java
@@ -1,6 +1,7 @@
 package cn.nukkit.entity;
 
 import cn.nukkit.Player;
+import cn.nukkit.item.Item;
 
 public interface EntityTameable {
 
@@ -23,6 +24,19 @@ public interface EntityTameable {
     boolean isSitting();
 
     void setSitting(boolean sitting);
+
+    /**
+     * Does using this item on this entity tame it.
+     *
+     * <p>The item lives inside {@code onInteract} of every tameable entity, so a server can only
+     * learn that a wild animal has just become a pet after it already happened. Asking here lets
+     * it decide while the item is still in the player's hand, the same way
+     * {@code BaseEntity#isBreedingItem} does for breeding. Whether the entity is free to be tamed
+     * at all - it has no owner, it is not angry - stays with the caller.
+     */
+    default boolean isTamingItem(Item item) {
+        return false;
+    }
 
     default boolean isOwner(Entity entity) {
         return entity instanceof Player && entity.getUniqueId().toString().equals(this.getOwnerUUID());

--- a/src/main/java/cn/nukkit/entity/mob/EntityWolf.java
+++ b/src/main/java/cn/nukkit/entity/mob/EntityWolf.java
@@ -519,6 +519,7 @@ public class EntityWolf extends EntityTameableMob implements InventoryHolder {
             item.getId() == ItemID.ROTTEN_FLESH;
     }
 
+    @Override
     public boolean isBreedingItem(Item item) {
         return item.getId() == ItemID.RAW_CHICKEN ||
             item.getId() == ItemID.COOKED_CHICKEN ||
@@ -531,6 +532,11 @@ public class EntityWolf extends EntityTameableMob implements InventoryHolder {
             item.getId() == ItemID.RAW_RABBIT ||
             item.getId() == ItemID.COOKED_RABBIT ||
             item.getId() == ItemID.ROTTEN_FLESH;
+    }
+
+    @Override
+    public boolean isTamingItem(Item item) {
+        return item.getId() == ItemID.BONE;
     }
 
     public int getHealableItem(Item item) {

--- a/src/main/java/cn/nukkit/entity/passive/EntityChicken.java
+++ b/src/main/java/cn/nukkit/entity/passive/EntityChicken.java
@@ -119,9 +119,13 @@ public class EntityChicken extends EntityWalkingAnimal implements EntityClimateV
     }
 
     @Override
+    public boolean isBreedingItem(Item item) {
+        return this.isFeedItem(item);
+    }
+
+    @Override
     public boolean onInteract(Player player, Item item, Vector3 clickedPos) {
-        if (item.getId() == Item.SEEDS || item.getId() == Item.BEETROOT_SEEDS ||
-                item.getId() == Item.MELON_SEEDS || item.getId() == Item.PUMPKIN_SEEDS) {
+        if (this.isBreedingItem(item)) {
             if (!this.isBaby() && !this.isInLoveCooldown()) {
                 player.getInventory().decreaseCount(player.getInventory().getHeldItemIndex());
                 this.level.addParticle(new ItemBreakParticle(

--- a/src/main/java/cn/nukkit/entity/passive/EntityCow.java
+++ b/src/main/java/cn/nukkit/entity/passive/EntityCow.java
@@ -72,7 +72,7 @@ public class EntityCow extends EntityWalkingAnimal implements EntityClimateVaria
             }
             this.level.addLevelSoundEvent(this, LevelSoundEventPacket.SOUND_MILK);
             return false;
-        } else if (item.getId() == Item.WHEAT && !this.isBaby() && !this.isInLoveCooldown()) {
+        } else if (this.isBreedingItem(item) && !this.isBaby() && !this.isInLoveCooldown()) {
             if (!player.isCreative()) {
                 player.getInventory().decreaseCount(player.getInventory().getHeldItemIndex());
             }
@@ -88,6 +88,11 @@ public class EntityCow extends EntityWalkingAnimal implements EntityClimateVaria
     @Override
     public boolean isFeedItem(Item item) {
         return item.getId() == Item.WHEAT;
+    }
+
+    @Override
+    public boolean isBreedingItem(Item item) {
+        return this.isFeedItem(item);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/entity/passive/EntityDolphin.java
+++ b/src/main/java/cn/nukkit/entity/passive/EntityDolphin.java
@@ -56,8 +56,13 @@ public class EntityDolphin extends EntityWaterAnimal {
     }
 
     @Override
+    public boolean isBreedingItem(Item item) {
+        return item.getId() == Item.RAW_FISH;
+    }
+
+    @Override
     public boolean onInteract(Player player, Item item, Vector3 clickedPos) {
-        if (item.getId() == Item.RAW_FISH && !this.isBaby() && !this.isInLoveCooldown()) {
+        if (this.isBreedingItem(item) && !this.isBaby() && !this.isInLoveCooldown()) {
             player.getInventory().decreaseCount(player.getInventory().getHeldItemIndex());
             this.level.addLevelSoundEvent(this, LevelSoundEventPacket.SOUND_EAT);
             this.level.addParticle(new ItemBreakParticle(this.add(0, this.getMountedYOffset(), 0), Item.get(Item.RAW_FISH)));

--- a/src/main/java/cn/nukkit/entity/passive/EntityFox.java
+++ b/src/main/java/cn/nukkit/entity/passive/EntityFox.java
@@ -46,7 +46,7 @@ public class EntityFox extends EntityWalkingAnimal {
 
     @Override
     public boolean onInteract(Player player, Item item, Vector3 clickedPos) {
-        if (item.getId() == Item.SWEET_BERRIES && !this.isBaby() && !this.isInLoveCooldown()) {
+        if (this.isBreedingItem(item) && !this.isBaby() && !this.isInLoveCooldown()) {
             player.getInventory().decreaseCount(player.getInventory().getHeldItemIndex());
             this.level.addLevelSoundEvent(this, LevelSoundEventPacket.SOUND_EAT);
             this.level.addParticle(new ItemBreakParticle(this.add(0, this.getMountedYOffset(), 0), Item.get(Item.SWEET_BERRIES)));
@@ -59,6 +59,11 @@ public class EntityFox extends EntityWalkingAnimal {
     @Override
     public boolean isFeedItem(Item item) {
         return item.getId() == Item.SWEET_BERRIES;
+    }
+
+    @Override
+    public boolean isBreedingItem(Item item) {
+        return this.isFeedItem(item);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/entity/passive/EntityHorseBase.java
+++ b/src/main/java/cn/nukkit/entity/passive/EntityHorseBase.java
@@ -141,7 +141,7 @@ public class EntityHorseBase extends EntityWalkingAnimal implements EntityRideab
 
     @Override
     public boolean onInteract(Player player, Item item, Vector3 clickedPos) {
-        if (this.isFeedItem(item) && !this.isInLoveCooldown()) {
+        if (this.isBreedingItem(item) && !this.isInLoveCooldown()) {
             this.level.addLevelSoundEvent(this, LevelSoundEventPacket.SOUND_EAT);
             this.level.addParticle(new ItemBreakParticle(this.add(0, this.getMountedYOffset(), 0), Item.get(item.getId(), 0, 1)));
             this.setInLove();
@@ -252,6 +252,12 @@ public class EntityHorseBase extends EntityWalkingAnimal implements EntityRideab
                 item.getId() == Item.SUGAR ||
                 item.getId() == Item.BREAD ||
                 item.getId() == Item.GOLDEN_CARROT;
+    }
+
+    // 马类的喂食与繁殖物品恒同，直接复用 isFeedItem
+    @Override
+    public boolean isBreedingItem(Item item) {
+        return this.isFeedItem(item);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/entity/passive/EntityMooshroom.java
+++ b/src/main/java/cn/nukkit/entity/passive/EntityMooshroom.java
@@ -61,6 +61,11 @@ public class EntityMooshroom extends EntityWalkingAnimal {
     }
 
     @Override
+    public boolean isBreedingItem(Item item) {
+        return this.isFeedItem(item);
+    }
+
+    @Override
     public Item[] getDrops() {
         List<Item> drops = new ArrayList<>();
 
@@ -102,7 +107,7 @@ public class EntityMooshroom extends EntityWalkingAnimal {
             }
             this.level.addLevelSoundEvent(this, LevelSoundEventPacket.SOUND_MILK);
             return false;
-        } else if (item.getId() == Item.WHEAT && !this.isBaby() && !this.isInLoveCooldown()) {
+        } else if (this.isBreedingItem(item) && !this.isBaby() && !this.isInLoveCooldown()) {
             if (!player.isCreative()) {
                 player.getInventory().decreaseCount(player.getInventory().getHeldItemIndex());
             }

--- a/src/main/java/cn/nukkit/entity/passive/EntityPig.java
+++ b/src/main/java/cn/nukkit/entity/passive/EntityPig.java
@@ -81,21 +81,20 @@ public class EntityPig extends EntityWalkingAnimal implements EntityRideable, En
                 || id == Item.BEETROOT;
     }
 
+    // 胡萝卜钓竿仅用于骑乘转向，不触发繁殖
+    @Override
+    public boolean isBreedingItem(Item item) {
+        int id = item.getId();
+        return id == Item.CARROT
+                || id == Item.POTATO
+                || id == Item.BEETROOT;
+    }
+
     @Override
     public boolean onInteract(Player player, Item item, Vector3 clickedPos) {
-        if (item.getId() == Item.CARROT && !this.isBaby() && !this.isInLoveCooldown()) {
+        if (this.isBreedingItem(item) && !this.isBaby() && !this.isInLoveCooldown()) {
             player.getInventory().decreaseCount(player.getInventory().getHeldItemIndex());
-            this.level.addParticle(new ItemBreakParticle(this.add(0,this.getMountedYOffset(),0),Item.get(Item.CARROT)));
-            this.setInLove();
-            return true;
-        } else if (item.getId() == Item.POTATO && !this.isBaby() && !this.isInLoveCooldown()) {
-            player.getInventory().decreaseCount(player.getInventory().getHeldItemIndex());
-            this.level.addParticle(new ItemBreakParticle(this.add(0,this.getMountedYOffset(),0),Item.get(Item.POTATO)));
-            this.setInLove();
-            return true;
-        } else if (item.getId() == Item.BEETROOT && !this.isBaby() && !this.isInLoveCooldown()) {
-            player.getInventory().decreaseCount(player.getInventory().getHeldItemIndex());
-            this.level.addParticle(new ItemBreakParticle(this.add(0,this.getMountedYOffset(),0),Item.get(Item.BEETROOT)));
+            this.level.addParticle(new ItemBreakParticle(this.add(0,this.getMountedYOffset(),0), Item.get(item.getId())));
             this.setInLove();
             return true;
         } else if (item.getId() == Item.SADDLE && !this.isSaddled() && !this.isBaby() && !this.isInLoveCooldown()) {

--- a/src/main/java/cn/nukkit/entity/passive/EntityRabbit.java
+++ b/src/main/java/cn/nukkit/entity/passive/EntityRabbit.java
@@ -85,8 +85,14 @@ public class EntityRabbit extends EntityJumpingAnimal {
     }
 
     @Override
+    public boolean isBreedingItem(Item item) {
+        int id = item.getId();
+        return id == Item.DANDELION || id == Item.CARROT || id == Item.GOLDEN_CARROT;
+    }
+
+    @Override
     public boolean onInteract(Player player, Item item, Vector3 clickedPos) {
-        if (item.getId() == Item.DANDELION || item.getId() == Item.CARROT || item.getId() == Item.GOLDEN_CARROT) {
+        if (this.isBreedingItem(item)) {
             player.getInventory().decreaseCount(player.getInventory().getHeldItemIndex());
             this.level.addLevelSoundEvent(this, LevelSoundEventPacket.SOUND_EAT);
             this.level.addParticle(new ItemBreakParticle(this.add(0,this.getMountedYOffset(),0), item));

--- a/src/main/java/cn/nukkit/entity/passive/EntitySheep.java
+++ b/src/main/java/cn/nukkit/entity/passive/EntitySheep.java
@@ -84,7 +84,7 @@ public class EntitySheep extends EntityWalkingAnimal {
         if (item.getId() == Item.DYE) {
             this.setColor(((ItemDye) item).getDyeColor().getWoolData());
             return true;
-        } else if (item.getId() == Item.WHEAT && !this.isBaby() && !this.isInLoveCooldown()) {
+        } else if (this.isBreedingItem(item) && !this.isBaby() && !this.isInLoveCooldown()) {
             player.getInventory().decreaseCount(player.getInventory().getHeldItemIndex());
             this.level.addLevelSoundEvent(this, LevelSoundEventPacket.SOUND_EAT);
             this.level.addParticle(new ItemBreakParticle(this.add(0, this.getMountedYOffset(), 0), Item.get(Item.WHEAT)));
@@ -113,6 +113,11 @@ public class EntitySheep extends EntityWalkingAnimal {
     @Override
     public boolean isFeedItem(Item item) {
         return item.getId() == Item.WHEAT;
+    }
+
+    @Override
+    public boolean isBreedingItem(Item item) {
+        return this.isFeedItem(item);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/entity/passive/EntityWalkingAnimal.java
+++ b/src/main/java/cn/nukkit/entity/passive/EntityWalkingAnimal.java
@@ -111,13 +111,14 @@ public abstract class EntityWalkingAnimal extends EntityWalking implements Entit
                 && entity.canBeFollowed();
     }
 
+    /**
+     * 判断玩家手持该物品时本实体是否会被吸引跟随（诱饵语义，与 {@link #isBreedingItem} 不是同一概念）。
+     * <p>
+     * Whether this entity follows a player holding the item (lure semantics; a different notion
+     * from {@link #isBreedingItem}).
+     */
     public boolean isFeedItem(Item item) {
         return false;
-    }
-
-    @Override
-    public boolean isBreedingItem(Item item) {
-        return this.isFeedItem(item);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/entity/passive/EntityWalkingAnimal.java
+++ b/src/main/java/cn/nukkit/entity/passive/EntityWalkingAnimal.java
@@ -116,6 +116,11 @@ public abstract class EntityWalkingAnimal extends EntityWalking implements Entit
     }
 
     @Override
+    public boolean isBreedingItem(Item item) {
+        return this.isFeedItem(item);
+    }
+
+    @Override
     public boolean isFriendly() {
         return true;
     }

--- a/src/test/java/cn/nukkit/entity/EntityBreedingItemTest.java
+++ b/src/test/java/cn/nukkit/entity/EntityBreedingItemTest.java
@@ -1,0 +1,134 @@
+package cn.nukkit.entity;
+
+import cn.nukkit.MockServer;
+import cn.nukkit.entity.mob.EntityWolf;
+import cn.nukkit.entity.passive.*;
+import cn.nukkit.item.Item;
+import cn.nukkit.level.GameRules;
+import cn.nukkit.level.Level;
+import cn.nukkit.level.format.FullChunk;
+import cn.nukkit.level.format.LevelProvider;
+import cn.nukkit.level.vibration.VibrationManager;
+import cn.nukkit.nbt.tag.CompoundTag;
+import cn.nukkit.nbt.tag.DoubleTag;
+import cn.nukkit.nbt.tag.FloatTag;
+import cn.nukkit.nbt.tag.ListTag;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+
+/**
+ * 校验 {@code isBreedingItem}/{@code isTamingItem} 与 onInteract 实际繁殖/驯服行为一致。
+ * <p>
+ * Verifies that {@code isBreedingItem}/{@code isTamingItem} match what onInteract actually
+ * breeds or tames with — in particular the lure-vs-breed divergence (pig's carrot on a
+ * stick, strider/cat/ocelot which never breed).
+ */
+public class EntityBreedingItemTest {
+
+    @BeforeAll
+    static void initServer() {
+        MockServer.init();
+    }
+
+    @Test
+    public void pigBreedingExcludesCarrotOnAStick() {
+        EntityPig pig = new EntityPig(newMockChunk(), baseNbt());
+
+        assertTrue(pig.isBreedingItem(Item.get(Item.CARROT)));
+        assertTrue(pig.isBreedingItem(Item.get(Item.POTATO)));
+        assertTrue(pig.isBreedingItem(Item.get(Item.BEETROOT)));
+        assertFalse(pig.isBreedingItem(Item.get(Item.CARROT_ON_A_STICK)),
+                "carrot on a stick only steers a saddled pig, it must not answer as breeding");
+        assertTrue(pig.isFeedItem(Item.get(Item.CARROT_ON_A_STICK)),
+                "the lure list keeps the stick");
+    }
+
+    @Test
+    public void animalsWithoutBreedingAnswerFalse() {
+        assertFalse(new EntityStrider(newMockChunk(), baseNbt())
+                .isBreedingItem(Item.get(Item.WARPED_FUNGUS_ON_A_STICK)));
+        assertFalse(new EntityCat(newMockChunk(), baseNbt())
+                .isBreedingItem(Item.get(Item.RAW_FISH)));
+        assertFalse(new EntityOcelot(newMockChunk(), baseNbt())
+                .isBreedingItem(Item.get(Item.RAW_FISH)));
+    }
+
+    @Test
+    public void breedingAnimalsAnswerTheirFood() {
+        assertTrue(new EntityChicken(newMockChunk(), baseNbt()).isBreedingItem(Item.get(Item.SEEDS)));
+        assertTrue(new EntityCow(newMockChunk(), baseNbt()).isBreedingItem(Item.get(Item.WHEAT)));
+        assertTrue(new EntitySheep(newMockChunk(), baseNbt()).isBreedingItem(Item.get(Item.WHEAT)));
+        assertTrue(new EntityMooshroom(newMockChunk(), baseNbt()).isBreedingItem(Item.get(Item.WHEAT)));
+        assertTrue(new EntityFox(newMockChunk(), baseNbt()).isBreedingItem(Item.get(Item.SWEET_BERRIES)));
+        assertTrue(new EntityHorse(newMockChunk(), baseNbt()).isBreedingItem(Item.get(Item.GOLDEN_CARROT)));
+        assertTrue(new EntityRabbit(newMockChunk(), baseNbt()).isBreedingItem(Item.get(Item.DANDELION)));
+        assertTrue(new EntityDolphin(newMockChunk(), baseNbt()).isBreedingItem(Item.get(Item.RAW_FISH)));
+    }
+
+    @Test
+    public void unrelatedItemsAnswerFalse() {
+        assertFalse(new EntityCow(newMockChunk(), baseNbt()).isBreedingItem(Item.get(Item.SEEDS)));
+        assertFalse(new EntityChicken(newMockChunk(), baseNbt()).isBreedingItem(Item.get(Item.WHEAT)));
+    }
+
+    @Test
+    public void wolfAnswersTamingAndBreedingItems() {
+        EntityWolf wolf = new EntityWolf(newMockChunk(), baseNbt());
+
+        assertTrue(wolf.isTamingItem(Item.get(Item.BONE)));
+        assertFalse(wolf.isTamingItem(Item.get(Item.RAW_BEEF)));
+        assertTrue(wolf.isBreedingItem(Item.get(Item.RAW_BEEF)));
+        assertFalse(new EntityOcelot(newMockChunk(), baseNbt()).isTamingItem(Item.get(Item.RAW_FISH)),
+                "ocelots have no taming implementation, so no item tames them");
+    }
+
+    private static FullChunk newMockChunk() {
+        Level level = mock(Level.class);
+        lenient().when(level.getServer()).thenReturn(MockServer.get());
+        lenient().when(level.getMinBlockY()).thenReturn(-64);
+        lenient().when(level.getMaxBlockY()).thenReturn(319);
+        lenient().when(level.getGameRules()).thenReturn(GameRules.getDefault());
+        lenient().when(level.getChunkPlayers(0, 0)).thenReturn(Collections.emptyMap());
+        lenient().when(level.getNearbyEntities(any(), any())).thenReturn(new Entity[0]);
+        lenient().when(level.getNearbyEntities(any(), any(), anyBoolean(), anyBoolean())).thenReturn(new Entity[0]);
+        lenient().when(level.getBlockIdAt(any(FullChunk.class), anyInt(), anyInt(), anyInt())).thenReturn(0);
+        lenient().when(level.getVibrationManager()).thenReturn(mock(VibrationManager.class));
+        try {
+            Field f = Level.class.getDeclaredField("isBeingConverted");
+            f.setAccessible(true);
+            f.setBoolean(level, true);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        FullChunk chunk = mock(FullChunk.class);
+        LevelProvider provider = mock(LevelProvider.class);
+        lenient().when(chunk.getProvider()).thenReturn(provider);
+        lenient().when(provider.getLevel()).thenReturn(level);
+        return chunk;
+    }
+
+    private static CompoundTag baseNbt() {
+        return new CompoundTag()
+                .putList(new ListTag<>("Pos")
+                        .add(new DoubleTag("", 0.5))
+                        .add(new DoubleTag("", 64.0))
+                        .add(new DoubleTag("", 0.5)))
+                .putList(new ListTag<>("Motion")
+                        .add(new DoubleTag("", 0))
+                        .add(new DoubleTag("", 0))
+                        .add(new DoubleTag("", 0)))
+                .putList(new ListTag<>("Rotation")
+                        .add(new FloatTag("", 0))
+                        .add(new FloatTag("", 0)));
+    }
+}


### PR DESCRIPTION
Breeding and taming are the only ways a player creates new mobs out of nothing,
and both of them are invisible until they already happened. Every breeder knows
its own food - EntityWalkingAnimal has isFeedItem, EntityWolf has its own
isBreedingItem, the rabbit and the dolphin compare item ids inline in
onInteract - and nothing asks the entity from the outside. A server that wants
to keep a farm from growing without limit has to copy those three lists and
watch them drift, or refuse after the food has already been eaten.

BaseEntity gains isBreedingItem(Item), answered by the lists the entities
already carry, and EntityTameable gains isTamingItem(Item), answered by the wolf
with the bone it already looks for. Both are pure questions with no side
effects, so PlayerInteractEntityEvent becomes enough: a plugin sees the intent
while the item is still in the player's hand and refusing costs the player
nothing.

No behaviour changes: the rabbit and the dolphin now call the list they used to
compare inline, and every other entity answers false as before.
