### PR TITLE
block: make every sweet berry bush stage break instantly

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockSweetBerryBush.java
+++ b/src/main/java/cn/nukkit/block/BlockSweetBerryBush.java
@@ -64,7 +64,7 @@ public class BlockSweetBerryBush extends BlockFlowable {
 
     @Override
     public double getHardness() {
-        return this.getDamage() == 0? 0 : 0.25;
+        return 0;
     }
 
     @Override

--- a/src/test/java/cn/nukkit/block/BlockSweetBerryBushBreakTimeTest.java
+++ b/src/test/java/cn/nukkit/block/BlockSweetBerryBushBreakTimeTest.java
@@ -1,0 +1,20 @@
+package cn.nukkit.block;
+
+import cn.nukkit.item.Item;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class BlockSweetBerryBushBreakTimeTest {
+
+    @Test
+    void everyGrowthStageBreaksInstantly() {
+        for (int growthStage = 0; growthStage <= 3; growthStage++) {
+            BlockSweetBerryBush bush = new BlockSweetBerryBush(growthStage);
+
+            assertEquals(0d, bush.getHardness(), "hardness at growth stage " + growthStage);
+            assertEquals(0d, bush.calculateBreakTime(Item.AIR_ITEM),
+                    "break time at growth stage " + growthStage);
+        }
+    }
+}


### PR DESCRIPTION
Bedrock treats sweet berry bushes as instant-break at every growth stage.
The previous mature-stage hardness calculated 0.375 seconds and made the
core fast-break check reject normal client input.

Keep hardness at zero for all four stages and cover both the property and
the resulting break time.