### PR TITLE
item: keep totems single and preserve old overstacks

### DIFF
--- a/src/main/java/cn/nukkit/item/Item.java
+++ b/src/main/java/cn/nukkit/item/Item.java
@@ -1652,7 +1652,7 @@ public class Item implements Cloneable, BlockID, ItemID, ItemNamespaceId, Protoc
     }
 
     public int getMaxStackSize() {
-        return 64;
+        return id == TOTEM ? 1 : 64;
     }
 
     final public Short getFuelTime() {

--- a/src/main/java/cn/nukkit/nbt/NBTIO.java
+++ b/src/main/java/cn/nukkit/nbt/NBTIO.java
@@ -83,7 +83,11 @@ public class NBTIO {
             item.setCount(count);
         }
 
-        if (item.count > item.getMaxStackSize()) {
+        // Old direct container writes could persist two totems in one slot. Keep their exact
+        // count until the host migration can split them into separate slots; clamping here
+        // silently deletes the paid or looted tail before any inventory code can see it.
+        // Other malformed stacks keep the original defensive clamp.
+        if (item.count > item.getMaxStackSize() && item.getId() != Item.TOTEM) {
             item.count = item.getMaxStackSize();
             tag.putByte("Count", item.getMaxStackSize());
         }

--- a/src/test/java/cn/nukkit/item/ItemTotemStackLimitTest.java
+++ b/src/test/java/cn/nukkit/item/ItemTotemStackLimitTest.java
@@ -1,0 +1,39 @@
+package cn.nukkit.item;
+
+import cn.nukkit.nbt.NBTIO;
+import cn.nukkit.nbt.tag.CompoundTag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ItemTotemStackLimitTest {
+
+    @Test
+    void plainItemWithTotemIdStillHasVanillaStackLimit() {
+        Item fallback = new Item(Item.TOTEM, 0, 2, "Totem of Undying");
+
+        assertEquals(1, fallback.getMaxStackSize());
+    }
+
+    @Test
+    void persistedTotemOverstackSurvivesUntilInventoryMigration() {
+        CompoundTag persisted = item(Item.TOTEM, 2);
+
+        Item decoded = NBTIO.getItemHelper(persisted);
+
+        assertEquals(Item.TOTEM, decoded.getId());
+        assertEquals(2, decoded.getCount());
+        assertEquals(2, persisted.getByte("Count"));
+    }
+
+    @Test
+    void otherMalformedStacksKeepTheDefensiveClamp() {
+        Item decoded = NBTIO.getItemHelper(item(Item.DIAMOND, 65));
+
+        assertEquals(64, decoded.getCount());
+    }
+
+    private static CompoundTag item(int id, int count) {
+        return new CompoundTag().putByte("Count", count).putShort("Damage", 0).putShort("id", id);
+    }
+}


### PR DESCRIPTION
Direct container writers could store two typed totems in one slot because
BaseInventory.setItem does not enforce the item's stack limit. Item.get also
falls back to a plain Item after a constructor failure, giving the canonical
totem id the base limit of 64.

Make the base Item report a limit of one for the totem id, so inventory
transfers and addItem keep the vanilla invariant even for a fallback object.
Do not truncate an already persisted totem overstack during NBT decoding: the
host migration needs the original count to split it across slots without
silently deleting paid or looted items. Other invalid stacks retain the old
clamp.