### PR TITLE
Prevent clipping after denied creative breaks without repeated floor corrections

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -155,6 +155,9 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
     public static final int SPECTATOR = 3;
     public static final int VIEW = SPECTATOR;
 
+    private static final double CREATIVE_BREAK_POSITION_EPSILON = 1.0E-4;
+    private static final int CREATIVE_BREAK_CORRECTION_TICKS = 5;
+
     public static final int CRAFTING_SMALL = 0;
     public static final int CRAFTING_BIG = 1;
     public static final int ANVIL_WINDOW_ID = 2;
@@ -256,6 +259,10 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
     protected long randomClientId;
 
     protected Location forceMovement = null;
+
+    private Level deniedCreativeBreakLevel;
+    private BlockVector3 deniedCreativeBreakBlock;
+    private int deniedCreativeBreakExpiresAtTick;
 
     protected Location teleportPosition = null;
 
@@ -660,6 +667,61 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
 
         double speedRatio = (double) configuredFlySpeed / DEFAULT_FLY_SPEED;
         return vanillaLimitSquared * speedRatio * speedRatio;
+    }
+
+    void armDeniedCreativeBreakCorrection(BlockVector3 blockPos) {
+        if (!this.isCreative() || this.noClip || this.riding != null
+                || blockPos.distanceSquared(this) > 4
+                || blockPos.getY() + CREATIVE_BREAK_POSITION_EPSILON >= this.y) {
+            return;
+        }
+
+        Block block = this.level.getBlock(blockPos.asVector3(), false);
+        AxisAlignedBB feet = this.boundingBox.clone().shrink(0.05, 0, 0.05);
+        feet.setMinY(this.y - 0.05);
+        feet.setMaxY(this.y + CREATIVE_BREAK_POSITION_EPSILON);
+        if (!block.collidesWithBB(feet)) {
+            return;
+        }
+
+        this.deniedCreativeBreakLevel = this.level;
+        this.deniedCreativeBreakBlock = new BlockVector3(
+                blockPos.getX(), blockPos.getY(), blockPos.getZ());
+        this.deniedCreativeBreakExpiresAtTick = this.server.getTick()
+                + CREATIVE_BREAK_CORRECTION_TICKS;
+    }
+
+    private Vector3 correctDeniedCreativeBreakMovement(Vector3 clientPos) {
+        if (this.deniedCreativeBreakBlock == null) {
+            return clientPos;
+        }
+        if (!this.isCreative() || this.noClip || this.riding != null
+                || this.level != this.deniedCreativeBreakLevel
+                || this.server.getTick() > this.deniedCreativeBreakExpiresAtTick) {
+            this.clearDeniedCreativeBreakCorrection();
+            return clientPos;
+        }
+        if (clientPos.y >= this.y - CREATIVE_BREAK_POSITION_EPSILON) {
+            return clientPos;
+        }
+
+        Block block = this.level.getBlock(this.deniedCreativeBreakBlock.asVector3(), false);
+        AxisAlignedBB targetFeet = this.boundingBox
+                .getOffsetBoundingBox(clientPos.x - this.x, 0, clientPos.z - this.z)
+                .shrink(0.05, 0, 0.05);
+        targetFeet.setMinY(clientPos.y + CREATIVE_BREAK_POSITION_EPSILON);
+        targetFeet.setMaxY(this.y + 0.05);
+        if (!block.collidesWithBB(targetFeet)) {
+            this.clearDeniedCreativeBreakCorrection();
+            return clientPos;
+        }
+
+        return new Vector3(clientPos.x, this.y, clientPos.z);
+    }
+
+    private void clearDeniedCreativeBreakCorrection() {
+        this.deniedCreativeBreakLevel = null;
+        this.deniedCreativeBreakBlock = null;
     }
 
     public void setAllowModifyWorld(boolean value) {
@@ -2433,6 +2495,10 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
             }
         }
 
+        Vector3 correctedClientPos = this.correctDeniedCreativeBreakMovement(clientPos);
+        boolean correctedDeniedCreativeBreak = correctedClientPos != clientPos;
+        clientPos = correctedClientPos;
+
         double dx = clientPos.x - this.x;
         double dy = clientPos.y - this.y;
         double dz = clientPos.z - this.z;
@@ -2590,7 +2656,13 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                 this.speed.setComponents(0, 0, 0);
             }
         } else {
-            this.forceMovement = null;
+            if (correctedDeniedCreativeBreak) {
+                Location correction = this.getLocation().add(0, 0.00001, 0);
+                this.sendPosition(correction, MovePlayerPacket.MODE_NORMAL);
+                this.forceMovement = correction;
+            } else {
+                this.forceMovement = null;
+            }
 
             if (this.speed == null) {
                 speed = new Vector3(from.x - to.x, from.y - to.y, from.z - to.z);
@@ -5534,6 +5606,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                                 break;
                             }
 
+                            this.armDeniedCreativeBreakCorrection(blockVector);
                             inventory.sendContents(this);
                             inventory.sendHeldItem(this);
 
@@ -6041,6 +6114,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
         if (canInteract) {
             handItem = this.level.useBreakOn(blockPos.asVector3(), face, handItem, this, true);
             if (handItem == null) {
+                this.armDeniedCreativeBreakCorrection(blockPos);
                 this.level.sendBlocks(new Player[]{this}, new Vector3[]{blockPos.asVector3()}, UpdateBlockPacket.FLAG_ALL_PRIORITY);
 
                 BlockEntity blockEntity = this.level.getBlockEntity(blockPos.asVector3());
@@ -6065,6 +6139,8 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
 
         inventory.sendContents(this);
         inventory.sendHeldItem(this);
+
+        this.armDeniedCreativeBreakCorrection(blockPos);
 
         if (blockPos.distanceSquared(this) < 10000) {
             Vector3 pos = blockPos.asVector3();

--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -156,6 +156,9 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
     public static final int VIEW = SPECTATOR;
 
     private static final double CREATIVE_BREAK_POSITION_EPSILON = 1.0E-4;
+    // Bedrock resting contact can sit 0.005 blocks below the collision top. This
+    // controls packets only; the authoritative position still stays on the floor.
+    private static final double CREATIVE_BREAK_CORRECTION_TOLERANCE = 0.01;
     private static final int CREATIVE_BREAK_CORRECTION_TICKS = 5;
 
     public static final int CRAFTING_SMALL = 0;
@@ -701,7 +704,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
             this.clearDeniedCreativeBreakCorrection();
             return clientPos;
         }
-        if (clientPos.y >= this.y - CREATIVE_BREAK_POSITION_EPSILON) {
+        if (clientPos.y >= this.y) {
             return clientPos;
         }
 
@@ -709,14 +712,43 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
         AxisAlignedBB targetFeet = this.boundingBox
                 .getOffsetBoundingBox(clientPos.x - this.x, 0, clientPos.z - this.z)
                 .shrink(0.05, 0, 0.05);
-        targetFeet.setMinY(clientPos.y + CREATIVE_BREAK_POSITION_EPSILON);
-        targetFeet.setMaxY(this.y + 0.05);
+        targetFeet.setMinY(clientPos.y);
+        targetFeet.setMaxY(this.y + CREATIVE_BREAK_POSITION_EPSILON);
         if (!block.collidesWithBB(targetFeet)) {
             this.clearDeniedCreativeBreakCorrection();
             return clientPos;
         }
 
-        return new Vector3(clientPos.x, this.y, clientPos.z);
+        // Locate the highest crossed surface using the block's actual collision
+        // predicate. getBoundingBox() alone omits the upper half of stairs.
+        // Testing the interval above each midpoint makes the search monotonic,
+        // including blocks whose collision consists of disconnected pieces.
+        double lowerY = clientPos.y;
+        double upperY = this.y + CREATIVE_BREAK_POSITION_EPSILON;
+        for (int probe = 0; probe < 40 && upperY - lowerY > 1.0E-7; probe++) {
+            double middleY = (lowerY + upperY) * 0.5;
+            targetFeet.setMinY(middleY);
+            if (block.collidesWithBB(targetFeet)) {
+                lowerY = middleY;
+            } else {
+                upperY = middleY;
+            }
+        }
+        // A replacement block may enclose the current feet. Preserve the existing
+        // denial guard without pushing the player above their accepted height.
+        double floorY = Math.min(this.y, upperY);
+        double crossedAt = (this.y - floorY) / (this.y - clientPos.y);
+        targetFeet.offset(-(clientPos.x - this.x) * (1 - crossedAt), 0,
+                -(clientPos.z - this.z) * (1 - crossedAt));
+        targetFeet.setMinY(floorY - CREATIVE_BREAK_POSITION_EPSILON);
+        targetFeet.setMaxY(floorY + CREATIVE_BREAK_POSITION_EPSILON);
+        if (!block.collidesWithBB(targetFeet)) {
+            // Diagonal motion may enter this column after passing below its top.
+            this.clearDeniedCreativeBreakCorrection();
+            return clientPos;
+        }
+
+        return new Vector3(clientPos.x, floorY, clientPos.z);
     }
 
     private void clearDeniedCreativeBreakCorrection() {
@@ -2496,7 +2528,8 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
         }
 
         Vector3 correctedClientPos = this.correctDeniedCreativeBreakMovement(clientPos);
-        boolean correctedDeniedCreativeBreak = correctedClientPos != clientPos;
+        boolean correctedDeniedCreativeBreak = correctedClientPos.y - clientPos.y
+                > CREATIVE_BREAK_CORRECTION_TOLERANCE;
         clientPos = correctedClientPos;
 
         double dx = clientPos.x - this.x;
@@ -4081,7 +4114,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                 Vector3 newPos = new Vector3(movePlayerPacket.x, movePlayerPacket.y - this.getBaseOffset(), movePlayerPacket.z);
                 double dis = newPos.distanceSquared(this);
 
-                if (dis == 0 && movePlayerPacket.yaw % 360 == this.yaw && movePlayerPacket.pitch % 360 == this.pitch) {
+                if (this.forceMovement == null && dis == 0 && movePlayerPacket.yaw % 360 == this.yaw && movePlayerPacket.pitch % 360 == this.pitch) {
                     break;
                 }
 
@@ -4489,7 +4522,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                 }
 
                 double distSqrt = clientPosition.distanceSquared(this);
-                if (distSqrt == 0.0 && authPacket.getYaw() % 360 == this.yaw && authPacket.getPitch() % 360 == this.pitch) {
+                if (this.forceMovement == null && distSqrt == 0.0 && authPacket.getYaw() % 360 == this.yaw && authPacket.getPitch() % 360 == this.pitch) {
                     break;
                 }
 

--- a/src/test/java/cn/nukkit/PlayerDeniedCreativeBreakContactTest.java
+++ b/src/test/java/cn/nukkit/PlayerDeniedCreativeBreakContactTest.java
@@ -1,0 +1,346 @@
+package cn.nukkit;
+
+import cn.nukkit.block.Block;
+import cn.nukkit.block.BlockAir;
+import cn.nukkit.block.BlockEndPortalFrame;
+import cn.nukkit.block.BlockSlabStone;
+import cn.nukkit.block.BlockStairsStone;
+import cn.nukkit.block.BlockStone;
+import cn.nukkit.block.BlockTrapdoor;
+import cn.nukkit.level.Level;
+import cn.nukkit.level.format.FullChunk;
+import cn.nukkit.level.format.generic.BaseFullChunk;
+import cn.nukkit.level.vibration.VibrationManager;
+import cn.nukkit.math.BlockVector3;
+import cn.nukkit.math.SimpleAxisAlignedBB;
+import cn.nukkit.math.Vector3;
+import cn.nukkit.math.Vector3f;
+import cn.nukkit.network.SourceInterface;
+import cn.nukkit.network.protocol.DataPacket;
+import cn.nukkit.network.protocol.MovePlayerPacket;
+import cn.nukkit.network.protocol.PlayerAuthInputPacket;
+import cn.nukkit.network.protocol.ProtocolInfo;
+import cn.nukkit.network.session.NetworkPlayerSession;
+import cn.nukkit.plugin.PluginManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+
+import java.net.InetSocketAddress;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PlayerDeniedCreativeBreakContactTest {
+
+    private static Stream<Arguments> movementModes() {
+        return Stream.of(
+                Arguments.of(ProtocolInfo.v1_20_0, 0),
+                Arguments.of(ProtocolInfo.v1_20_0, 1),
+                Arguments.of(ProtocolInfo.v1_21_90, 2),
+                Arguments.of(ProtocolInfo.v1_26_40, 2),
+                Arguments.of(ProtocolInfo.v1_26_45, 2));
+    }
+
+    private static Stream<Arguments> partialSupports() {
+        return Stream.of(
+                Arguments.of(new BlockTrapdoor(), 0.5, 70.1875),
+                Arguments.of(new BlockEndPortalFrame(), 0.5, 70.8125),
+                Arguments.of(new BlockSlabStone(), 0.5, 70.5),
+                Arguments.of(new BlockSlabStone(8), 0.5, 71.0),
+                Arguments.of(new BlockStairsStone(), 0.2, 70.5),
+                Arguments.of(new BlockStairsStone(), 0.8, 71.0));
+    }
+
+    @ParameterizedTest
+    @MethodSource("partialSupports")
+    void airborneDescentLandsOnTheActualPartialSupport(Block support, double x, double top) {
+        TestPlayer player = createPlayer(support, x, top);
+        player.armDeniedCreativeBreakCorrection(new BlockVector3(0, 70, 0));
+        player.move(new Vector3(x, top + 0.42, 0.5));
+
+        player.move(new Vector3(x, 69.8, 0.5));
+
+        assertEquals(top, player.y, 0.000001);
+        assertEquals(top, player.getBoundingBox().getMinY(), 0.000001);
+        assertNotNull(player.forceMovement);
+    }
+
+    @ParameterizedTest
+    @MethodSource("movementModes")
+    void realLandingAcknowledgementAllowsTheNextJumpAndEdgeExit(int protocol, int mode) {
+        TestPlayer player = trapdoorPlayer(protocol, mode);
+        player.move(new Vector3(0.5, 70.6, 0.5));
+        player.move(new Vector3(0.5, 69.8, 0.5));
+        assertEquals(70.1875, player.y, 0.000001);
+        assertNotNull(player.forceMovement);
+
+        player.input(0.5, 70.1875, 0.5);
+        assertNull(player.forceMovement);
+        player.applyQueuedMovement();
+        player.input(0.6, 70.6075, 0.5);
+        assertNotNull(player.newPosition);
+        assertNull(player.forceMovement);
+        player.applyQueuedMovement();
+        assertEquals(70.6075, player.y, 0.00001);
+
+        player.input(1.4, 70.0, 0.5);
+        assertNull(player.forceMovement);
+        player.applyQueuedMovement();
+        assertEquals(1.4, player.x, 0.00001);
+        assertEquals(70.0, player.y, 0.00001);
+    }
+
+    @ParameterizedTest
+    @MethodSource("movementModes")
+    void exactlyStationaryPacketReleasesPendingCorrection(int protocol, int mode) {
+        TestPlayer player = trapdoorPlayer(protocol, mode);
+        float decodedFeetY = (float) (70.1875 + player.baseOffset()) - player.baseOffset();
+        player.moveTo(0.5, decodedFeetY, 0.5);
+        player.forceMovement = player.getLocation().add(0, 0.00001, 0);
+
+        player.input(0.5, 70.1875, 0.5);
+
+        assertNull(player.forceMovement, "An unchanged movement packet must acknowledge the correction");
+        assertNotNull(player.newPosition);
+        player.applyQueuedMovement();
+        player.input(0.5, 70.6075, 0.5);
+        assertNotNull(player.newPosition);
+        assertNull(player.forceMovement);
+    }
+
+    @ParameterizedTest
+    @MethodSource("movementModes")
+    void recordedRestingContactDoesNotSendRepeatedCorrections(int protocol, int mode) {
+        TestPlayer player = trapdoorPlayer(protocol, mode);
+        // Recorded Bedrock resting contact, including its settling cycle.
+        double[] feetY = {70.1825, 70.1825, 70.1842, 70.1853, 70.1860, 70.1868,
+                70.1870, 70.1872, 70.1873, 70.1874, 70.1874, 70.1875, 70.1875};
+        for (int cycle = 0; cycle < 3; cycle++) {
+            for (double y : feetY) {
+                player.input(0.5, y, 0.5);
+                player.applyQueuedMovement();
+                assertEquals(70.1875, player.y, 0.00001);
+                assertNull(player.forceMovement);
+                assertEquals(0, player.selfPositionPackets);
+            }
+        }
+        player.input(0.65, 70.1825, 0.5);
+        player.applyQueuedMovement();
+        assertEquals(0.65, player.x, 0.00001);
+        assertEquals(70.1875, player.y, 0.000001);
+        player.input(0.8, 70.6075, 0.5);
+        player.applyQueuedMovement();
+        assertEquals(70.6075, player.y, 0.00001);
+        assertEquals(0, player.selfPositionPackets);
+    }
+
+    @ParameterizedTest
+    @MethodSource("movementModes")
+    void smallContactCannotAccumulateAndDeeperInputStillCorrects(int protocol, int mode) {
+        TestPlayer player = trapdoorPlayer(protocol, mode);
+        for (int i = 0; i < 20; i++) {
+            player.input(0.5, player.y - 0.005, 0.5);
+            player.applyQueuedMovement();
+            assertEquals(70.1875, player.y, 0.000001);
+            assertEquals(70.1875, player.getBoundingBox().getMinY(), 0.000001);
+            assertNull(player.forceMovement);
+        }
+        assertEquals(0, player.selfPositionPackets);
+
+        player.input(0.5, 70.1675, 0.5);
+        player.applyQueuedMovement();
+        assertEquals(70.1875, player.y, 0.000001);
+        assertNotNull(player.forceMovement);
+        assertEquals(1, player.selfPositionPackets);
+        assertEquals(MovePlayerPacket.MODE_NORMAL, player.lastSendMode);
+    }
+
+    @Test
+    void diagonalMotionBelowTheSupportDoesNotSnapOntoIt() {
+        TestPlayer player = createPlayer(new BlockTrapdoor(), 0.5, 70.1875);
+        player.armDeniedCreativeBreakCorrection(new BlockVector3(0, 70, 0));
+        player.move(new Vector3(4.5, 72, 0.5));
+        player.move(new Vector3(0.5, 66, 0.5));
+        assertEquals(66, player.y, 0.000001);
+        assertNull(player.forceMovement);
+    }
+
+    @Test
+    void sideOfHigherRimDoesNotBecomeADeniedFloor() {
+        TestPlayer player = createPlayer(new BlockTrapdoor(), 0.5, 70.1875);
+        Block rim = new BlockStone();
+        rim.setComponents(1, 70, 0);
+        player.blocks.put("1:70:0", rim);
+        player.armDeniedCreativeBreakCorrection(new BlockVector3(0, 70, 0));
+        player.move(new Vector3(0.5, 70.6, 0.5));
+        player.move(new Vector3(0.8, 70.4, 0.5));
+        assertEquals(70.4, player.y, 0.000001);
+        assertEquals(0.8, player.x, 0.000001);
+        assertNull(player.forceMovement);
+    }
+
+    @Test
+    void ordinaryMovementWithoutADeniedBreakIsUnchanged() {
+        TestPlayer player = createPlayer(new BlockTrapdoor(), 0.5, 70.1875);
+        player.move(new Vector3(0.5, 69.8, 0.5));
+        assertEquals(69.8, player.y, 0.000001);
+        assertNull(player.forceMovement);
+    }
+
+    @Test
+    void changedLevelCancelsPendingCorrection() {
+        TestPlayer player = trapdoorPlayer(ProtocolInfo.v1_21_90, 2);
+        player.level = Mockito.mock(Level.class);
+        player.move(new Vector3(0.5, 69.8, 0.5));
+        assertEquals(69.8, player.y, 0.000001);
+        assertNull(player.forceMovement);
+    }
+
+    private static TestPlayer trapdoorPlayer(int protocol, int mode) {
+        TestPlayer player = createPlayer(new BlockTrapdoor(), 0.5, 70.1875);
+        player.protocol = protocol;
+        MockServer.get().serverAuthoritativeMovementMode = mode;
+        player.armDeniedCreativeBreakCorrection(new BlockVector3(0, 70, 0));
+        return player;
+    }
+
+    private static TestPlayer createPlayer(Block support, double x, double top) {
+        MockServer.reset();
+        Map<String, Block> blocks = new HashMap<>();
+        support.setComponents(0, 70, 0);
+        blocks.put("0:70:0", support);
+        Level level = Mockito.mock(Level.class);
+        Mockito.when(level.getMinBlockY()).thenReturn(-64);
+        Mockito.when(level.getMaxBlockY()).thenReturn(319);
+        Mockito.when(level.getVibrationManager()).thenReturn(Mockito.mock(VibrationManager.class));
+        Mockito.when(level.getBlock(Mockito.any(Vector3.class), Mockito.eq(false)))
+                .thenAnswer(invocation -> {
+                    Vector3 pos = invocation.getArgument(0);
+                    return blocks.getOrDefault(pos.getFloorX() + ":" + pos.getFloorY() + ":" + pos.getFloorZ(), new BlockAir());
+                });
+        Mockito.when(level.getBlock(Mockito.any(FullChunk.class), Mockito.anyInt(), Mockito.anyInt(),
+                        Mockito.anyInt(), Mockito.eq(0), Mockito.eq(false)))
+                .thenAnswer(invocation -> blocks.getOrDefault(invocation.getArgument(1) + ":"
+                        + invocation.getArgument(2) + ":" + invocation.getArgument(3), new BlockAir()));
+        support.level = level;
+        BaseFullChunk chunk = Mockito.mock(BaseFullChunk.class);
+        Mockito.when(chunk.isGenerated()).thenReturn(true);
+        Server server = MockServer.get();
+        Mockito.when(server.getDefaultLevel()).thenReturn(level);
+        Mockito.when(server.getViewDistance()).thenReturn(1);
+        Mockito.when(server.getTick()).thenReturn(1000);
+        Mockito.when(server.getPluginManager()).thenReturn(Mockito.mock(PluginManager.class));
+        SourceInterface source = Mockito.mock(SourceInterface.class);
+        Mockito.when(source.getSession(Mockito.any(InetSocketAddress.class)))
+                .thenReturn(Mockito.mock(NetworkPlayerSession.class));
+        TestPlayer player = new TestPlayer(source);
+        player.blocks = blocks;
+        player.level = level;
+        player.chunk = chunk;
+        player.spawned = true;
+        player.loggedIn = true;
+        player.loginVerified = true;
+        player.protocol = ProtocolInfo.v1_21_90;
+        player.lastTeleportTick = -1000;
+        player.markAlive();
+        player.temporalVector = new Vector3();
+        player.adventureSettings = new AdventureSettings(player);
+        player.gamemode = Player.CREATIVE;
+        player.boundingBox = new SimpleAxisAlignedBB(0, 0, 0, 0.6, 1.8, 0.6);
+        player.moveTo(x, top, 0.5);
+        player.lastX = x;
+        player.lastY = top;
+        player.lastZ = 0.5;
+        player.firstMove = true;
+        return player;
+    }
+
+    private static final class TestPlayer extends Player {
+        private Map<String, Block> blocks;
+        private int selfPositionPackets;
+        private int lastSendMode = -1;
+
+        private TestPlayer(SourceInterface source) {
+            super(source, 1L, new InetSocketAddress("127.0.0.1", 19132));
+        }
+
+        private float baseOffset() {
+            return getBaseOffset();
+        }
+
+        private void markAlive() {
+            health = 20;
+        }
+
+        private void move(Vector3 position) {
+            handleMovement(position, 1);
+        }
+
+        private void input(double x, double y, double z) {
+            newPosition = null;
+            if (!isMovementServerAuthoritative()) {
+                MovePlayerPacket packet = new MovePlayerPacket();
+                packet.x = (float) x;
+                packet.y = (float) (y + getBaseOffset());
+                packet.z = (float) z;
+                handleDataPacket(packet);
+            } else {
+                PlayerAuthInputPacket packet = new PlayerAuthInputPacket();
+                packet.setPosition(new Vector3f((float) x, (float) (y + getBaseOffset()), (float) z));
+                handleDataPacket(packet);
+            }
+        }
+
+        private void applyQueuedMovement() {
+            if (newPosition != null) move(newPosition);
+        }
+
+        private void moveTo(double x, double y, double z) {
+            this.x = x;
+            this.y = y;
+            this.z = z;
+            boundingBox.setBounds(x - 0.3, y, z - 0.3, x + 0.3, y + getHeight(), z + 0.3);
+        }
+
+        @Override
+        public boolean isInsideOfWater() {
+            return false;
+        }
+
+        @Override
+        public boolean dataPacket(DataPacket packet) {
+            return true;
+        }
+
+        @Override
+        public boolean fastMove(double dx, double dy, double dz) {
+            moveTo(x + dx, y + dy, z + dz);
+            return true;
+        }
+
+        @Override
+        public void sendPosition(double x, double y, double z, double yaw, double pitch, double headYaw,
+                                 int mode, Collection<Player> targets) {
+            if (targets == null || targets.contains(this)) {
+                selfPositionPackets++;
+                lastSendMode = mode;
+            }
+        }
+
+        @Override
+        public void sendPosition(Vector3 pos, double yaw, double pitch, double headYaw,
+                                 int mode, Player[] targets) {
+            if (targets == null || Arrays.asList(targets).contains(this)) {
+                selfPositionPackets++;
+                lastSendMode = mode;
+            }
+        }
+    }
+}

--- a/src/test/java/cn/nukkit/PlayerFlightMovementLimitTest.java
+++ b/src/test/java/cn/nukkit/PlayerFlightMovementLimitTest.java
@@ -1,9 +1,26 @@
 package cn.nukkit;
 
+import cn.nukkit.block.Block;
+import cn.nukkit.level.Level;
+import cn.nukkit.level.format.generic.BaseFullChunk;
+import cn.nukkit.math.AxisAlignedBB;
+import cn.nukkit.math.BlockVector3;
+import cn.nukkit.math.SimpleAxisAlignedBB;
+import cn.nukkit.math.Vector3;
+import cn.nukkit.network.SourceInterface;
+import cn.nukkit.network.protocol.DataPacket;
+import cn.nukkit.network.protocol.MovePlayerPacket;
+import cn.nukkit.network.session.NetworkPlayerSession;
+import cn.nukkit.plugin.PluginManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.net.InetSocketAddress;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Answers.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
@@ -59,5 +76,300 @@ class PlayerFlightMovementLimitTest {
 
         player.setFlySpeed(Float.MAX_VALUE);
         assertTrue(Double.isFinite(player.movementSanityLimitSquared(100d)));
+    }
+
+    @Test
+    void deniedBreakOnPartialSupportKeepsHorizontalProgress() {
+        Level level = mockingLevel();
+        Block support = partialSupport(level);
+        TestPlayer player = createPlayer(level);
+        player.gamemode = Player.CREATIVE;
+        player.armDeniedCreativeBreakCorrection(new BlockVector3(0, 64, 0));
+
+        player.driveServerAuthMovement(new Vector3(0.9, 64.6, 0.5));
+
+        assertEquals(0.9, player.x, 0.000001);
+        assertEquals(64.8125, player.y, 0.000001);
+        assertNotNull(player.forceMovement);
+        assertEquals(0.9, player.forceMovement.x, 0.000001);
+        assertEquals(MovePlayerPacket.MODE_NORMAL, player.lastSendMode);
+
+        Vector3 correctionAck = new Vector3(
+                player.forceMovement.x, player.forceMovement.y, player.forceMovement.z);
+        player.driveServerAuthMovement(correctionAck);
+        assertNull(player.forceMovement);
+
+        player.driveServerAuthMovement(new Vector3(1.26, 64.7, 0.5));
+
+        assertEquals(1.26, player.x, 0.000001);
+        assertEquals(64.7, player.y, 0.000001);
+        assertNull(player.forceMovement);
+        Mockito.verify(support, Mockito.atLeastOnce()).collidesWithBB(Mockito.any());
+    }
+
+    @Test
+    void packetFloatNoiseDoesNotTriggerDeniedBreakCorrection() {
+        Level level = mockingLevel();
+        partialSupport(level, 126, 126.8125);
+        TestPlayer player = createPlayer(level);
+        player.gamemode = Player.CREATIVE;
+        player.moveTo(0.5, 126.8125, 0.5);
+        player.armDeniedCreativeBreakCorrection(new BlockVector3(0, 126, 0));
+
+        float baseOffset = player.baseOffset();
+        float packetY = (float) (player.y + baseOffset);
+        double decodedY = packetY - baseOffset;
+        assertTrue(decodedY < player.y);
+        player.driveHandleMovement(new Vector3(0.6, decodedY, 0.5));
+
+        assertEquals(0.6, player.x, 0.000001);
+        assertEquals(decodedY, player.y, 0.000000001);
+        assertNull(player.forceMovement);
+        assertEquals(-1, player.lastSendMode);
+    }
+
+    @Test
+    void onePacketCannotSkipBelowDeniedSupport() {
+        Level level = mockingLevel();
+        partialSupport(level);
+        TestPlayer player = createPlayer(level);
+        player.gamemode = Player.CREATIVE;
+        player.armDeniedCreativeBreakCorrection(new BlockVector3(0, 64, 0));
+
+        player.driveHandleMovement(new Vector3(0.6, 63.5, 0.5));
+
+        assertEquals(0.6, player.x, 0.000001);
+        assertEquals(64.8125, player.y, 0.000001);
+        assertNotNull(player.forceMovement);
+    }
+
+    @Test
+    void unrelatedDeniedBreakDoesNotClearPendingSupport() {
+        Level level = mockingLevel();
+        partialSupport(level);
+        TestPlayer player = createPlayer(level);
+        player.gamemode = Player.CREATIVE;
+        player.armDeniedCreativeBreakCorrection(new BlockVector3(0, 64, 0));
+
+        player.armDeniedCreativeBreakCorrection(new BlockVector3(0, 65, 0));
+        player.armDeniedCreativeBreakCorrection(new BlockVector3(100, 64, 0));
+        player.driveHandleMovement(new Vector3(0.9, 64.6, 0.5));
+
+        assertEquals(0.9, player.x, 0.000001);
+        assertEquals(64.8125, player.y, 0.000001);
+        assertNotNull(player.forceMovement);
+    }
+
+    @Test
+    void changedSupportCancelsPendingCorrection() {
+        Level level = mockingLevel();
+        Block support = partialSupport(level);
+        Block replacement = Mockito.mock(Block.class);
+        Mockito.when(level.getBlock(Mockito.any(Vector3.class), Mockito.eq(false)))
+                .thenReturn(support, replacement);
+        TestPlayer player = createPlayer(level);
+        player.gamemode = Player.CREATIVE;
+        player.armDeniedCreativeBreakCorrection(new BlockVector3(0, 64, 0));
+
+        player.driveHandleMovement(new Vector3(0.9, 64.4, 0.5));
+
+        assertEquals(0.9, player.x, 0.000001);
+        assertEquals(64.4, player.y, 0.000001);
+        assertNull(player.forceMovement);
+    }
+
+    @Test
+    void collidingReplacementKeepsPendingCorrection() {
+        Level level = mockingLevel();
+        Block support = partialSupport(level);
+        Block replacement = Mockito.mock(Block.class);
+        AxisAlignedBB collision = new SimpleAxisAlignedBB(0, 64, 0, 1, 65, 1);
+        Mockito.when(replacement.collidesWithBB(Mockito.any()))
+                .thenAnswer(invocation -> collision.intersectsWith(invocation.getArgument(0)));
+        Mockito.when(level.getBlock(Mockito.any(Vector3.class), Mockito.eq(false)))
+                .thenReturn(support, replacement);
+        TestPlayer player = createPlayer(level);
+        player.gamemode = Player.CREATIVE;
+        player.armDeniedCreativeBreakCorrection(new BlockVector3(0, 64, 0));
+
+        player.driveHandleMovement(new Vector3(0.9, 64.4, 0.5));
+
+        assertEquals(0.9, player.x, 0.000001);
+        assertEquals(64.8125, player.y, 0.000001);
+        assertNotNull(player.forceMovement);
+    }
+
+    @Test
+    void expiredCorrectionDoesNotAffectMovement() {
+        Level level = mockingLevel();
+        partialSupport(level);
+        TestPlayer player = createPlayer(level);
+        player.gamemode = Player.CREATIVE;
+        Mockito.when(MockServer.get().getTick()).thenReturn(10, 16);
+        player.armDeniedCreativeBreakCorrection(new BlockVector3(0, 64, 0));
+
+        player.driveHandleMovement(new Vector3(0.9, 64.4, 0.5));
+
+        assertEquals(0.9, player.x, 0.000001);
+        assertEquals(64.4, player.y, 0.000001);
+        assertNull(player.forceMovement);
+    }
+
+    @Test
+    void sideBlockDistantBlockAndSurvivalDoNotArmCorrection() {
+        Level level = mockingLevel();
+        partialSupport(level);
+        TestPlayer player = createPlayer(level);
+        player.gamemode = Player.CREATIVE;
+        player.armDeniedCreativeBreakCorrection(new BlockVector3(0, 65, 0));
+        player.armDeniedCreativeBreakCorrection(new BlockVector3(100, 64, 0));
+        Mockito.verify(level, Mockito.never())
+                .getBlock(Mockito.any(Vector3.class), Mockito.eq(false));
+        player.driveHandleMovement(new Vector3(0.9, 64.4, 0.5));
+        assertEquals(64.4, player.y, 0.000001);
+
+        player.moveTo(0.5, 64.8125, 0.5);
+        player.gamemode = Player.SURVIVAL;
+        player.armDeniedCreativeBreakCorrection(new BlockVector3(0, 64, 0));
+        player.driveHandleMovement(new Vector3(0.9, 64.4, 0.5));
+        assertEquals(64.4, player.y, 0.000001);
+        assertNull(player.forceMovement);
+    }
+
+    private static Level mockingLevel() {
+        MockServer.reset();
+        Level level = Mockito.mock(Level.class);
+        Mockito.when(level.getMinBlockY()).thenReturn(-64);
+        Mockito.when(level.getMaxBlockY()).thenReturn(319);
+        Mockito.when(level.hasCollision(Mockito.any(), Mockito.any(), Mockito.eq(false)))
+                .thenReturn(false);
+        return level;
+    }
+
+    private static Block partialSupport(Level level) {
+        return partialSupport(level, 64, 64.8125);
+    }
+
+    private static Block partialSupport(Level level, double minY, double maxY) {
+        Block block = Mockito.mock(Block.class);
+        AxisAlignedBB collision = new SimpleAxisAlignedBB(0, minY, 0, 1, maxY, 1);
+        Mockito.when(block.collidesWithBB(Mockito.any()))
+                .thenAnswer(invocation -> collision.intersectsWith(invocation.getArgument(0)));
+        Mockito.when(level.getBlock(Mockito.any(Vector3.class), Mockito.eq(false)))
+                .thenReturn(block);
+        return block;
+    }
+
+    private static TestPlayer createPlayer(Level level) {
+        BaseFullChunk chunk = Mockito.mock(BaseFullChunk.class);
+        Mockito.when(chunk.isGenerated()).thenReturn(true);
+
+        Server server = MockServer.get();
+        Mockito.when(server.getDefaultLevel()).thenReturn(level);
+        Mockito.when(server.getViewDistance()).thenReturn(1);
+        Mockito.when(server.getAllowFlight()).thenReturn(false);
+        Mockito.when(level.getChunk(0, 0, false)).thenReturn(chunk);
+        Mockito.when(server.getPluginManager()).thenReturn(Mockito.mock(PluginManager.class));
+
+        SourceInterface sourceInterface = Mockito.mock(SourceInterface.class);
+        Mockito.when(sourceInterface.getSession(Mockito.any(InetSocketAddress.class)))
+                .thenReturn(Mockito.mock(NetworkPlayerSession.class));
+
+        TestPlayer player = new TestPlayer(sourceInterface);
+        player.level = level;
+        player.chunk = chunk;
+        player.spawned = true;
+        player.markAlive();
+        player.temporalVector = new Vector3();
+        player.adventureSettings = new AdventureSettings(player);
+        player.boundingBox = new SimpleAxisAlignedBB(0.2, 64.8125, 0.2, 0.8, 66.6125, 0.8);
+        player.moveTo(0.5, 64.8125, 0.5);
+        player.lastX = 0.5;
+        player.lastY = 64.8125;
+        player.lastZ = 0.5;
+        player.firstMove = true;
+        return player;
+    }
+
+    private static final class TestPlayer extends Player {
+
+        private int lastSendMode = -1;
+
+        private TestPlayer(SourceInterface sourceInterface) {
+            super(sourceInterface, 1L, new InetSocketAddress("127.0.0.1", 19132));
+        }
+
+        private void driveHandleMovement(Vector3 clientPos) {
+            this.handleMovement(clientPos, 1);
+        }
+
+        private void driveServerAuthMovement(Vector3 clientPos) {
+            if (this.forceMovement != null
+                    && clientPos.distanceSquared(this.forceMovement) > 0.1) {
+                this.sendPosition(this.forceMovement, MovePlayerPacket.MODE_RESET);
+                return;
+            }
+            this.forceMovement = null;
+            this.handleMovement(clientPos, 1);
+        }
+
+        private float baseOffset() {
+            return this.getBaseOffset();
+        }
+
+        private void moveTo(double x, double y, double z) {
+            this.x = x;
+            this.y = y;
+            this.z = z;
+            this.boundingBox.setBounds(
+                    x - 0.3, y, z - 0.3, x + 0.3, y + this.getHeight(), z + 0.3);
+        }
+
+        private void markAlive() {
+            this.health = 20;
+        }
+
+        @Override
+        public boolean isInsideOfWater() {
+            return false;
+        }
+
+        @Override
+        public boolean dataPacket(DataPacket packet) {
+            return true;
+        }
+
+        @Override
+        public void sendPosition(
+                double x,
+                double y,
+                double z,
+                double yaw,
+                double pitch,
+                double headYaw,
+                int mode,
+                java.util.Collection<Player> targets) {
+            this.lastSendMode = mode;
+        }
+
+        @Override
+        public void sendPosition(
+                Vector3 pos,
+                double yaw,
+                double pitch,
+                double headYaw,
+                int mode,
+                Player[] targets) {
+            this.lastSendMode = mode;
+        }
+
+        @Override
+        public boolean fastMove(double dx, double dy, double dz) {
+            this.boundingBox.offset(dx, dy, dz);
+            this.x += dx;
+            this.y += dy;
+            this.z += dz;
+            return true;
+        }
     }
 }

--- a/src/test/java/cn/nukkit/PlayerFlightMovementLimitTest.java
+++ b/src/test/java/cn/nukkit/PlayerFlightMovementLimitTest.java
@@ -123,7 +123,7 @@ class PlayerFlightMovementLimitTest {
         player.driveHandleMovement(new Vector3(0.6, decodedY, 0.5));
 
         assertEquals(0.6, player.x, 0.000001);
-        assertEquals(decodedY, player.y, 0.000000001);
+        assertEquals(126.8125, player.y, 0.000000001);
         assertNull(player.forceMovement);
         assertEquals(-1, player.lastSendMode);
     }

--- a/src/test/java/cn/nukkit/entity/data/SkinDimensionValidationTest.java
+++ b/src/test/java/cn/nukkit/entity/data/SkinDimensionValidationTest.java
@@ -1,6 +1,8 @@
 package cn.nukkit.entity.data;
 
+import cn.nukkit.MockServer;
 import cn.nukkit.utils.SerializedImage;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -14,6 +16,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * match width×height renders invisible on the client.
  */
 class SkinDimensionValidationTest {
+
+    @BeforeAll
+    static void initServer() {
+        MockServer.init();
+    }
 
     private Skin validBase() {
         Skin skin = new Skin();


### PR DESCRIPTION
## Problem

A creative client predicts an instant block break before the server validates it. When interaction checks or a block-break event deny the break, the restored support can disagree with movement that the client has already sent. Reverting an entire movement frame causes horizontal rubber-banding, while restoring the previous airborne Y can leave the player suspended above a partial block.

Resting contact can also place Bedrock's reported feet about 0.005 blocks below the real surface. Repeatedly correcting that harmless offset creates a correction/acknowledgement loop and can reject the next jump.

## Changes

- Arm a five-tick correction only after a denied creative break below the player, covering both server-authoritative breaking and the legacy inventory transaction path.
- Preserve the existing level, expiry, distance, creative-mode, riding, no-clip, and live-support checks. Unrelated denied breaks cannot replace the pending support.
- Resolve the crossed top using the denied block's actual collision predicate, including both halves of stairs. The search is bounded to 40 probes of that one block; ordinary creative movement does not gain a world-wide floor sweep.
- Land on the actual crossed surface while preserving accepted X/Z. Check horizontal overlap at the crossing instant so diagonal movement below an overhang is accepted. A taller replacement retains the previous protection without pushing the player upward.
- Normalize small downward contact locally so it cannot accumulate below the authoritative floor. The 0.01-block tolerance controls correction packets only and does not enlarge the geometric support search.
- Let an exactly stationary movement packet acknowledge pending corrections in both input formats, allowing the next jump.

`SkinDimensionValidationTest` initializes its mock server explicitly to remove its existing dependency on test order.

## Validation

`mvn -q -B -Dtest=SkinDimensionValidationTest,PlayerFlightMovementLimitTest,PlayerFallCheckTest,PlayerDeniedCreativeBreakContactTest test`

59 tests passed with zero failures or errors. Coverage includes real trapdoors, end portal frames, lower/upper slabs and both stair heights; one-packet falls; horizontal edge exits; diagonal overhang and pit-rim movement; recorded resting-contact cycles; penetration accumulation; stationary acknowledgements; and the original denied-break guard regressions. Packet tests cover protocols 1.20.0, 1.21.90, 1.26.40 and 1.26.45 across five protocol/movement-mode combinations.
