### PR TITLE
entity: recognize a totem by its item id

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -6870,7 +6870,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                 }
             } else {
                 // 发包给客户端清除不死图腾，防止影响自杀等操作
-                if (this.getOffhandInventory().getItemFast(0) instanceof ItemTotem) {
+                if (Entity.isTotem(this.getOffhandInventory().getItemFast(0))) {
                     InventorySlotPacket pk = new InventorySlotPacket();
                     pk.slot = 0;
                     pk.item = Item.AIR_ITEM;
@@ -6884,7 +6884,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                 int id = this.getWindowId(this.getInventory());
                 if (id != -1) {
                     for (Entry<Integer, Item> entry : this.getInventory().getContents().entrySet()) {
-                        if (entry.getValue() instanceof ItemTotem) {
+                        if (Entity.isTotem(entry.getValue())) {
                             InventorySlotPacket pk = new InventorySlotPacket();
                             pk.slot = entry.getKey();
                             pk.item = Item.AIR_ITEM;

--- a/src/main/java/cn/nukkit/entity/Entity.java
+++ b/src/main/java/cn/nukkit/entity/Entity.java
@@ -42,6 +42,7 @@ import cn.nukkit.potion.Effect;
 import cn.nukkit.utils.*;
 import com.google.common.collect.Iterables;
 import org.apache.commons.math3.util.FastMath;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
@@ -1762,9 +1763,14 @@ public abstract class Entity extends Location implements Metadatable {
         }
     }
 
-    static boolean isTotem(Item item) {
-        // The numeric id is what survives inventory serialization. A plugin-created or restored
-        // stack may therefore be a plain Item even though it is the canonical vanilla totem.
+    /**
+     * 判断是否为不死图腾：按数字 id 而非 instanceof，插件直构的 plain Item 也能识别。
+     * <p>
+     * Whether the item is a totem, matched by numeric id so plugin-created plain
+     * {@code Item} stacks are recognized as well as typed {@code ItemTotem}s.
+     */
+    @ApiStatus.Internal
+    public static boolean isTotem(Item item) {
         return item != null && item.getId() == Item.TOTEM && item.getCount() > 0;
     }
 

--- a/src/main/java/cn/nukkit/entity/Entity.java
+++ b/src/main/java/cn/nukkit/entity/Entity.java
@@ -24,7 +24,6 @@ import cn.nukkit.event.player.PlayerInteractEvent;
 import cn.nukkit.event.player.PlayerInteractEvent.Action;
 import cn.nukkit.event.player.PlayerTeleportEvent;
 import cn.nukkit.item.Item;
-import cn.nukkit.item.ItemTotem;
 import cn.nukkit.item.enchantment.Enchantment;
 import cn.nukkit.level.*;
 import cn.nukkit.level.format.FullChunk;
@@ -1763,6 +1762,12 @@ public abstract class Entity extends Location implements Metadatable {
         }
     }
 
+    static boolean isTotem(Item item) {
+        // The numeric id is what survives inventory serialization. A plugin-created or restored
+        // stack may therefore be a plain Item even though it is the canonical vanilla totem.
+        return item != null && item.getId() == Item.TOTEM && item.getCount() > 0;
+    }
+
     public boolean attack(EntityDamageEvent source) {
         if (hasEffect(Effect.FIRE_RESISTANCE)
                 && (source.getCause() == DamageCause.FIRE
@@ -1833,10 +1838,10 @@ public abstract class Entity extends Location implements Metadatable {
             if (source.getCause() != DamageCause.VOID && source.getCause() != DamageCause.SUICIDE) {
                 boolean totem = false;
                 boolean isOffhand = false;
-                if (p.getOffhandInventory().getItemFast(0) instanceof ItemTotem) {
+                if (isTotem(p.getOffhandInventory().getItemFast(0))) {
                     totem = true;
                     isOffhand = true;
-                } else if (p.getInventory().getItemInHandFast() instanceof ItemTotem) {
+                } else if (isTotem(p.getInventory().getItemInHandFast())) {
                     totem = true;
                 }
                 if (totem) {
@@ -1857,15 +1862,15 @@ public abstract class Entity extends Location implements Metadatable {
                     p.dataPacket(pk);
 
                     if (isOffhand) {
-                        p.getOffhandInventory().clear(0);
+                        p.getOffhandInventory().decreaseCount(0);
                     } else {
-                        p.getInventory().clear(p.getInventory().getHeldItemIndex());
+                        p.getInventory().decreaseCount(p.getInventory().getHeldItemIndex());
                     }
 
                     source.setCancelled(true);
                     return false;
                 }
-            } else if (p.getOffhandInventory().getItemFast(0) instanceof ItemTotem) {
+            } else if (isTotem(p.getOffhandInventory().getItemFast(0))) {
                 // This damage bypasses the totem (SUICIDE/VOID) and will kill the player. Hide the
                 // offhand totem before the death/damage signal reaches the client to prevent its
                 // local auto-revival creating a "ghost" state; the real item is left untouched.

--- a/src/test/java/cn/nukkit/entity/EntityTotemTest.java
+++ b/src/test/java/cn/nukkit/entity/EntityTotemTest.java
@@ -2,8 +2,6 @@ package cn.nukkit.entity;
 
 import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemTotem;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -25,15 +23,5 @@ class EntityTotemTest {
         assertFalse(Entity.isTotem(null));
         assertFalse(Entity.isTotem(new Item(Item.TOTEM, 0, 0, "Totem of Undying")));
         assertFalse(Entity.isTotem(new Item(Item.STONE, 0, 1, "Stone")));
-    }
-
-    @Test
-    void consumesOnlyOneTotemFromEitherHand() throws Exception {
-        String source = Files.readString(Path.of("src/main/java/cn/nukkit/entity/Entity.java"));
-
-        assertTrue(source.contains("getOffhandInventory().decreaseCount(0)"));
-        assertTrue(
-                source.contains(
-                        "getInventory().decreaseCount(p.getInventory().getHeldItemIndex())"));
     }
 }

--- a/src/test/java/cn/nukkit/entity/EntityTotemTest.java
+++ b/src/test/java/cn/nukkit/entity/EntityTotemTest.java
@@ -1,0 +1,39 @@
+package cn.nukkit.entity;
+
+import cn.nukkit.item.Item;
+import cn.nukkit.item.ItemTotem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EntityTotemTest {
+
+    @Test
+    void recognizesCanonicalTotemIdWithoutDependingOnTheJavaSubclass() {
+        Item restoredAsPlainItem = new Item(Item.TOTEM, 0, 1, "Totem of Undying");
+
+        assertTrue(Entity.isTotem(restoredAsPlainItem));
+        assertTrue(Entity.isTotem(new ItemTotem(0)));
+        assertTrue(Entity.isTotem(new Item(Item.TOTEM, 0, 2, "Totem of Undying")));
+    }
+
+    @Test
+    void rejectsEmptyAndDifferentItems() {
+        assertFalse(Entity.isTotem(null));
+        assertFalse(Entity.isTotem(new Item(Item.TOTEM, 0, 0, "Totem of Undying")));
+        assertFalse(Entity.isTotem(new Item(Item.STONE, 0, 1, "Stone")));
+    }
+
+    @Test
+    void consumesOnlyOneTotemFromEitherHand() throws Exception {
+        String source = Files.readString(Path.of("src/main/java/cn/nukkit/entity/Entity.java"));
+
+        assertTrue(source.contains("getOffhandInventory().decreaseCount(0)"));
+        assertTrue(
+                source.contains(
+                        "getInventory().decreaseCount(p.getInventory().getHeldItemIndex())"));
+    }
+}


### PR DESCRIPTION
Inventory deserialization and plugin-created stacks can carry the canonical
totem id in a plain Item object instead of ItemTotem. Entity.attack checked the
Java subclass, so such a real totem stayed in the player's hand while the
player died.

The item id is the stable protocol and inventory identity. Use it for both
hands and for the void/suicide client guard, while still rejecting empty
stacks. Consume exactly one item so even an invalid plugin-created stack cannot
lose every totem at once. Typed ItemTotem stacks keep the same behavior.