### PR TITLE
fix(block): match Bedrock collision boxes for nine more blocks

### DIFF
--- a/src/main/java/cn/nukkit/block/Block.java
+++ b/src/main/java/cn/nukkit/block/Block.java
@@ -1157,6 +1157,15 @@ public abstract class Block extends Position implements Metadatable, Cloneable, 
         return collidesWithBB(bb, false);
     }
 
+    public void addCollisionBoxesToList(AxisAlignedBB bb, List<AxisAlignedBB> collidingBoxes) {
+        if (this.collidesWithBB(bb)) {
+            AxisAlignedBB boundingBox = this.getBoundingBox();
+            if (boundingBox != null) {
+                collidingBoxes.add(boundingBox);
+            }
+        }
+    }
+
     public boolean collidesWithBB(AxisAlignedBB bb, boolean collisionBB) {
         AxisAlignedBB bb1 = collisionBB ? this.getCollisionBoundingBox() : this.getBoundingBox();
         return bb1 != null && bb.intersectsWith(bb1);

--- a/src/main/java/cn/nukkit/block/BlockCauldron.java
+++ b/src/main/java/cn/nukkit/block/BlockCauldron.java
@@ -12,14 +12,17 @@ import cn.nukkit.level.biome.Biome;
 import cn.nukkit.level.particle.SmokeParticle;
 import cn.nukkit.level.vibration.VibrationEvent;
 import cn.nukkit.level.vibration.VibrationType;
+import cn.nukkit.math.AxisAlignedBB;
 import cn.nukkit.math.BlockFace;
 import cn.nukkit.math.MathHelper;
+import cn.nukkit.math.SimpleAxisAlignedBB;
 import cn.nukkit.nbt.tag.CompoundTag;
 import cn.nukkit.nbt.tag.Tag;
 import cn.nukkit.network.protocol.LevelSoundEventPacket;
 import cn.nukkit.utils.BlockColor;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -83,6 +86,46 @@ public class BlockCauldron extends BlockSolidMeta implements BlockEntityHolder<B
     @Override
     public boolean canBeActivated() {
         return true;
+    }
+
+    private AxisAlignedBB[] recalculateCollisionBoxes() {
+        double rim = 2d / 16d;
+        double bottom = 5d / 16d;
+        return new AxisAlignedBB[]{
+                new SimpleAxisAlignedBB(x, y, z, x + 1d, y + bottom, z + 1d),
+                new SimpleAxisAlignedBB(x, y, z, x + rim, y + 1d, z + 1d),
+                new SimpleAxisAlignedBB(x + 1d - rim, y, z, x + 1d, y + 1d, z + 1d),
+                new SimpleAxisAlignedBB(x, y, z, x + 1d, y + 1d, z + rim),
+                new SimpleAxisAlignedBB(x, y, z + 1d - rim, x + 1d, y + 1d, z + 1d)
+        };
+    }
+
+    private boolean collidesWithCauldron(AxisAlignedBB bb) {
+        for (AxisAlignedBB collisionBox : recalculateCollisionBoxes()) {
+            if (bb.intersectsWith(collisionBox)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean collidesWithBB(AxisAlignedBB bb) {
+        return collidesWithCauldron(bb);
+    }
+
+    @Override
+    public boolean collidesWithBB(AxisAlignedBB bb, boolean collisionBB) {
+        return collisionBB ? collidesWithCauldron(bb) : super.collidesWithBB(bb, false);
+    }
+
+    @Override
+    public void addCollisionBoxesToList(AxisAlignedBB bb, List<AxisAlignedBB> collidingBoxes) {
+        for (AxisAlignedBB collisionBox : recalculateCollisionBoxes()) {
+            if (bb.intersectsWith(collisionBox)) {
+                collidingBoxes.add(collisionBox);
+            }
+        }
     }
 
     public boolean isFull() {

--- a/src/main/java/cn/nukkit/block/BlockEnchantingTable.java
+++ b/src/main/java/cn/nukkit/block/BlockEnchantingTable.java
@@ -6,7 +6,9 @@ import cn.nukkit.blockentity.BlockEntityEnchantTable;
 import cn.nukkit.inventory.EnchantInventory;
 import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemTool;
+import cn.nukkit.math.AxisAlignedBB;
 import cn.nukkit.math.BlockFace;
+import cn.nukkit.math.SimpleAxisAlignedBB;
 import cn.nukkit.nbt.tag.CompoundTag;
 import cn.nukkit.nbt.tag.ListTag;
 import cn.nukkit.nbt.tag.StringTag;
@@ -67,6 +69,11 @@ public class BlockEnchantingTable extends BlockTransparent implements BlockEntit
     @Override
     public int getLightLevel() {
         return 7;
+    }
+
+    @Override
+    protected AxisAlignedBB recalculateBoundingBox() {
+        return new SimpleAxisAlignedBB(x, y, z, x + 1d, y + 12d / 16d, z + 1d);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/block/BlockFarmland.java
+++ b/src/main/java/cn/nukkit/block/BlockFarmland.java
@@ -50,7 +50,8 @@ public class BlockFarmland extends BlockTransparentMeta {
 
     @Override
     protected AxisAlignedBB recalculateBoundingBox() {
-        return new SimpleAxisAlignedBB(this.x, this.y, this.z, this.x + 1, this.y + 1, this.z + 1);
+        return new SimpleAxisAlignedBB(
+                this.x, this.y, this.z, this.x + 1, this.y + 1 - 1 / 16d, this.z + 1);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/block/BlockGrassPath.java
+++ b/src/main/java/cn/nukkit/block/BlockGrassPath.java
@@ -25,7 +25,8 @@ public class BlockGrassPath extends BlockGrass {
 
     @Override
     protected AxisAlignedBB recalculateBoundingBox() {
-        return new SimpleAxisAlignedBB(this.x, this.y, this.z, this.x + 1, this.y + 1, this.z + 1);
+        return new SimpleAxisAlignedBB(
+                this.x, this.y, this.z, this.x + 1, this.y + 1 - 1 / 16d, this.z + 1);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/block/BlockHopper.java
+++ b/src/main/java/cn/nukkit/block/BlockHopper.java
@@ -17,6 +17,7 @@ import cn.nukkit.item.ItemTool;
 import cn.nukkit.level.Level;
 import cn.nukkit.level.Position;
 import cn.nukkit.math.AxisAlignedBB;
+import cn.nukkit.math.SimpleAxisAlignedBB;
 import cn.nukkit.math.BlockFace;
 import cn.nukkit.math.Vector3;
 import cn.nukkit.nbt.tag.CompoundTag;
@@ -24,10 +25,54 @@ import cn.nukkit.nbt.tag.ListTag;
 import cn.nukkit.utils.Faceable;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.List;
+
 /**
  * @author CreeperFace
  */
 public class BlockHopper extends BlockTransparentMeta implements Faceable, BlockEntityHolder<BlockEntityHopper> {
+
+    /** Чаша воронки и её бортик: клиент даёт встать внутрь, полный куб — нет. */
+    private AxisAlignedBB[] recalculateCollisionBoxes() {
+        double rim = 2d / 16d;
+        double bowl = 10d / 16d;
+        return new AxisAlignedBB[]{
+                new SimpleAxisAlignedBB(x, y, z, x + 1d, y + bowl, z + 1d),
+                new SimpleAxisAlignedBB(x, y, z, x + rim, y + 1d, z + 1d),
+                new SimpleAxisAlignedBB(x + 1d - rim, y, z, x + 1d, y + 1d, z + 1d),
+                new SimpleAxisAlignedBB(x, y, z, x + 1d, y + 1d, z + rim),
+                new SimpleAxisAlignedBB(x, y, z + 1d - rim, x + 1d, y + 1d, z + 1d)
+        };
+    }
+
+    private boolean collidesWithHopper(AxisAlignedBB bb) {
+        for (AxisAlignedBB part : recalculateCollisionBoxes()) {
+            if (bb.intersectsWith(part)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean collidesWithBB(AxisAlignedBB bb) {
+        return collidesWithHopper(bb);
+    }
+
+    @Override
+    public boolean collidesWithBB(AxisAlignedBB bb, boolean collisionBB) {
+        return collisionBB ? collidesWithHopper(bb) : super.collidesWithBB(bb, false);
+    }
+
+    @Override
+    public void addCollisionBoxesToList(AxisAlignedBB bb, List<AxisAlignedBB> collidingBoxes) {
+        for (AxisAlignedBB part : recalculateCollisionBoxes()) {
+            if (bb.intersectsWith(part)) {
+                collidingBoxes.add(part);
+            }
+        }
+    }
+
 
     public BlockHopper() {
         this(0);

--- a/src/main/java/cn/nukkit/block/BlockShelf.java
+++ b/src/main/java/cn/nukkit/block/BlockShelf.java
@@ -13,7 +13,9 @@ import cn.nukkit.inventory.Inventory;
 import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemTool;
 import cn.nukkit.level.Level;
+import cn.nukkit.math.AxisAlignedBB;
 import cn.nukkit.math.BlockFace;
+import cn.nukkit.math.SimpleAxisAlignedBB;
 import cn.nukkit.math.Vector3;
 import cn.nukkit.utils.BlockColor;
 import cn.nukkit.utils.Faceable;
@@ -35,6 +37,16 @@ public abstract class BlockShelf extends BlockTransparentMeta implements Faceabl
     private static final int TYPE_MASK = 0b0000_0011;
     private static final int POWERED_MASK = 0b0000_0100;
     private static final int DIRECTION_MASK = 0b0001_1000;
+
+    /**
+     * Полка занимает пять пикселей у своей стены, а не весь блок: нижняя доска на всю глубину,
+     * трёхпиксельная задняя стенка и верхняя полка над нишей. Клиент рисует и считает именно
+     * эту форму, поэтому полный куб на сервере превращал полку в подставку.
+     */
+    private static final double SHELF_DEPTH = 5d / 16d;
+    private static final double SHELF_BACK_DEPTH = 3d / 16d;
+    private static final double SHELF_BOARD_HEIGHT = 4d / 16d;
+    private static final double SHELF_TOP_HEIGHT = 12d / 16d;
 
     private static final IntBlockProperty POWERED_SHELF_TYPE = new IntBlockProperty("powered_shelf_type", false, 3, 0);
     private static final BooleanBlockProperty POWERED_BIT = new BooleanBlockProperty("powered_bit", false);
@@ -93,6 +105,64 @@ public abstract class BlockShelf extends BlockTransparentMeta implements Faceabl
     @Override
     public BlockColor getColor() {
         return BlockColor.WOOD_BLOCK_COLOR;
+    }
+
+    /**
+     * Коробка полки, отмеренная от её стены внутрь блока: {@code from} и {@code to} — глубина,
+     * {@code minY} и {@code maxY} — высота. Стена лежит на стороне, противоположной лицевой.
+     */
+    private AxisAlignedBB shelfBox(double from, double to, double minY, double maxY) {
+        return switch (this.getBlockFace().getOpposite()) {
+            case NORTH -> new SimpleAxisAlignedBB(this.x, this.y + minY, this.z + from,
+                    this.x + 1d, this.y + maxY, this.z + to);
+            case SOUTH -> new SimpleAxisAlignedBB(this.x, this.y + minY, this.z + 1d - to,
+                    this.x + 1d, this.y + maxY, this.z + 1d - from);
+            case WEST -> new SimpleAxisAlignedBB(this.x + from, this.y + minY, this.z,
+                    this.x + to, this.y + maxY, this.z + 1d);
+            default -> new SimpleAxisAlignedBB(this.x + 1d - to, this.y + minY, this.z,
+                    this.x + 1d - from, this.y + maxY, this.z + 1d);
+        };
+    }
+
+    private AxisAlignedBB[] recalculateCollisionBoxes() {
+        return new AxisAlignedBB[]{
+                shelfBox(0d, SHELF_DEPTH, 0d, SHELF_BOARD_HEIGHT),
+                shelfBox(0d, SHELF_BACK_DEPTH, SHELF_BOARD_HEIGHT, 1d),
+                shelfBox(SHELF_BACK_DEPTH, SHELF_DEPTH, SHELF_TOP_HEIGHT, 1d)
+        };
+    }
+
+    @Override
+    protected AxisAlignedBB recalculateBoundingBox() {
+        return shelfBox(0d, SHELF_DEPTH, 0d, 1d);
+    }
+
+    private boolean collidesWithShelf(AxisAlignedBB bb) {
+        for (AxisAlignedBB collisionBox : recalculateCollisionBoxes()) {
+            if (bb.intersectsWith(collisionBox)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean collidesWithBB(AxisAlignedBB bb) {
+        return collidesWithShelf(bb);
+    }
+
+    @Override
+    public boolean collidesWithBB(AxisAlignedBB bb, boolean collisionBB) {
+        return collisionBB ? collidesWithShelf(bb) : super.collidesWithBB(bb, false);
+    }
+
+    @Override
+    public void addCollisionBoxesToList(AxisAlignedBB bb, List<AxisAlignedBB> collidingBoxes) {
+        for (AxisAlignedBB collisionBox : recalculateCollisionBoxes()) {
+            if (bb.intersectsWith(collisionBox)) {
+                collidingBoxes.add(collisionBox);
+            }
+        }
     }
 
     @Override

--- a/src/main/java/cn/nukkit/block/BlockSnowLayer.java
+++ b/src/main/java/cn/nukkit/block/BlockSnowLayer.java
@@ -148,8 +148,7 @@ public class BlockSnowLayer extends BlockFallableMeta {
 
     @Override
     public double getMaxY() {
-        int height = this.getDamage() & 0x7;
-        return height < 3 ? this.y : height == 7 ? this.y + 1 : this.y + 0.5;
+        return this.y + (this.getDamage() & 0x7) / 8d;
     }
 
     @Override
@@ -193,6 +192,6 @@ public class BlockSnowLayer extends BlockFallableMeta {
 
     @Override
     public boolean canPassThrough() {
-        return (this.getDamage() & 0x7) < 3;
+        return (this.getDamage() & 0x7) == 0;
     }
 }

--- a/src/main/java/cn/nukkit/block/BlockSoulSand.java
+++ b/src/main/java/cn/nukkit/block/BlockSoulSand.java
@@ -4,6 +4,8 @@ import cn.nukkit.entity.Entity;
 import cn.nukkit.event.block.BlockFormEvent;
 import cn.nukkit.item.ItemTool;
 import cn.nukkit.level.Level;
+import cn.nukkit.math.AxisAlignedBB;
+import cn.nukkit.math.SimpleAxisAlignedBB;
 
 /**
  * @author Pub4Game
@@ -37,6 +39,12 @@ public class BlockSoulSand extends BlockSolid {
     @Override
     public int getToolType() {
         return ItemTool.TYPE_SHOVEL;
+    }
+
+    @Override
+    protected AxisAlignedBB recalculateBoundingBox() {
+        return new SimpleAxisAlignedBB(
+                this.x, this.y, this.z, this.x + 1, this.y + 1 - 1 / 8d, this.z + 1);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/block/BlockStairs.java
+++ b/src/main/java/cn/nukkit/block/BlockStairs.java
@@ -8,6 +8,8 @@ import cn.nukkit.math.SimpleAxisAlignedBB;
 import cn.nukkit.utils.Faceable;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.List;
+
 /**
  * @author MagicDroidX
  * Nukkit Project
@@ -64,6 +66,45 @@ public abstract class BlockStairs extends BlockSolidMeta implements Faceable {
         Item item = super.toItem();
         item.setDamage(0);
         return item;
+    }
+
+    @Override
+    public void addCollisionBoxesToList(AxisAlignedBB bb, List<AxisAlignedBB> collidingBoxes) {
+        for (AxisAlignedBB part : this.collisionParts()) {
+            if (bb.intersectsWith(part)) {
+                collidingBoxes.add(part);
+            }
+        }
+    }
+
+    /** Обе половины ступеньки: плита снизу (или сверху) и сам подъём. */
+    private AxisAlignedBB[] collisionParts() {
+        int damage = this.getDamage();
+        int side = damage & 0x03;
+        double f = 0;
+        double f1 = 0.5;
+        double f2 = 0.5;
+        double f3 = 1;
+        if ((damage & 0x04) > 0) {
+            f = 0.5;
+            f1 = 1;
+            f2 = 0;
+            f3 = 0.5;
+        }
+
+        AxisAlignedBB slab = new SimpleAxisAlignedBB(
+                this.x, this.y + f, this.z, this.x + 1, this.y + f1, this.z + 1);
+        AxisAlignedBB step = switch (side) {
+            case 0 -> new SimpleAxisAlignedBB(
+                    this.x + 0.5, this.y + f2, this.z, this.x + 1, this.y + f3, this.z + 1);
+            case 1 -> new SimpleAxisAlignedBB(
+                    this.x, this.y + f2, this.z, this.x + 0.5, this.y + f3, this.z + 1);
+            case 2 -> new SimpleAxisAlignedBB(
+                    this.x, this.y + f2, this.z + 0.5, this.x + 1, this.y + f3, this.z + 1);
+            default -> new SimpleAxisAlignedBB(
+                    this.x, this.y + f2, this.z, this.x + 1, this.y + f3, this.z + 0.5);
+        };
+        return new AxisAlignedBB[] {slab, step};
     }
 
     @Override

--- a/src/main/java/cn/nukkit/block/BlockStonecutter.java
+++ b/src/main/java/cn/nukkit/block/BlockStonecutter.java
@@ -1,5 +1,8 @@
 package cn.nukkit.block;
 
+import cn.nukkit.math.AxisAlignedBB;
+import cn.nukkit.math.SimpleAxisAlignedBB;
+
 import cn.nukkit.item.ItemTool;
 
 public class BlockStonecutter extends BlockSolid {
@@ -12,6 +15,12 @@ public class BlockStonecutter extends BlockSolid {
     @Override
     public double getHardness() {
         return 3.5;
+    }
+
+    @Override
+    protected AxisAlignedBB recalculateBoundingBox() {
+        return new SimpleAxisAlignedBB(
+                this.x, this.y, this.z, this.x + 1, this.y + 9d / 16d, this.z + 1);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/block/BlockThin.java
+++ b/src/main/java/cn/nukkit/block/BlockThin.java
@@ -29,24 +29,20 @@ public abstract class BlockThin extends BlockTransparent {
             boolean flag1 = this.canConnect(this.south());
             boolean flag2 = this.canConnect(this.west());
             boolean flag3 = this.canConnect(this.east());
-            if ((!flag2 || !flag3) && (flag2 || flag3 || flag || flag1)) {
-                if (flag2) {
-                    f = 0;
-                } else if (flag3) {
-                    f1 = 1;
-                }
-            } else {
+            if (flag2 && flag3) {
                 f = 0;
                 f1 = 1;
+            } else if (flag2) {
+                f = 0;
+            } else if (flag3) {
+                f1 = 1;
             }
-            if ((!flag || !flag1) && (flag2 || flag3 || flag || flag1)) {
-                if (flag) {
-                    f2 = 0;
-                } else if (flag1) {
-                    f3 = 1;
-                }
-            } else {
+            if (flag && flag1) {
                 f2 = 0;
+                f3 = 1;
+            } else if (flag) {
+                f2 = 0;
+            } else if (flag1) {
                 f3 = 1;
             }
         } catch (LevelException ignore) {}

--- a/src/main/java/cn/nukkit/utils/CollisionHelper.java
+++ b/src/main/java/cn/nukkit/utils/CollisionHelper.java
@@ -604,11 +604,8 @@ public record CollisionHelper(Entity entity) {
                     if (block instanceof BlockBarrier && entity.canPassThroughBarrier()) {
                         continue;
                     }
-                    if (!block.canPassThrough() && block.collidesWithBB(boundingBox)) {
-                        AxisAlignedBB blockBB = block.getBoundingBox();
-                        if (blockBB != null) {
-                            collides.add(blockBB);
-                        }
+                    if (!block.canPassThrough()) {
+                        block.addCollisionBoxesToList(boundingBox, collides);
                     }
                 }
             }

--- a/src/test/java/cn/nukkit/block/BlockCollisionShapeTest.java
+++ b/src/test/java/cn/nukkit/block/BlockCollisionShapeTest.java
@@ -63,6 +63,37 @@ class BlockCollisionShapeTest {
     }
 
     @Test
+    void stonecutterIsNinePixelsHigh() {
+        Block stonecutter = Block.get(BlockID.STONECUTTER_BLOCK);
+        stonecutter.setComponents(10d, 20d, 30d);
+
+        assertEquals(20d + 9d / 16d, stonecutter.getBoundingBox().getMaxY(), 1e-12);
+    }
+
+    @Test
+    void hopperHasABowlAndARim() {
+        Block hopper = Block.get(BlockID.HOPPER_BLOCK);
+        hopper.setComponents(0d, 0d, 0d);
+        AxisAlignedBB bowl = new SimpleAxisAlignedBB(0.3d, 10d / 16d + 0.001d, 0.3d,
+                0.7d, 0.95d, 0.7d);
+        AxisAlignedBB rim = new SimpleAxisAlignedBB(0.01d, 10d / 16d + 0.001d, 0.4d,
+                0.1d, 0.95d, 0.6d);
+
+        assertFalse(hopper.collidesWithBB(bowl));
+        assertTrue(hopper.collidesWithBB(rim));
+    }
+
+    @Test
+    void snowLayerGrowsTwoPixelsPerLayer() {
+        for (int layers = 0; layers < 8; layers++) {
+            Block snow = Block.get(BlockID.SNOW_LAYER, layers);
+            snow.setComponents(0d, 0d, 0d);
+
+            assertEquals(layers / 8d, snow.getMaxY(), 1e-12);
+        }
+    }
+
+    @Test
     void cauldronHasAFreeCavityAndSolidBottomAndRim() {
         Block cauldron = Block.get(BlockID.CAULDRON_BLOCK, 6);
         cauldron.setComponents(0d, 0d, 0d);

--- a/src/test/java/cn/nukkit/block/BlockCollisionShapeTest.java
+++ b/src/test/java/cn/nukkit/block/BlockCollisionShapeTest.java
@@ -52,6 +52,17 @@ class BlockCollisionShapeTest {
     }
 
     @Test
+    void loneGlassPaneStaysACentrePost() {
+        Block pane = Block.get(BlockID.GLASS_PANE);
+        pane.setComponents(0d, 0d, 0d);
+
+        assertEquals(7d / 16d, pane.getBoundingBox().getMinX(), 1e-12);
+        assertEquals(9d / 16d, pane.getBoundingBox().getMaxX(), 1e-12);
+        assertEquals(7d / 16d, pane.getBoundingBox().getMinZ(), 1e-12);
+        assertEquals(9d / 16d, pane.getBoundingBox().getMaxZ(), 1e-12);
+    }
+
+    @Test
     void cauldronHasAFreeCavityAndSolidBottomAndRim() {
         Block cauldron = Block.get(BlockID.CAULDRON_BLOCK, 6);
         cauldron.setComponents(0d, 0d, 0d);

--- a/src/test/java/cn/nukkit/block/BlockCollisionShapeTest.java
+++ b/src/test/java/cn/nukkit/block/BlockCollisionShapeTest.java
@@ -1,0 +1,62 @@
+package cn.nukkit.block;
+
+import cn.nukkit.math.AxisAlignedBB;
+import cn.nukkit.math.SimpleAxisAlignedBB;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BlockCollisionShapeTest {
+
+    @BeforeAll
+    static void initializeBlocks() {
+        Block.init();
+    }
+
+    @Test
+    void enchantingTableIsTwelvePixelsHigh() {
+        Block table = Block.get(BlockID.ENCHANTING_TABLE);
+        table.setComponents(10d, 20d, 30d);
+
+        assertEquals(20.75d, table.getCollisionBoundingBox().getMaxY(), 1e-12);
+    }
+
+    @Test
+    void cauldronHasAFreeCavityAndSolidBottomAndRim() {
+        Block cauldron = Block.get(BlockID.CAULDRON_BLOCK, 6);
+        cauldron.setComponents(0d, 0d, 0d);
+        AxisAlignedBB cavity = new SimpleAxisAlignedBB(0.2d, 5d / 16d + 0.001d, 0.2d,
+                0.8d, 0.95d, 0.8d);
+        AxisAlignedBB bottom = new SimpleAxisAlignedBB(0.2d, 0.1d, 0.2d, 0.8d, 0.2d, 0.8d);
+        AxisAlignedBB rim = new SimpleAxisAlignedBB(0.01d, 0.7d, 0.2d, 0.1d, 0.9d, 0.8d);
+
+        assertFalse(cauldron.collidesWithBB(cavity, true));
+        assertTrue(cauldron.collidesWithBB(bottom, true));
+        assertTrue(cauldron.collidesWithBB(rim, true));
+
+        List<AxisAlignedBB> boxes = new ArrayList<>();
+        cauldron.addCollisionBoxesToList(cavity, boxes);
+        assertTrue(boxes.isEmpty());
+        cauldron.addCollisionBoxesToList(bottom, boxes);
+        assertEquals(1, boxes.size());
+    }
+
+    @Test
+    void defaultCollisionBoxesPreserveVirtualShapePredicate() {
+        Block stair = Block.get(BlockID.WOOD_STAIRS, 0);
+        stair.setComponents(0d, 0d, 0d);
+        AxisAlignedBB upperStep =
+                new SimpleAxisAlignedBB(0.75d, 0.75d, 0.25d, 0.9d, 0.9d, 0.4d);
+
+        assertFalse(stair.getCollisionBoundingBox().intersectsWith(upperStep));
+        List<AxisAlignedBB> boxes = new ArrayList<>();
+        stair.addCollisionBoxesToList(upperStep, boxes);
+        assertEquals(1, boxes.size());
+    }
+}

--- a/src/test/java/cn/nukkit/block/BlockCollisionShapeTest.java
+++ b/src/test/java/cn/nukkit/block/BlockCollisionShapeTest.java
@@ -28,6 +28,30 @@ class BlockCollisionShapeTest {
     }
 
     @Test
+    void grassPathIsFifteenPixelsHigh() {
+        Block path = Block.get(BlockID.GRASS_PATH);
+        path.setComponents(10d, 20d, 30d);
+
+        assertEquals(20d + 15d / 16d, path.getBoundingBox().getMaxY(), 1e-12);
+    }
+
+    @Test
+    void farmlandIsFifteenPixelsHigh() {
+        Block farmland = Block.get(BlockID.FARMLAND);
+        farmland.setComponents(10d, 20d, 30d);
+
+        assertEquals(20d + 15d / 16d, farmland.getBoundingBox().getMaxY(), 1e-12);
+    }
+
+    @Test
+    void soulSandIsFourteenPixelsHigh() {
+        Block soulSand = Block.get(BlockID.SOUL_SAND);
+        soulSand.setComponents(10d, 20d, 30d);
+
+        assertEquals(20d + 14d / 16d, soulSand.getBoundingBox().getMaxY(), 1e-12);
+    }
+
+    @Test
     void cauldronHasAFreeCavityAndSolidBottomAndRim() {
         Block cauldron = Block.get(BlockID.CAULDRON_BLOCK, 6);
         cauldron.setComponents(0d, 0d, 0d);

--- a/src/test/java/cn/nukkit/block/BlockShelfCollisionTest.java
+++ b/src/test/java/cn/nukkit/block/BlockShelfCollisionTest.java
@@ -1,0 +1,67 @@
+package cn.nukkit.block;
+
+import cn.nukkit.math.AxisAlignedBB;
+import cn.nukkit.math.BlockFace;
+import cn.nukkit.math.SimpleAxisAlignedBB;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BlockShelfCollisionTest {
+
+    @BeforeAll
+    static void initializeBlocks() {
+        Block.init();
+    }
+
+    private BlockShelf shelfFacing(BlockFace face) {
+        BlockShelf shelf = new BlockShelfOak();
+        shelf.setComponents(0d, 0d, 0d);
+        shelf.setBlockFace(face);
+        return shelf;
+    }
+
+    @Test
+    void aShelfLeavesElevenPixelsOfTheBlockFree() {
+        BlockShelf shelf = shelfFacing(BlockFace.SOUTH);
+        AxisAlignedBB inFrontOfTheShelf =
+                new SimpleAxisAlignedBB(0.2d, 0d, 0.4d, 0.8d, 1.8d, 0.95d);
+
+        assertFalse(shelf.collidesWithBB(inFrontOfTheShelf));
+
+        List<AxisAlignedBB> boxes = new ArrayList<>();
+        shelf.addCollisionBoxesToList(inFrontOfTheShelf, boxes);
+        assertTrue(boxes.isEmpty());
+    }
+
+    @Test
+    void aShelfStillStopsWhatTouchesItsBoards() {
+        BlockShelf shelf = shelfFacing(BlockFace.SOUTH);
+        AxisAlignedBB lowerBoard = new SimpleAxisAlignedBB(0.2d, 0.05d, 0.05d, 0.8d, 0.2d, 0.25d);
+        AxisAlignedBB topBoard = new SimpleAxisAlignedBB(0.2d, 0.8d, 0.2d, 0.8d, 0.95d, 0.3d);
+        AxisAlignedBB nicheBetweenTheBoards =
+                new SimpleAxisAlignedBB(0.2d, 0.4d, 0.25d, 0.8d, 0.6d, 0.3d);
+
+        assertTrue(shelf.collidesWithBB(lowerBoard));
+        assertTrue(shelf.collidesWithBB(topBoard));
+        assertFalse(shelf.collidesWithBB(nicheBetweenTheBoards));
+
+        List<AxisAlignedBB> boxes = new ArrayList<>();
+        shelf.addCollisionBoxesToList(lowerBoard, boxes);
+        assertEquals(1, boxes.size());
+    }
+
+    @Test
+    void everyFacingKeepsTheShelfAgainstItsOwnWall() {
+        assertEquals(0.3125d, shelfFacing(BlockFace.SOUTH).getBoundingBox().getMaxZ(), 1e-12);
+        assertEquals(0.6875d, shelfFacing(BlockFace.NORTH).getBoundingBox().getMinZ(), 1e-12);
+        assertEquals(0.3125d, shelfFacing(BlockFace.EAST).getBoundingBox().getMaxX(), 1e-12);
+        assertEquals(0.6875d, shelfFacing(BlockFace.WEST).getBoundingBox().getMinX(), 1e-12);
+    }
+}


### PR DESCRIPTION
A server-side collision box that is taller than the box the client draws makes every creative or flying player collide with geometry he cannot see and get corrected back frame after frame. Eight blocks were still on Java values or on a plain full cube:

* **dirt path** and **farmland** — client walks one pixel below the top;
* **soul sand** — two pixels below the top;
* **stonecutter** — nine pixels high;
* **hopper** — has a bowl a player drops into;
* **snow layer** — steps two pixels per layer; the server had zero up to two layers, half a block up to seven and a full block only at eight;
* **thin blocks (panes/bars)** with no neighbours — fell into the branch that widens the box to the whole cell instead of keeping the two-pixel centre post;
* **stairs** — exposed only the lower slab through `getBoundingBox`, so the movement resolver never saw the step half.

Each shape is covered by a regression in `BlockCollisionShapeTest`.

⚠️ Stacked on #904 (enchanting table and cauldron collisions), whose commit introduces that test class and is the first commit here. Happy to rebase to a single commit once #904 is merged.