### PR TITLE
fix(entity): bound client absorption capacity on 1.26

### DIFF
--- a/src/main/java/cn/nukkit/entity/Entity.java
+++ b/src/main/java/cn/nukkit/entity/Entity.java
@@ -2485,10 +2485,21 @@ public abstract class Entity extends Location implements Metadatable {
         return absorption;
     }
 
+    static Attribute clientAbsorptionAttribute(float absorption, int protocol) {
+        Attribute attribute = Attribute.getAttribute(Attribute.ABSORPTION);
+        if (protocol >= ProtocolInfo.v1_26_0) {
+            // Bedrock 1.26 builds one HUD heart slot per advertised capacity point. Sending the
+            // server-side Float.MAX_VALUE range therefore freezes mobile clients. Preserve
+            // custom values above vanilla's 16 absorption points instead of clipping them.
+            attribute.setMaxValue(Math.max(16.0f, absorption));
+        }
+        return attribute.setValue(absorption);
+    }
+
     public void setAbsorption(float absorption) {
         if (absorption != this.absorption || (this instanceof Player player && player.protocol >= ProtocolInfo.v1_21_60)) {
             this.absorption = absorption;
-            if (this instanceof Player player) player.setAttribute(Attribute.getAttribute(Attribute.ABSORPTION).setValue(absorption));
+            if (this instanceof Player player) player.setAttribute(clientAbsorptionAttribute(absorption, player.protocol));
         }
     }
 

--- a/src/test/java/cn/nukkit/entity/EntityAbsorptionAttributeTest.java
+++ b/src/test/java/cn/nukkit/entity/EntityAbsorptionAttributeTest.java
@@ -1,0 +1,43 @@
+package cn.nukkit.entity;
+
+import cn.nukkit.MockServer;
+import cn.nukkit.network.protocol.ProtocolInfo;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class EntityAbsorptionAttributeTest {
+
+    @BeforeAll
+    static void init() {
+        MockServer.init();
+        Attribute.init();
+    }
+
+    @Test
+    void sendsFiniteHudCapacityToVersion126Clients() {
+        Attribute full = Entity.clientAbsorptionAttribute(16.0f, ProtocolInfo.v1_26_0);
+        Attribute damaged = Entity.clientAbsorptionAttribute(7.0f, ProtocolInfo.v1_26_0);
+
+        assertEquals(16.0f, full.getValue());
+        assertEquals(16.0f, full.getMaxValue());
+        assertEquals(7.0f, damaged.getValue());
+        assertEquals(16.0f, damaged.getMaxValue());
+    }
+
+    @Test
+    void keepsLargeCustomAbsorptionRepresentable() {
+        Attribute custom = Entity.clientAbsorptionAttribute(24.0f, ProtocolInfo.v1_26_0);
+
+        assertEquals(24.0f, custom.getValue());
+        assertEquals(24.0f, custom.getMaxValue());
+    }
+
+    @Test
+    void leavesOlderClientPacketsUnchanged() {
+        Attribute old = Entity.clientAbsorptionAttribute(16.0f, ProtocolInfo.v1_21_60);
+
+        assertEquals(Float.MAX_VALUE, old.getMaxValue());
+    }
+}


### PR DESCRIPTION
Bedrock 1.26 renders the advertised absorption maximum as HUD capacity.
Nukkit sent Float.MAX_VALUE, so one enchanted golden apple created thousands
of empty hearts and made Android clients stall even though the real absorption
value remained 16.

Keep the server-side attribute range unchanged for plugins and older clients.
Only the per-player packet for 1.26+ gets a finite capacity, never smaller
than vanilla enchanted-apple absorption or the actual custom value.