### PR TITLE
fix(entity): keep pathfinding body yaw while tracking a target

### DIFF
--- a/src/main/java/cn/nukkit/entity/EntityLiving.java
+++ b/src/main/java/cn/nukkit/entity/EntityLiving.java
@@ -592,6 +592,17 @@ public abstract class EntityLiving extends Entity implements EntityDamageable {
     }
 
     public void lookAt(Vector3 target) {
+        this.lookAt(target, true);
+    }
+
+    /**
+     * Turn only the entity's head towards a target while preserving the body's route-facing yaw.
+     */
+    protected void lookHeadAt(Vector3 target) {
+        this.lookAt(target, false);
+    }
+
+    private void lookAt(Vector3 target, boolean turnBody) {
         double dx = this.x - target.x;
         double dy = this.y - target.y;
         double dz = this.z - target.z;
@@ -601,7 +612,11 @@ public abstract class EntityLiving extends Entity implements EntityDamageable {
         if (dz > 0.0d) {
             yaw = -yaw + 180.0d;
         }
-        this.setRotation(yaw, pitch);
+        if (turnBody) {
+            this.setRotation(yaw, pitch);
+        } else {
+            this.setRotation(this.yaw, pitch, yaw);
+        }
     }
 
     public EntityHuman getNearbyHuman() {

--- a/src/main/java/cn/nukkit/entity/EntityWalking.java
+++ b/src/main/java/cn/nukkit/entity/EntityWalking.java
@@ -143,6 +143,16 @@ public abstract class EntityWalking extends BaseEntity {
         return false;
     }
 
+    /**
+     * Keep the body aligned with the pathfinder while the head tracks a live target.
+     */
+    protected void turnBodyTowardsAndLookAt(double bodyYaw, Vector3 headTarget) {
+        this.turnBodyTowards(bodyYaw);
+        if (headTarget != null) {
+            this.lookHeadAt(headTarget);
+        }
+    }
+
     @Override
     public Vector3 updateMove(int tickDiff) {
         if (!this.isInTickingRange()) {
@@ -181,6 +191,7 @@ public abstract class EntityWalking extends BaseEntity {
             }
 
             if (this.getServer().getMobAiEnabled()) {
+                Vector3 headTarget = null;
                 if (this.followTarget != null && !this.followTarget.closed && this.followTarget.isAlive() && this.target != null && this.followTarget.canBeFollowed()) {
                     double x = this.target.x - this.x;
                     double z = this.target.z - this.z;
@@ -209,7 +220,7 @@ public abstract class EntityWalking extends BaseEntity {
                         }
                     }
                     if (this.noRotateTicks <= 0 && (this.passengers.isEmpty() || this instanceof EntityLlama || this instanceof EntityPig) && this.stayTime <= 0 && diff != 0) {
-                        this.lookAt(this.followTarget);
+                        headTarget = this.followTarget;
                     }
                 }
 
@@ -248,8 +259,12 @@ public abstract class EntityWalking extends BaseEntity {
                         }
                     }
                     if (this.noRotateTicks <= 0 && !distance && (this.passengers.isEmpty() || this instanceof EntityLlama || this instanceof EntityPig) && this.stayTime <= 0 && diff > 0.001) {
-                        this.turnBodyTowards(FastMath.toDegrees(-FastMath.atan2(x / diff, z / diff)));
+                        this.turnBodyTowardsAndLookAt(FastMath.toDegrees(-FastMath.atan2(x / diff, z / diff)), headTarget);
+                        headTarget = null;
                     }
+                }
+                if (headTarget != null) {
+                    this.lookHeadAt(headTarget);
                 }
             }
 

--- a/src/test/java/cn/nukkit/entity/EntityWalkingOrientationTest.java
+++ b/src/test/java/cn/nukkit/entity/EntityWalkingOrientationTest.java
@@ -1,0 +1,36 @@
+package cn.nukkit.entity;
+
+import cn.nukkit.math.Vector3;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class EntityWalkingOrientationTest {
+
+    @Test
+    void routeFacingBodySurvivesTrackingAPlayerOffTheRoute() {
+        EntityWalking entity = Mockito.mock(EntityWalking.class, Mockito.CALLS_REAL_METHODS);
+        entity.x = 0;
+        entity.y = 0;
+        entity.z = 0;
+        entity.setRotation(0, 0, 0);
+
+        entity.turnBodyTowardsAndLookAt(90, new Vector3(10, 0, 0));
+
+        assertEquals(30, entity.getYaw(), "body follows the route with the normal turn limit");
+        assertEquals(-90, entity.getHeadYaw(), "head keeps tracking the player");
+        assertEquals(0, entity.getPitch());
+    }
+
+    @Test
+    void routeFacingWithoutALiveTargetTurnsBodyAndHeadTogether() {
+        EntityWalking entity = Mockito.mock(EntityWalking.class, Mockito.CALLS_REAL_METHODS);
+        entity.setRotation(0, 0, 0);
+
+        entity.turnBodyTowardsAndLookAt(90, null);
+
+        assertEquals(30, entity.getYaw());
+        assertEquals(30, entity.getHeadYaw());
+    }
+}


### PR DESCRIPTION
Walking mobs used lookAt(followTarget) before turning towards the current route node. That reset body yaw to the player every tick, so the 30-degree smoothing limit could never reach a lateral detour and obstacle checks inspected the wrong facing.

Track the live target with head yaw only after the body turns towards the route. Keep the old body-and-head behavior for wandering without a live target, and cover both orientation paths.