### PR TITLE
fix(block): match enchanting table and cauldron collisions

### DIFF
--- a/src/main/java/cn/nukkit/block/Block.java
+++ b/src/main/java/cn/nukkit/block/Block.java
@@ -1150,6 +1150,15 @@ public abstract class Block extends Position implements Metadatable, Cloneable, 
         return collidesWithBB(bb, false);
     }
 
+    public void addCollisionBoxesToList(AxisAlignedBB bb, List<AxisAlignedBB> collidingBoxes) {
+        if (this.collidesWithBB(bb)) {
+            AxisAlignedBB boundingBox = this.getBoundingBox();
+            if (boundingBox != null) {
+                collidingBoxes.add(boundingBox);
+            }
+        }
+    }
+
     public boolean collidesWithBB(AxisAlignedBB bb, boolean collisionBB) {
         AxisAlignedBB bb1 = collisionBB ? this.getCollisionBoundingBox() : this.getBoundingBox();
         return bb1 != null && bb.intersectsWith(bb1);

--- a/src/main/java/cn/nukkit/block/BlockCauldron.java
+++ b/src/main/java/cn/nukkit/block/BlockCauldron.java
@@ -12,14 +12,17 @@ import cn.nukkit.level.biome.Biome;
 import cn.nukkit.level.particle.SmokeParticle;
 import cn.nukkit.level.vibration.VibrationEvent;
 import cn.nukkit.level.vibration.VibrationType;
+import cn.nukkit.math.AxisAlignedBB;
 import cn.nukkit.math.BlockFace;
 import cn.nukkit.math.MathHelper;
+import cn.nukkit.math.SimpleAxisAlignedBB;
 import cn.nukkit.nbt.tag.CompoundTag;
 import cn.nukkit.nbt.tag.Tag;
 import cn.nukkit.network.protocol.LevelSoundEventPacket;
 import cn.nukkit.utils.BlockColor;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -83,6 +86,46 @@ public class BlockCauldron extends BlockSolidMeta implements BlockEntityHolder<B
     @Override
     public boolean canBeActivated() {
         return true;
+    }
+
+    private AxisAlignedBB[] recalculateCollisionBoxes() {
+        double rim = 2d / 16d;
+        double bottom = 5d / 16d;
+        return new AxisAlignedBB[]{
+                new SimpleAxisAlignedBB(x, y, z, x + 1d, y + bottom, z + 1d),
+                new SimpleAxisAlignedBB(x, y, z, x + rim, y + 1d, z + 1d),
+                new SimpleAxisAlignedBB(x + 1d - rim, y, z, x + 1d, y + 1d, z + 1d),
+                new SimpleAxisAlignedBB(x, y, z, x + 1d, y + 1d, z + rim),
+                new SimpleAxisAlignedBB(x, y, z + 1d - rim, x + 1d, y + 1d, z + 1d)
+        };
+    }
+
+    private boolean collidesWithCauldron(AxisAlignedBB bb) {
+        for (AxisAlignedBB collisionBox : recalculateCollisionBoxes()) {
+            if (bb.intersectsWith(collisionBox)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean collidesWithBB(AxisAlignedBB bb) {
+        return collidesWithCauldron(bb);
+    }
+
+    @Override
+    public boolean collidesWithBB(AxisAlignedBB bb, boolean collisionBB) {
+        return collisionBB ? collidesWithCauldron(bb) : super.collidesWithBB(bb, false);
+    }
+
+    @Override
+    public void addCollisionBoxesToList(AxisAlignedBB bb, List<AxisAlignedBB> collidingBoxes) {
+        for (AxisAlignedBB collisionBox : recalculateCollisionBoxes()) {
+            if (bb.intersectsWith(collisionBox)) {
+                collidingBoxes.add(collisionBox);
+            }
+        }
     }
 
     public boolean isFull() {

--- a/src/main/java/cn/nukkit/block/BlockEnchantingTable.java
+++ b/src/main/java/cn/nukkit/block/BlockEnchantingTable.java
@@ -6,7 +6,9 @@ import cn.nukkit.blockentity.BlockEntityEnchantTable;
 import cn.nukkit.inventory.EnchantInventory;
 import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemTool;
+import cn.nukkit.math.AxisAlignedBB;
 import cn.nukkit.math.BlockFace;
+import cn.nukkit.math.SimpleAxisAlignedBB;
 import cn.nukkit.nbt.tag.CompoundTag;
 import cn.nukkit.nbt.tag.ListTag;
 import cn.nukkit.nbt.tag.StringTag;
@@ -67,6 +69,11 @@ public class BlockEnchantingTable extends BlockTransparent implements BlockEntit
     @Override
     public int getLightLevel() {
         return 7;
+    }
+
+    @Override
+    protected AxisAlignedBB recalculateBoundingBox() {
+        return new SimpleAxisAlignedBB(x, y, z, x + 1d, y + 12d / 16d, z + 1d);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/utils/CollisionHelper.java
+++ b/src/main/java/cn/nukkit/utils/CollisionHelper.java
@@ -604,11 +604,8 @@ public record CollisionHelper(Entity entity) {
                     if (block instanceof BlockBarrier && entity.canPassThroughBarrier()) {
                         continue;
                     }
-                    if (!block.canPassThrough() && block.collidesWithBB(boundingBox)) {
-                        AxisAlignedBB blockBB = block.getBoundingBox();
-                        if (blockBB != null) {
-                            collides.add(blockBB);
-                        }
+                    if (!block.canPassThrough()) {
+                        block.addCollisionBoxesToList(boundingBox, collides);
                     }
                 }
             }

--- a/src/test/java/cn/nukkit/block/BlockCollisionShapeTest.java
+++ b/src/test/java/cn/nukkit/block/BlockCollisionShapeTest.java
@@ -1,0 +1,62 @@
+package cn.nukkit.block;
+
+import cn.nukkit.math.AxisAlignedBB;
+import cn.nukkit.math.SimpleAxisAlignedBB;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BlockCollisionShapeTest {
+
+    @BeforeAll
+    static void initializeBlocks() {
+        Block.init();
+    }
+
+    @Test
+    void enchantingTableIsTwelvePixelsHigh() {
+        Block table = Block.get(BlockID.ENCHANTING_TABLE);
+        table.setComponents(10d, 20d, 30d);
+
+        assertEquals(20.75d, table.getCollisionBoundingBox().getMaxY(), 1e-12);
+    }
+
+    @Test
+    void cauldronHasAFreeCavityAndSolidBottomAndRim() {
+        Block cauldron = Block.get(BlockID.CAULDRON_BLOCK, 6);
+        cauldron.setComponents(0d, 0d, 0d);
+        AxisAlignedBB cavity = new SimpleAxisAlignedBB(0.2d, 5d / 16d + 0.001d, 0.2d,
+                0.8d, 0.95d, 0.8d);
+        AxisAlignedBB bottom = new SimpleAxisAlignedBB(0.2d, 0.1d, 0.2d, 0.8d, 0.2d, 0.8d);
+        AxisAlignedBB rim = new SimpleAxisAlignedBB(0.01d, 0.7d, 0.2d, 0.1d, 0.9d, 0.8d);
+
+        assertFalse(cauldron.collidesWithBB(cavity, true));
+        assertTrue(cauldron.collidesWithBB(bottom, true));
+        assertTrue(cauldron.collidesWithBB(rim, true));
+
+        List<AxisAlignedBB> boxes = new ArrayList<>();
+        cauldron.addCollisionBoxesToList(cavity, boxes);
+        assertTrue(boxes.isEmpty());
+        cauldron.addCollisionBoxesToList(bottom, boxes);
+        assertEquals(1, boxes.size());
+    }
+
+    @Test
+    void defaultCollisionBoxesPreserveVirtualShapePredicate() {
+        Block stair = Block.get(BlockID.WOOD_STAIRS, 0);
+        stair.setComponents(0d, 0d, 0d);
+        AxisAlignedBB upperStep =
+                new SimpleAxisAlignedBB(0.75d, 0.75d, 0.25d, 0.9d, 0.9d, 0.4d);
+
+        assertFalse(stair.getCollisionBoundingBox().intersectsWith(upperStep));
+        List<AxisAlignedBB> boxes = new ArrayList<>();
+        stair.addCollisionBoxesToList(upperStep, boxes);
+        assertEquals(1, boxes.size());
+    }
+}


### PR DESCRIPTION
The client treats the enchanting table as twelve pixels high and the
cauldron as a hollow frame with a five-pixel bottom. The server used a
full cube for both, so movement onto either block was corrected back and
forth against geometry the client could not see.

Expose composite collision boxes to the movement helper, match both
shapes to Bedrock, and cover the solid and hollow parts with regressions.