### PR TITLE
fix(block): keep the end portal frame 13/16 tall once the eye is in

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockEndPortalFrame.java
+++ b/src/main/java/cn/nukkit/block/BlockEndPortalFrame.java
@@ -63,12 +63,17 @@ public class BlockEndPortalFrame extends BlockTransparentMeta implements Faceabl
 
     @Override
     protected AxisAlignedBB recalculateBoundingBox() {
+        // Bedrock parity: the frame is 13/16 tall with or without the eye. Java raises the box to
+        // a full block once the eye is in; Bedrock clients keep standing at 0.8125, so the server
+        // saw every creative player 0.1875 deep inside the block and pushed them back out on each
+        // move. Confirmed against PocketMine-MP EndPortalFrame
+        // (AxisAlignedBB::one()->trim(Facing::UP, 3 / 16), no eye branch).
         return new SimpleAxisAlignedBB(
                 this.x,
                 this.y,
                 this.z,
                 this.x + 1,
-                this.y + ((this.getDamage() & 0x04) > 0 ? 1 : 0.8125),
+                this.y + 0.8125,
                 this.z + 1
         );
     }


### PR DESCRIPTION
BlockEndPortalFrame raises its collision box to a full block as soon as the eye bit is set. That is Java Edition behaviour: on Bedrock the frame stays 13/16 tall with or without the eye.

The client therefore keeps standing at y + 0.8125 while the server believes the floor is at y + 1. Survival players do not notice, but a creative or flying player is corrected on every move and gets thrown back and forth as long as he stands on a filled frame.

Value confirmed against PocketMine-MP `EndPortalFrame`, which returns `AxisAlignedBB::one()->trim(Facing::UP, 3 / 16)` with no eye branch at all.