### PR TITLE
block: match Bedrock haste break speed

### DIFF
--- a/src/main/java/cn/nukkit/block/Block.java
+++ b/src/main/java/cn/nukkit/block/Block.java
@@ -942,10 +942,17 @@ public abstract class Block extends Position implements Metadatable, Cloneable, 
             }
         }
 
-        if (hasConduitPower) hasteEffectLevel = Integer.max(hasteEffectLevel, 2);
+        int effectiveHasteEffectLevel = hasConduitPower
+                ? Integer.max(hasteEffectLevel, 2)
+                : hasteEffectLevel;
+
+        if (effectiveHasteEffectLevel > 0) {
+            speedMultiplier *= 1 + (0.2 * effectiveHasteEffectLevel);
+        }
 
         if (hasteEffectLevel > 0) {
-            speedMultiplier *= 1 + (0.2 * hasteEffectLevel);
+            // Bedrock applies an additional exponential bonus to the actual haste effect.
+            speedMultiplier *= Math.pow(1.2, hasteEffectLevel);
         }
 
         if (miningFatigueLevel > 0) {

--- a/src/test/java/cn/nukkit/block/BlockShulkerBoxBreakTimeTest.java
+++ b/src/test/java/cn/nukkit/block/BlockShulkerBoxBreakTimeTest.java
@@ -1,0 +1,55 @@
+package cn.nukkit.block;
+
+import cn.nukkit.Player;
+import cn.nukkit.inventory.PlayerInventory;
+import cn.nukkit.item.Item;
+import cn.nukkit.potion.Effect;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class BlockShulkerBoxBreakTimeTest {
+
+    @Test
+    void hasteUsesBedrockBreakSpeed() {
+        Player player = mockPlayerWithEmptyHelmet();
+        Effect haste = Mockito.mock(Effect.class);
+        Mockito.when(player.getEffect(Effect.HASTE)).thenReturn(haste);
+        Mockito.when(haste.getAmplifier()).thenReturn(3);
+
+        Block shulkerBox = new BlockUndyedShulkerBox();
+        int hasteLevel = 4;
+        double expectedSeconds = 3d
+                / ((1d + 0.2d * hasteLevel) * Math.pow(1.2d, hasteLevel));
+
+        assertEquals(3d,
+                shulkerBox.calculateBreakTimeNotInAir(Item.AIR_ITEM, null),
+                1e-12,
+                "base hand break time");
+        assertEquals(expectedSeconds,
+                shulkerBox.calculateBreakTimeNotInAir(Item.AIR_ITEM, player),
+                1e-12,
+                "haste amplifier 3 must match Bedrock client progress");
+    }
+
+    @Test
+    void conduitPowerKeepsExistingBreakSpeed() {
+        Player player = mockPlayerWithEmptyHelmet();
+        Mockito.when(player.hasEffect(Effect.CONDUIT_POWER)).thenReturn(true);
+        Block shulkerBox = new BlockUndyedShulkerBox();
+
+        assertEquals(3d / 1.4d,
+                shulkerBox.calculateBreakTimeNotInAir(Item.AIR_ITEM, player),
+                1e-12,
+                "conduit power must keep its existing linear multiplier");
+    }
+
+    private static Player mockPlayerWithEmptyHelmet() {
+        Player player = Mockito.mock(Player.class);
+        PlayerInventory inventory = Mockito.mock(PlayerInventory.class);
+        Mockito.when(player.getInventory()).thenReturn(inventory);
+        Mockito.when(inventory.getHelmet()).thenReturn(Item.AIR_ITEM);
+        return player;
+    }
+}


### PR DESCRIPTION
Bedrock applies an additional exponential bonus for every haste level.
Without it, the server expects high-level haste breaks to take roughly
twice as long as the client and rejects legitimate input as fast-break.

Use the same multiplier as the live Bedrock-compatible network and cover
the reported undyed shulker box case at haste amplifier 3.