### PR TITLE
fix(level): suppress synchronous drops from creative placement

### DIFF
--- a/src/main/java/cn/nukkit/level/CreativePlacementDropGuard.java
+++ b/src/main/java/cn/nukkit/level/CreativePlacementDropGuard.java
@@ -1,0 +1,103 @@
+package cn.nukkit.level;
+
+import cn.nukkit.Player;
+import cn.nukkit.block.Block;
+import cn.nukkit.block.BlockShulkerBox;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ * Identifies an automatic break caused synchronously by the block currently being placed.
+ *
+ * <p>The stack is thread-local because a placement can re-enter item use through a plugin. Every
+ * placement pushes a scope, including non-creative ones, so an inner placement can never inherit
+ * an outer creative scope.
+ */
+final class CreativePlacementDropGuard {
+
+    private record Placement(Level level, boolean creative, int blockId, int x, int y, int z) {
+    }
+
+    private static final ThreadLocal<Deque<Placement>> ACTIVE =
+            ThreadLocal.withInitial(ArrayDeque::new);
+
+    private CreativePlacementDropGuard() {
+    }
+
+    static Scope enter(Level level, Player player, Block block) {
+        return enter(
+                level,
+                player != null && player.isCreative(),
+                block.getId(),
+                block.getFloorX(),
+                block.getFloorY(),
+                block.getFloorZ());
+    }
+
+    static boolean suppresses(Level level, Player player, Block block) {
+        return suppresses(
+                level,
+                player == null,
+                block.getId(),
+                block.getFloorX(),
+                block.getFloorY(),
+                block.getFloorZ(),
+                block instanceof BlockShulkerBox);
+    }
+
+    static Scope enter(
+            Level level, boolean creative, int blockId, int x, int y, int z) {
+        Placement placement = new Placement(level, creative, blockId, x, y, z);
+        ACTIVE.get().push(placement);
+        return new Scope(placement);
+    }
+
+    static boolean suppresses(
+            Level level,
+            boolean automaticBreak,
+            int blockId,
+            int x,
+            int y,
+            int z,
+            boolean shulkerBox) {
+        if (!automaticBreak || shulkerBox) {
+            return false;
+        }
+        Placement placement = ACTIVE.get().peek();
+        return placement != null
+                && placement.creative()
+                && placement.level() == level
+                && placement.blockId() == blockId
+                && placement.x() == x
+                && placement.y() == y
+                && placement.z() == z;
+    }
+
+    static final class Scope implements AutoCloseable {
+
+        private final Placement placement;
+        private boolean closed;
+
+        private Scope(Placement placement) {
+            this.placement = placement;
+        }
+
+        @Override
+        public void close() {
+            if (closed) {
+                return;
+            }
+            closed = true;
+            Deque<Placement> placements = ACTIVE.get();
+            if (placements.peek() == placement) {
+                placements.pop();
+            } else {
+                placements.removeFirstOccurrence(placement);
+            }
+            if (placements.isEmpty()) {
+                ACTIVE.remove();
+            }
+        }
+    }
+}

--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -2880,7 +2880,8 @@ public class Level implements ChunkManager, Metadatable {
             item = new ItemBlock(Block.get(BlockID.AIR), 0, 0);
         }
 
-        if (this.gameRules.getBoolean(GameRule.DO_TILE_DROPS)) {
+        if (this.gameRules.getBoolean(GameRule.DO_TILE_DROPS)
+                && !CreativePlacementDropGuard.suppresses(this, player, target)) {
             if (!isSilkTouch && player != null && drops.length != 0) { // For example no xp from redstone if it's mined with stone pickaxe
                 if (player.isSurvival() || player.isAdventure()) {
                     this.dropExpOrb(vector.add(0.5, 0.5, 0.5), dropExp);
@@ -3163,7 +3164,12 @@ public class Level implements ChunkManager, Metadatable {
             this.scheduleUpdate(block, 1);
         }
 
-        if (!hand.place(item, block, target, face, fx, fy, fz, player)) {
+        boolean placed;
+        try (CreativePlacementDropGuard.Scope ignored =
+                     CreativePlacementDropGuard.enter(this, player, hand)) {
+            placed = hand.place(item, block, target, face, fx, fy, fz, player);
+        }
+        if (!placed) {
             if (liquidMoved) {
                 this.setBlock(block, 0, block, false, false);
                 this.setBlock(block, 1, Block.get(BlockID.AIR), false, false);

--- a/src/test/java/cn/nukkit/level/CreativePlacementDropGuardTest.java
+++ b/src/test/java/cn/nukkit/level/CreativePlacementDropGuardTest.java
@@ -1,0 +1,98 @@
+package cn.nukkit.level;
+
+import cn.nukkit.block.BlockID;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+class CreativePlacementDropGuardTest {
+
+    private static final int MOSS_CARPET = BlockID.MOSS_CARPET;
+
+    private final Level world = mock(Level.class);
+
+    @Test
+    void suppressesAnyAutomaticDropFromTheCreativeBlockBeingPlaced() {
+        try (CreativePlacementDropGuard.Scope ignored =
+                     CreativePlacementDropGuard.enter(world, true, MOSS_CARPET, 5, 10, 5)) {
+            assertTrue(
+                    CreativePlacementDropGuard.suppresses(
+                            world, true, MOSS_CARPET, 5, 10, 5, false));
+        }
+    }
+
+    @Test
+    void keepsTheSameAutomaticDropFromSurvivalPlacement() {
+        try (CreativePlacementDropGuard.Scope ignored =
+                     CreativePlacementDropGuard.enter(world, false, MOSS_CARPET, 5, 10, 5)) {
+            assertFalse(
+                    CreativePlacementDropGuard.suppresses(
+                            world, true, MOSS_CARPET, 5, 10, 5, false));
+        }
+    }
+
+    @Test
+    void keepsHonestDropsFromAdjacentBlocksAndOtherWorlds() {
+        Level otherWorld = mock(Level.class);
+        try (CreativePlacementDropGuard.Scope ignored =
+                     CreativePlacementDropGuard.enter(world, true, MOSS_CARPET, 5, 10, 5)) {
+            assertFalse(
+                    CreativePlacementDropGuard.suppresses(
+                            world, true, MOSS_CARPET, 6, 10, 5, false));
+            assertFalse(
+                    CreativePlacementDropGuard.suppresses(
+                            world, true, BlockID.TORCH, 5, 10, 5, false));
+            assertFalse(
+                    CreativePlacementDropGuard.suppresses(
+                            otherWorld, true, MOSS_CARPET, 5, 10, 5, false));
+        }
+    }
+
+    @Test
+    void keepsPlayerAuthoredAndShulkerDrops() {
+        try (CreativePlacementDropGuard.Scope ignored =
+                     CreativePlacementDropGuard.enter(world, true, MOSS_CARPET, 5, 10, 5)) {
+            assertFalse(
+                    CreativePlacementDropGuard.suppresses(
+                            world, false, MOSS_CARPET, 5, 10, 5, false));
+            assertFalse(
+                    CreativePlacementDropGuard.suppresses(
+                            world, true, MOSS_CARPET, 5, 10, 5, true));
+        }
+    }
+
+    @Test
+    void innerSurvivalPlacementMasksAnOuterCreativePlacement() {
+        try (CreativePlacementDropGuard.Scope outer =
+                     CreativePlacementDropGuard.enter(world, true, MOSS_CARPET, 5, 10, 5)) {
+            try (CreativePlacementDropGuard.Scope inner =
+                         CreativePlacementDropGuard.enter(
+                                 world, false, MOSS_CARPET, 5, 10, 5)) {
+                assertFalse(
+                        CreativePlacementDropGuard.suppresses(
+                                world, true, MOSS_CARPET, 5, 10, 5, false));
+            }
+            assertTrue(
+                    CreativePlacementDropGuard.suppresses(
+                            world, true, MOSS_CARPET, 5, 10, 5, false));
+        }
+    }
+
+    @Test
+    void closingAfterFailureCannotLeakCreativeOriginIntoTheNextDrop() {
+        try {
+            try (CreativePlacementDropGuard.Scope ignored =
+                         CreativePlacementDropGuard.enter(world, true, MOSS_CARPET, 5, 10, 5)) {
+                throw new IllegalStateException("placement failed");
+            }
+        } catch (IllegalStateException expected) {
+            // The scope must be closed by try-with-resources before the next drop is inspected.
+        }
+
+        assertFalse(
+                CreativePlacementDropGuard.suppresses(
+                        world, true, MOSS_CARPET, 5, 10, 5, false));
+    }
+}


### PR DESCRIPTION
A block can place itself, fail its support check during the nested update, and call useBreakOn before useItemOn returns. Creative mode does not consume the source item, so spawning that automatic drop prints a real item on every click. Moss carpet on a ladder is one deterministic example.

Track the exact world, cell and block id only while Block.place is on the stack. Suppress automatic drops from that same block when the placement started in creative mode. Nested non-creative placement masks an outer scope, player-authored breaks and neighbouring blocks remain untouched, and shulker boxes keep their NBT-bearing drop.

The scope is closed with try-with-resources so a false return or exception cannot leak creative provenance into later drops.