### PR TITLE
fix(block): give crying obsidian the Bedrock hardness 35

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockCryingObsidian.java
+++ b/src/main/java/cn/nukkit/block/BlockCryingObsidian.java
@@ -20,10 +20,6 @@ public class BlockCryingObsidian extends BlockSolid {
 
     @Override
     public double getHardness() {
-        // Bedrock parity: crying obsidian has hardness 35 on Bedrock (50 in Java), the same as
-        // obsidian. With 50 the server expected 9.4 s for a plain diamond pickaxe while every
-        // client finished in 6.6 s, so each break was refused as too fast and the block
-        // reappeared. Confirmed against PocketMine-MP VanillaBlocksInputs (35.0 /* 50 in Java */).
         return 35;
     }
 

--- a/src/main/java/cn/nukkit/block/BlockCryingObsidian.java
+++ b/src/main/java/cn/nukkit/block/BlockCryingObsidian.java
@@ -20,7 +20,11 @@ public class BlockCryingObsidian extends BlockSolid {
 
     @Override
     public double getHardness() {
-        return 50;
+        // Bedrock parity: crying obsidian has hardness 35 on Bedrock (50 in Java), the same as
+        // obsidian. With 50 the server expected 9.4 s for a plain diamond pickaxe while every
+        // client finished in 6.6 s, so each break was refused as too fast and the block
+        // reappeared. Confirmed against PocketMine-MP VanillaBlocksInputs (35.0 /* 50 in Java */).
+        return 35;
     }
 
     @Override


### PR DESCRIPTION
BlockCryingObsidian returns hardness 50, copied from Java Edition. Bedrock uses 35 — the same value BlockObsidian already returns.

Because of that a plain diamond pickaxe finishes the block in ~6.6 s while the server expects ~9.4 s, so every break is classified as a fast break and cancelled: the block reappears and nothing drops. Reproduced on every protocol from 786 to 2168, so it is the block data and not a client version issue.

Value confirmed against PocketMine-MP `VanillaBlocksInputs` (`35.0 /* 50 in Java */`).