### PR TITLE
feat(level): fire a cancellable event for automatic block drops

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockDoor.java
+++ b/src/main/java/cn/nukkit/block/BlockDoor.java
@@ -232,7 +232,6 @@ public abstract class BlockDoor extends BlockTransparentMeta implements Faceable
                 Block up = this.up();
 
                 if (up instanceof BlockDoor) {
-                    this.getLevel().setBlock(up, Block.get(BlockID.AIR), false);
                     this.getLevel().useBreakOn(this, getToolType() == ItemTool.TYPE_PICKAXE ? Item.get(ItemID.DIAMOND_PICKAXE) : Item.get(Item.WOODEN_PICKAXE)); // Drop iron doors
                 }
 

--- a/src/main/java/cn/nukkit/block/BlockPistonBase.java
+++ b/src/main/java/cn/nukkit/block/BlockPistonBase.java
@@ -219,11 +219,10 @@ public abstract class BlockPistonBase extends BlockSolidMeta implements Faceable
             List<Block> destroyBlocks = calculator.getBlocksToDestroy();
             for (int i = destroyBlocks.size() - 1; i >= 0; --i) {
                 Block block = destroyBlocks.get(i);
-                this.level.useBreakOn(block, null, null, true);
-
                 if (Server.getInstance().dropSpawners && block instanceof BlockMobSpawner){
-                    this.level.dropItem(block.add(0.5, 0.5, 0.5), Item.get(Item.MONSTER_SPAWNER, 0, 1));
+                    this.level.dropItemFromAutomaticBlock(block, Item.get(Item.MONSTER_SPAWNER, 0, 1));
                 }
+                this.level.useBreakOn(block, null, null, true);
             }
 
             attached = newBlocks.stream().map(Vector3::asBlockVector3).collect(Collectors.toList());

--- a/src/main/java/cn/nukkit/event/block/AutomaticBlockDropsEvent.java
+++ b/src/main/java/cn/nukkit/event/block/AutomaticBlockDropsEvent.java
@@ -1,0 +1,65 @@
+package cn.nukkit.event.block;
+
+import cn.nukkit.block.Block;
+import cn.nukkit.event.Cancellable;
+import cn.nukkit.event.HandlerList;
+import cn.nukkit.item.Item;
+
+/**
+ * Called before a block-generated drop without its own player event is created. The terminal
+ * event for a break runs after the block is removed; direct drops produced from inside
+ * {@code Block.onBreak} run immediately
+ * with {@link #isOutermostBreak()} false and an empty changed-block list.
+ * Player-authored breaks already expose their primary batch through {@code BlockBreakEvent}; they
+ * therefore emit an empty terminal batch only to complete secondary-cell bookkeeping, while any
+ * direct secondary drops still use this event normally.
+ *
+ * <p>The source block is kept even though it has already been removed from the level. Plugins can
+ * therefore distinguish real block drops from items thrown at the same coordinates. The whole
+ * drop batch is exposed in one event so plugins can finish source-level bookkeeping exactly once,
+ * including for blocks with no drops or worlds with tile drops disabled. Drops created by a block
+ * entity's break hook are intentionally excluded: records, books and container contents belong to
+ * the player rather than to the removed block.
+ *
+ * <p>{@link #getChangedBlocks()} contains snapshots of every main-layer block synchronously
+ * replaced by this break chain. Nested automatic breaks report their own cells, while the
+ * outermost event reports their union and is identified by {@link #isOutermostBreak()}.
+ */
+public class AutomaticBlockDropsEvent extends BlockEvent implements Cancellable {
+
+    private static final HandlerList handlers = new HandlerList();
+
+    private Item[] drops;
+    private final Block[] changedBlocks;
+    private final boolean outermostBreak;
+
+    public AutomaticBlockDropsEvent(
+            Block block, Item[] drops, Block[] changedBlocks, boolean outermostBreak) {
+        super(block);
+        this.drops = drops;
+        this.changedBlocks = changedBlocks;
+        this.outermostBreak = outermostBreak;
+    }
+
+    public Item[] getDrops() {
+        return drops;
+    }
+
+    public void setDrops(Item[] drops) {
+        this.drops = drops;
+    }
+
+    /** Main-layer blocks replaced while this break and any nested automatic breaks were running. */
+    public Block[] getChangedBlocks() {
+        return changedBlocks;
+    }
+
+    /** Whether this event closes the outermost synchronous chain of automatic breaks. */
+    public boolean isOutermostBreak() {
+        return outermostBreak;
+    }
+
+    public static HandlerList getHandlers() {
+        return handlers;
+    }
+}

--- a/src/main/java/cn/nukkit/level/AutomaticBlockBreakTrace.java
+++ b/src/main/java/cn/nukkit/level/AutomaticBlockBreakTrace.java
@@ -1,0 +1,105 @@
+package cn.nukkit.level;
+
+import cn.nukkit.block.Block;
+import cn.nukkit.block.BlockID;
+import cn.nukkit.utils.Hash;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** Collects every main-layer block replaced by a synchronous automatic break chain. */
+final class AutomaticBlockBreakTrace {
+
+    private final Deque<Scope> scopes = new ArrayDeque<>();
+    private int blockEntityDropDepth;
+
+    boolean isActive() {
+        return !scopes.isEmpty();
+    }
+
+    Scope enter() {
+        Scope scope = new Scope(scopes.isEmpty());
+        scopes.push(scope);
+        return scope;
+    }
+
+    void record(Block previous, Block current) {
+        if (scopes.isEmpty()
+                || previous == null
+                || current == null
+                || previous.layer != 0
+                || previous.getId() == BlockID.AIR
+                || previous.getId() == current.getId()) {
+            return;
+        }
+        long key = Hash.hashBlock(previous.getFloorX(), previous.getFloorY(), previous.getFloorZ());
+        for (Scope scope : scopes) {
+            scope.changed.putIfAbsent(key, previous);
+        }
+    }
+
+    /**
+     * Returns the exact block snapshot responsible for a direct Level.dropItem call made from
+     * Block.onBreak. Block-entity onBreak hooks are excluded because those drops are container
+     * contents, records and books rather than copies of the removed block.
+     */
+    Block directDropSource(Block current) {
+        if (scopes.isEmpty() || blockEntityDropDepth > 0 || current == null) {
+            return null;
+        }
+        if (current.getId() != BlockID.AIR) {
+            return current;
+        }
+        long key = Hash.hashBlock(current.getFloorX(), current.getFloorY(), current.getFloorZ());
+        for (Scope scope : scopes) {
+            Block changed = scope.changed.get(key);
+            if (changed != null) {
+                return changed;
+            }
+        }
+        return null;
+    }
+
+    void enterBlockEntityDrops() {
+        blockEntityDropDepth++;
+    }
+
+    void leaveBlockEntityDrops() {
+        if (blockEntityDropDepth <= 0) {
+            throw new IllegalStateException("Block-entity drop scopes closed out of order");
+        }
+        blockEntityDropDepth--;
+    }
+
+    final class Scope implements AutoCloseable {
+
+        private final boolean outermost;
+        private final Map<Long, Block> changed = new LinkedHashMap<>();
+        private boolean closed;
+
+        private Scope(boolean outermost) {
+            this.outermost = outermost;
+        }
+
+        boolean isOutermost() {
+            return outermost;
+        }
+
+        Block[] changedBlocks() {
+            return changed.values().toArray(Block.EMPTY_ARRAY);
+        }
+
+        @Override
+        public void close() {
+            if (closed) {
+                return;
+            }
+            if (scopes.peek() != this) {
+                throw new IllegalStateException("Automatic block break scopes closed out of order");
+            }
+            scopes.pop();
+            closed = true;
+        }
+    }
+}

--- a/src/main/java/cn/nukkit/level/CreativePlacementDropGuard.java
+++ b/src/main/java/cn/nukkit/level/CreativePlacementDropGuard.java
@@ -1,0 +1,103 @@
+package cn.nukkit.level;
+
+import cn.nukkit.Player;
+import cn.nukkit.block.Block;
+import cn.nukkit.block.BlockShulkerBox;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ * Identifies an automatic break caused synchronously by the block currently being placed.
+ *
+ * <p>The stack is thread-local because a placement can re-enter item use through a plugin. Every
+ * placement pushes a scope, including non-creative ones, so an inner placement can never inherit
+ * an outer creative scope.
+ */
+final class CreativePlacementDropGuard {
+
+    private record Placement(Level level, boolean creative, int blockId, int x, int y, int z) {
+    }
+
+    private static final ThreadLocal<Deque<Placement>> ACTIVE =
+            ThreadLocal.withInitial(ArrayDeque::new);
+
+    private CreativePlacementDropGuard() {
+    }
+
+    static Scope enter(Level level, Player player, Block block) {
+        return enter(
+                level,
+                player != null && player.isCreative(),
+                block.getId(),
+                block.getFloorX(),
+                block.getFloorY(),
+                block.getFloorZ());
+    }
+
+    static boolean suppresses(Level level, Player player, Block block) {
+        return suppresses(
+                level,
+                player == null,
+                block.getId(),
+                block.getFloorX(),
+                block.getFloorY(),
+                block.getFloorZ(),
+                block instanceof BlockShulkerBox);
+    }
+
+    static Scope enter(
+            Level level, boolean creative, int blockId, int x, int y, int z) {
+        Placement placement = new Placement(level, creative, blockId, x, y, z);
+        ACTIVE.get().push(placement);
+        return new Scope(placement);
+    }
+
+    static boolean suppresses(
+            Level level,
+            boolean automaticBreak,
+            int blockId,
+            int x,
+            int y,
+            int z,
+            boolean shulkerBox) {
+        if (!automaticBreak || shulkerBox) {
+            return false;
+        }
+        Placement placement = ACTIVE.get().peek();
+        return placement != null
+                && placement.creative()
+                && placement.level() == level
+                && placement.blockId() == blockId
+                && placement.x() == x
+                && placement.y() == y
+                && placement.z() == z;
+    }
+
+    static final class Scope implements AutoCloseable {
+
+        private final Placement placement;
+        private boolean closed;
+
+        private Scope(Placement placement) {
+            this.placement = placement;
+        }
+
+        @Override
+        public void close() {
+            if (closed) {
+                return;
+            }
+            closed = true;
+            Deque<Placement> placements = ACTIVE.get();
+            if (placements.peek() == placement) {
+                placements.pop();
+            } else {
+                placements.removeFirstOccurrence(placement);
+            }
+            if (placements.isEmpty()) {
+                ACTIVE.remove();
+            }
+        }
+    }
+}

--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -2880,7 +2880,8 @@ public class Level implements ChunkManager, Metadatable {
             item = new ItemBlock(Block.get(BlockID.AIR), 0, 0);
         }
 
-        if (this.gameRules.getBoolean(GameRule.DO_TILE_DROPS)) {
+        if (this.gameRules.getBoolean(GameRule.DO_TILE_DROPS)
+                && !CreativePlacementDropGuard.suppresses(this, player, target)) {
             if (!isSilkTouch && player != null && drops.length != 0) { // For example no xp from redstone if it's mined with stone pickaxe
                 if (player.isSurvival() || player.isAdventure()) {
                     this.dropExpOrb(vector.add(0.5, 0.5, 0.5), dropExp);
@@ -3163,7 +3164,12 @@ public class Level implements ChunkManager, Metadatable {
             this.scheduleUpdate(block, 1);
         }
 
-        if (!hand.place(item, block, target, face, fx, fy, fz, player)) {
+        boolean placed;
+        try (CreativePlacementDropGuard.Scope ignored =
+                     CreativePlacementDropGuard.enter(this, player, hand)) {
+            placed = hand.place(item, block, target, face, fx, fy, fz, player);
+        }
+        if (!placed) {
             if (liquidMoved) {
                 this.setBlock(block, 0, block, false, false);
                 this.setBlock(block, 1, Block.get(BlockID.AIR), false, false);

--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -17,6 +17,7 @@ import cn.nukkit.entity.mob.EntitySnowGolem;
 import cn.nukkit.entity.passive.EntityIronGolem;
 import cn.nukkit.entity.projectile.EntityArrow;
 import cn.nukkit.entity.weather.EntityLightning;
+import cn.nukkit.event.block.AutomaticBlockDropsEvent;
 import cn.nukkit.event.block.BlockBreakEvent;
 import cn.nukkit.event.block.BlockPlaceEvent;
 import cn.nukkit.event.block.BlockUpdateEvent;
@@ -489,6 +490,7 @@ public class Level implements ChunkManager, Metadatable {
     private static final AtomicInteger callbackIdCounter = new AtomicInteger();
     private final Int2ObjectMap<BiConsumer<Block, Block>> callbackBlockSet = new Int2ObjectOpenHashMap<>();
     private final Int2ObjectMap<BiConsumer<Long, DataPacket>> callbackChunkPacketSend = new Int2ObjectOpenHashMap<>();
+    private final AutomaticBlockBreakTrace automaticBlockBreakTrace = new AutomaticBlockBreakTrace();
 
     public Level(Server server, String name, String path, Class<? extends LevelProvider> provider) {
         this.levelId = levelIdCounter++;
@@ -2471,6 +2473,8 @@ public class Level implements ChunkManager, Metadatable {
         blockPrevious.level = this;
         blockPrevious.layer = layer;
 
+        automaticBlockBreakTrace.record(blockPrevious, block);
+
         try {
             for (BiConsumer<Block, Block> callback : this.callbackBlockSet.values()) {
                 callback.accept(blockPrevious, block);
@@ -2677,6 +2681,42 @@ public class Level implements ChunkManager, Metadatable {
     }
 
     public void dropItem(Vector3 source, Item item, Vector3 motion, boolean dropAround, int delay) {
+        Block automaticSource = null;
+        if (automaticBlockBreakTrace.isActive()) {
+            automaticSource =
+                    automaticBlockBreakTrace.directDropSource(
+                            this.getBlock(
+                                    source.getFloorX(),
+                                    source.getFloorY(),
+                                    source.getFloorZ()));
+        }
+        this.dropItem(source, item, motion, dropAround, delay, automaticSource);
+    }
+
+    /** Drops an item explicitly caused by an automatic block removal outside Block.onBreak. */
+    public void dropItemFromAutomaticBlock(Block source, Item item) {
+        this.dropItem(source.add(0.5, 0.5, 0.5), item, null, false, 10, source);
+    }
+
+    private void dropItem(
+            Vector3 source,
+            Item item,
+            Vector3 motion,
+            boolean dropAround,
+            int delay,
+            Block automaticSource) {
+        Item[] drops = new Item[] {item};
+        if (automaticSource != null) {
+            drops = fireAutomaticBlockDrops(
+                    automaticSource, drops, Block.EMPTY_ARRAY, false);
+        }
+        for (Item drop : drops) {
+            this.spawnDroppedItem(source, drop, motion, dropAround, delay);
+        }
+    }
+
+    private void spawnDroppedItem(
+            Vector3 source, Item item, Vector3 motion, boolean dropAround, int delay) {
         if (item.getId() != 0 && item.getCount() > 0) {
             if (motion == null) {
                 if (dropAround) {
@@ -2708,6 +2748,16 @@ public class Level implements ChunkManager, Metadatable {
 
             itemEntity.spawnToAll();
         }
+    }
+
+    private Item[] fireAutomaticBlockDrops(
+            Block source, Item[] drops, Block[] changedBlocks, boolean outermostBreak) {
+        AutomaticBlockDropsEvent event =
+                new AutomaticBlockDropsEvent(source, drops, changedBlocks, outermostBreak);
+        this.server.getPluginManager().callEvent(event);
+        return event.isCancelled() || event.getDrops() == null
+                ? new Item[0]
+                : event.getDrops();
     }
 
     public EntityItem dropAndGetItem(Vector3 source, Item item) {
@@ -2863,21 +2913,49 @@ public class Level implements ChunkManager, Metadatable {
             this.addParticle(new DestroyBlockParticle(target.add(0.5), target), players.values());
         }
 
-        BlockEntity blockEntity = this.getBlockEntity(target);
-        if (blockEntity != null) {
-            blockEntity.onBreak();
-            blockEntity.close();
+        AutomaticBlockBreakTrace.Scope automaticBreak = automaticBlockBreakTrace.enter();
+        try {
+            BlockEntity blockEntity = this.getBlockEntity(target);
+            if (blockEntity != null) {
+                automaticBlockBreakTrace.enterBlockEntityDrops();
+                try {
+                    blockEntity.onBreak();
+                } finally {
+                    automaticBlockBreakTrace.leaveBlockEntityDrops();
+                }
+                blockEntity.close();
 
-            this.updateComparatorOutputLevel(target);
+                this.updateComparatorOutputLevel(target);
+            }
+
+            target.onBreak(item, player);
+        } finally {
+            automaticBreak.close();
         }
-
-        target.onBreak(item, player);
 
         item.useOn(target);
         if (item.isTool() && item.getDamage() >= item.getMaxDurability()) {
             this.addSoundToViewers(target, cn.nukkit.level.Sound.RANDOM_BREAK);
             this.addParticle(new ItemBreakParticle(target, item));
             item = new ItemBlock(Block.get(BlockID.AIR), 0, 0);
+        }
+
+        if (player == null) {
+            drops = fireAutomaticBlockDrops(
+                    target,
+                    drops,
+                    automaticBreak.changedBlocks(),
+                    automaticBreak.isOutermost());
+        } else {
+            // BlockBreakEvent has already filtered the player's primary drop batch. The empty
+            // terminal event only completes durable provenance for every secondary cell changed
+            // by Block.onBreak; direct secondary dropItem calls were filtered while the trace was
+            // active.
+            fireAutomaticBlockDrops(
+                    target,
+                    Item.EMPTY_ARRAY,
+                    automaticBreak.changedBlocks(),
+                    automaticBreak.isOutermost());
         }
 
         if (this.gameRules.getBoolean(GameRule.DO_TILE_DROPS)
@@ -3438,7 +3516,19 @@ public class Level implements ChunkManager, Metadatable {
             return;
         }
 
+        Block previous = automaticBlockBreakTrace.isActive()
+                ? this.getBlock(x, y, z, layer)
+                : null;
         this.getChunk(x >> 4, z >> 4, true).setBlockId(x & 0x0f, y, z & 0x0f, layer, id & Block.ID_MASK);
+        if (previous != null) {
+            Block current = Block.get(id, previous.getDamage());
+            current.x = x;
+            current.y = y;
+            current.z = z;
+            current.level = this;
+            current.layer = layer;
+            automaticBlockBreakTrace.record(previous, current);
+        }
         addBlockChange(x, y, z);
         temporalVector.setComponents(x, y, z);
         for (ChunkLoader loader : this.getChunkLoaders(x >> 4, z >> 4)) {
@@ -3458,9 +3548,22 @@ public class Level implements ChunkManager, Metadatable {
         }
 
         BaseFullChunk chunk = this.getChunk(x >> 4, z >> 4, true);
+        Block previous = automaticBlockBreakTrace.isActive()
+                ? this.getBlock(x, y, z, layer)
+                : null;
         boolean changed = chunk.setBlockAtLayer(x & 0x0f, y, z & 0x0f, layer, id & Block.ID_MASK, data & Block.DATA_MASK);
         if (!changed) {
             return false;
+        }
+
+        if (previous != null) {
+            Block current = Block.get(id, data);
+            current.x = x;
+            current.y = y;
+            current.z = z;
+            current.level = this;
+            current.layer = layer;
+            automaticBlockBreakTrace.record(previous, current);
         }
 
         addBlockChange(x, y, z);

--- a/src/test/java/cn/nukkit/event/block/AutomaticBlockDropsEventTest.java
+++ b/src/test/java/cn/nukkit/event/block/AutomaticBlockDropsEventTest.java
@@ -1,0 +1,38 @@
+package cn.nukkit.event.block;
+
+import cn.nukkit.block.Block;
+import cn.nukkit.item.Item;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+class AutomaticBlockDropsEventTest {
+
+    @Test
+    void exposesTheSourceBlockAndCanReplaceOrCancelTheWholeDropBatch() {
+        Block source = mock(Block.class);
+        Block companion = mock(Block.class);
+        Item first = mock(Item.class);
+        Item replacement = mock(Item.class);
+
+        AutomaticBlockDropsEvent event =
+                new AutomaticBlockDropsEvent(
+                        source, new Item[] {first}, new Block[] {source, companion}, true);
+
+        assertSame(source, event.getBlock());
+        assertArrayEquals(new Item[] {first}, event.getDrops());
+        assertArrayEquals(new Block[] {source, companion}, event.getChangedBlocks());
+        assertTrue(event.isOutermostBreak());
+        assertFalse(event.isCancelled());
+
+        event.setDrops(new Item[] {replacement});
+        event.setCancelled();
+
+        assertArrayEquals(new Item[] {replacement}, event.getDrops());
+        assertTrue(event.isCancelled());
+    }
+}

--- a/src/test/java/cn/nukkit/level/AutomaticBlockBreakTraceTest.java
+++ b/src/test/java/cn/nukkit/level/AutomaticBlockBreakTraceTest.java
@@ -1,0 +1,90 @@
+package cn.nukkit.level;
+
+import cn.nukkit.block.Block;
+import cn.nukkit.block.BlockID;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AutomaticBlockBreakTraceTest {
+
+    @Test
+    void outerScopeKeepsEveryCellChangedByNestedCompoundBreaks() {
+        AutomaticBlockBreakTrace trace = new AutomaticBlockBreakTrace();
+        Block bottom = at(Block.get(BlockID.DOUBLE_PLANT), 4, 70, -2, 0);
+        Block top = at(Block.get(BlockID.DOUBLE_PLANT), 4, 71, -2, 0);
+        Block water = at(Block.get(BlockID.WATER), 4, 70, -2, 0);
+        Block air = at(Block.get(BlockID.AIR), 4, 71, -2, 0);
+
+        try (AutomaticBlockBreakTrace.Scope outer = trace.enter()) {
+            assertTrue(outer.isOutermost());
+            try (AutomaticBlockBreakTrace.Scope nested = trace.enter()) {
+                assertFalse(nested.isOutermost());
+                trace.record(bottom, water);
+                trace.record(top, air);
+                assertArrayEquals(new Block[] {bottom, top}, nested.changedBlocks());
+            }
+            assertArrayEquals(new Block[] {bottom, top}, outer.changedBlocks());
+        }
+    }
+
+    @Test
+    void stateChangesSecondaryLayersAndAirPlacementsAreNotRemovals() {
+        AutomaticBlockBreakTrace trace = new AutomaticBlockBreakTrace();
+        Block doorClosed = at(Block.get(BlockID.WOODEN_DOOR_BLOCK, 0), 1, 2, 3, 0);
+        Block doorOpen = at(Block.get(BlockID.WOODEN_DOOR_BLOCK, 4), 1, 2, 3, 0);
+        Block overlay = at(Block.get(BlockID.STONE), 1, 2, 3, 1);
+        Block air = at(Block.get(BlockID.AIR), 5, 6, 7, 0);
+
+        try (AutomaticBlockBreakTrace.Scope scope = trace.enter()) {
+            trace.record(doorClosed, doorOpen);
+            trace.record(overlay, Block.get(BlockID.AIR));
+            trace.record(air, Block.get(BlockID.STONE));
+            assertArrayEquals(Block.EMPTY_ARRAY, scope.changedBlocks());
+        }
+    }
+
+    @Test
+    void directDropsKeepTheExactSourceAcrossAThreeBlockChainButExcludeContents() {
+        AutomaticBlockBreakTrace trace = new AutomaticBlockBreakTrace();
+        Block first = at(Block.get(BlockID.POINTED_DRIPSTONE), 8, 40, 9, 0);
+        Block second = at(Block.get(BlockID.POINTED_DRIPSTONE), 8, 41, 9, 0);
+        Block third = at(Block.get(BlockID.POINTED_DRIPSTONE), 8, 42, 9, 0);
+
+        assertFalse(trace.isActive());
+        try (AutomaticBlockBreakTrace.Scope ignored = trace.enter()) {
+            assertTrue(trace.isActive());
+            for (Block source : new Block[] {first, second, third}) {
+                assertSame(source, trace.directDropSource(source));
+                Block air = at(
+                        Block.get(BlockID.AIR),
+                        source.getFloorX(),
+                        source.getFloorY(),
+                        source.getFloorZ(),
+                        0);
+                trace.record(source, air);
+                assertSame(source, trace.directDropSource(air));
+            }
+
+            trace.enterBlockEntityDrops();
+            try {
+                assertNull(trace.directDropSource(first));
+            } finally {
+                trace.leaveBlockEntityDrops();
+            }
+        }
+        assertFalse(trace.isActive());
+    }
+
+    private static Block at(Block block, int x, int y, int z, int layer) {
+        block.x = x;
+        block.y = y;
+        block.z = z;
+        block.layer = layer;
+        return block;
+    }
+}

--- a/src/test/java/cn/nukkit/level/CreativePlacementDropGuardTest.java
+++ b/src/test/java/cn/nukkit/level/CreativePlacementDropGuardTest.java
@@ -1,0 +1,98 @@
+package cn.nukkit.level;
+
+import cn.nukkit.block.BlockID;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+class CreativePlacementDropGuardTest {
+
+    private static final int MOSS_CARPET = BlockID.MOSS_CARPET;
+
+    private final Level world = mock(Level.class);
+
+    @Test
+    void suppressesAnyAutomaticDropFromTheCreativeBlockBeingPlaced() {
+        try (CreativePlacementDropGuard.Scope ignored =
+                     CreativePlacementDropGuard.enter(world, true, MOSS_CARPET, 5, 10, 5)) {
+            assertTrue(
+                    CreativePlacementDropGuard.suppresses(
+                            world, true, MOSS_CARPET, 5, 10, 5, false));
+        }
+    }
+
+    @Test
+    void keepsTheSameAutomaticDropFromSurvivalPlacement() {
+        try (CreativePlacementDropGuard.Scope ignored =
+                     CreativePlacementDropGuard.enter(world, false, MOSS_CARPET, 5, 10, 5)) {
+            assertFalse(
+                    CreativePlacementDropGuard.suppresses(
+                            world, true, MOSS_CARPET, 5, 10, 5, false));
+        }
+    }
+
+    @Test
+    void keepsHonestDropsFromAdjacentBlocksAndOtherWorlds() {
+        Level otherWorld = mock(Level.class);
+        try (CreativePlacementDropGuard.Scope ignored =
+                     CreativePlacementDropGuard.enter(world, true, MOSS_CARPET, 5, 10, 5)) {
+            assertFalse(
+                    CreativePlacementDropGuard.suppresses(
+                            world, true, MOSS_CARPET, 6, 10, 5, false));
+            assertFalse(
+                    CreativePlacementDropGuard.suppresses(
+                            world, true, BlockID.TORCH, 5, 10, 5, false));
+            assertFalse(
+                    CreativePlacementDropGuard.suppresses(
+                            otherWorld, true, MOSS_CARPET, 5, 10, 5, false));
+        }
+    }
+
+    @Test
+    void keepsPlayerAuthoredAndShulkerDrops() {
+        try (CreativePlacementDropGuard.Scope ignored =
+                     CreativePlacementDropGuard.enter(world, true, MOSS_CARPET, 5, 10, 5)) {
+            assertFalse(
+                    CreativePlacementDropGuard.suppresses(
+                            world, false, MOSS_CARPET, 5, 10, 5, false));
+            assertFalse(
+                    CreativePlacementDropGuard.suppresses(
+                            world, true, MOSS_CARPET, 5, 10, 5, true));
+        }
+    }
+
+    @Test
+    void innerSurvivalPlacementMasksAnOuterCreativePlacement() {
+        try (CreativePlacementDropGuard.Scope outer =
+                     CreativePlacementDropGuard.enter(world, true, MOSS_CARPET, 5, 10, 5)) {
+            try (CreativePlacementDropGuard.Scope inner =
+                         CreativePlacementDropGuard.enter(
+                                 world, false, MOSS_CARPET, 5, 10, 5)) {
+                assertFalse(
+                        CreativePlacementDropGuard.suppresses(
+                                world, true, MOSS_CARPET, 5, 10, 5, false));
+            }
+            assertTrue(
+                    CreativePlacementDropGuard.suppresses(
+                            world, true, MOSS_CARPET, 5, 10, 5, false));
+        }
+    }
+
+    @Test
+    void closingAfterFailureCannotLeakCreativeOriginIntoTheNextDrop() {
+        try {
+            try (CreativePlacementDropGuard.Scope ignored =
+                         CreativePlacementDropGuard.enter(world, true, MOSS_CARPET, 5, 10, 5)) {
+                throw new IllegalStateException("placement failed");
+            }
+        } catch (IllegalStateException expected) {
+            // The scope must be closed by try-with-resources before the next drop is inspected.
+        }
+
+        assertFalse(
+                CreativePlacementDropGuard.suppresses(
+                        world, true, MOSS_CARPET, 5, 10, 5, false));
+    }
+}


### PR DESCRIPTION
Delayed block physics can remove compound blocks long after placement has returned. Expose the exact source, whole drop batch and every main-layer cell synchronously replaced by the break chain so plugins can apply provenance rules and finish bookkeeping once at the outermost event. Direct drops from Block.onBreak are filtered at their exact source for both world- and player-started chains, while the player primary batch and block-entity contents remain on their existing paths.