### PR TITLE
fix(player): import PocketMine-MP off-hand and ender chest data

### DIFF
--- a/src/main/java/cn/nukkit/entity/EntityHumanType.java
+++ b/src/main/java/cn/nukkit/entity/EntityHumanType.java
@@ -24,6 +24,12 @@ import java.util.List;
 
 public abstract class EntityHumanType extends EntityCreature implements InventoryHolder {
 
+    private static final String POCKETMINE_OFFHAND = "OffHandItem";
+    private static final String POCKETMINE_ENDER_CHEST = "EnderChestInventory";
+    /** Host-side durable storage must acknowledge the imported ender chest before clearing this. */
+    public static final String POCKETMINE_ENDER_IMPORT_PENDING =
+            "NukkitPocketMineEnderImportPending";
+
     protected PlayerInventory inventory;
     protected PlayerEnderChestInventory enderChestInventory;
     protected PlayerOffhandInventory offhandInventory;
@@ -47,6 +53,8 @@ public abstract class EntityHumanType extends EntityCreature implements Inventor
 
     @Override
     protected void initEntity() {
+        importPocketMineInventories(this.namedTag);
+
         this.inventory = new PlayerInventory(this);
         this.offhandInventory = new PlayerOffhandInventory(this);
 
@@ -76,6 +84,144 @@ public abstract class EntityHumanType extends EntityCreature implements Inventor
         }
 
         super.initEntity();
+    }
+
+    /**
+     * Converts the inventory tags written by PocketMine-MP to Nukkit's player-data layout.
+     *
+     * <p>PocketMine stores the offhand as a standalone {@code OffHandItem} compound and the
+     * ender chest as {@code EnderChestInventory}. Nukkit stores the same data in inventory slot
+     * {@code -106} and {@code EnderItems}. Ignoring the legacy tags makes both inventories appear
+     * empty on the first login after moving a world from PocketMine.
+     *
+     * <p>Existing Nukkit items always win their slots. A colliding legacy item is moved to the
+     * first empty slot; when no slot is available its legacy tag is retained for a later login.
+     * Successfully imported tags are removed, making the conversion idempotent.
+     */
+    static void importPocketMineInventories(CompoundTag playerData) {
+        importPocketMineOffhand(playerData);
+        if (importPocketMineEnderChest(playerData)) {
+            playerData.putBoolean(POCKETMINE_ENDER_IMPORT_PENDING, true);
+        }
+    }
+
+    private static void importPocketMineOffhand(CompoundTag playerData) {
+        if (!playerData.contains(POCKETMINE_OFFHAND, CompoundTag.class)) {
+            return;
+        }
+
+        CompoundTag legacyItem = playerData.getCompound(POCKETMINE_OFFHAND);
+        if (!containsItem(legacyItem)) {
+            playerData.remove(POCKETMINE_OFFHAND);
+            return;
+        }
+
+        ListTag<CompoundTag> inventory = playerData.contains("Inventory", ListTag.class)
+                ? playerData.getList("Inventory", CompoundTag.class)
+                : new ListTag<>("Inventory");
+
+        int targetSlot = hasItemAt(inventory, -106) ? firstEmptyMainSlot(inventory) : -106;
+        if (targetSlot == Integer.MIN_VALUE) {
+            return;
+        }
+
+        removeEmptyItemsAt(inventory, targetSlot);
+        inventory.add(legacyItem.copy().putByte("Slot", targetSlot));
+        playerData.putList(inventory);
+        playerData.remove(POCKETMINE_OFFHAND);
+    }
+
+    private static boolean importPocketMineEnderChest(CompoundTag playerData) {
+        if (!playerData.contains(POCKETMINE_ENDER_CHEST, ListTag.class)) {
+            return false;
+        }
+
+        ListTag<CompoundTag> legacy = playerData.getList(POCKETMINE_ENDER_CHEST, CompoundTag.class);
+        ListTag<CompoundTag> ender = playerData.contains("EnderItems", ListTag.class)
+                ? playerData.getList("EnderItems", CompoundTag.class)
+                : new ListTag<>("EnderItems");
+        ListTag<CompoundTag> inventory = playerData.contains("Inventory", ListTag.class)
+                ? playerData.getList("Inventory", CompoundTag.class)
+                : new ListTag<>("Inventory");
+        ListTag<CompoundTag> remaining = new ListTag<>(POCKETMINE_ENDER_CHEST);
+        boolean imported = false;
+        boolean movedToMainInventory = false;
+
+        for (CompoundTag legacyItem : legacy.getAll()) {
+            if (!containsItem(legacyItem)) {
+                continue;
+            }
+            int preferredSlot = legacyItem.getByte("Slot");
+            int targetSlot = preferredSlot >= 0 && preferredSlot < 27 && !hasItemAt(ender, preferredSlot)
+                    ? preferredSlot
+                    : firstEmptySlot(ender, 0, 27);
+            if (targetSlot != Integer.MIN_VALUE) {
+                removeEmptyItemsAt(ender, targetSlot);
+                ender.add(legacyItem.copy().putByte("Slot", targetSlot));
+                imported = true;
+            } else {
+                int mainSlot = firstEmptyMainSlot(inventory);
+                if (mainSlot == Integer.MIN_VALUE) {
+                    remaining.add(legacyItem.copy());
+                    continue;
+                }
+                removeEmptyItemsAt(inventory, mainSlot);
+                inventory.add(legacyItem.copy().putByte("Slot", mainSlot));
+                imported = true;
+                movedToMainInventory = true;
+            }
+        }
+
+        playerData.putList(ender);
+        if (movedToMainInventory) {
+            playerData.putList(inventory);
+        }
+        if (remaining.isEmpty()) {
+            playerData.remove(POCKETMINE_ENDER_CHEST);
+        } else {
+            playerData.putList(remaining);
+        }
+        return imported;
+    }
+
+    private static int firstEmptyMainSlot(ListTag<CompoundTag> inventory) {
+        return firstEmptySlot(inventory, 9, 45);
+    }
+
+    private static int firstEmptySlot(ListTag<CompoundTag> inventory, int fromInclusive, int toExclusive) {
+        for (int slot = fromInclusive; slot < toExclusive; slot++) {
+            if (!hasItemAt(inventory, slot)) {
+                return slot;
+            }
+        }
+        return Integer.MIN_VALUE;
+    }
+
+    private static boolean hasItemAt(ListTag<CompoundTag> inventory, int slot) {
+        for (CompoundTag item : inventory.getAll()) {
+            if (item.getByte("Slot") == slot && containsItem(item)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void removeEmptyItemsAt(ListTag<CompoundTag> inventory, int slot) {
+        for (CompoundTag item : inventory.getAll()) {
+            if (item.getByte("Slot") == slot && !containsItem(item)) {
+                inventory.remove(item);
+            }
+        }
+    }
+
+    private static boolean containsItem(CompoundTag item) {
+        if (item.getByte("Count") <= 0) {
+            return false;
+        }
+        if (item.containsString("Name")) {
+            return !"minecraft:air".equals(item.getString("Name"));
+        }
+        return item.containsShort("id") && item.getShort("id") != Item.AIR;
     }
 
     @Override

--- a/src/test/java/cn/nukkit/entity/PocketMinePlayerInventoryImportTest.java
+++ b/src/test/java/cn/nukkit/entity/PocketMinePlayerInventoryImportTest.java
@@ -1,0 +1,129 @@
+package cn.nukkit.entity;
+
+import cn.nukkit.nbt.tag.CompoundTag;
+import cn.nukkit.nbt.tag.ListTag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PocketMinePlayerInventoryImportTest {
+
+    @Test
+    void importsPocketMineOffhandAndEnderChest() {
+        CompoundTag speedTalisman = item("minecraft:totem_of_undying", 1)
+                .putCompound("tag", new CompoundTag().putString("talismanId", "speed"));
+        CompoundTag playerData = new CompoundTag()
+                .putCompound("OffHandItem", speedTalisman)
+                .putList("EnderChestInventory", new ListTag<CompoundTag>()
+                        .add(item("minecraft:diamond_sword", 1).putByte("Slot", 4)));
+
+        EntityHumanType.importPocketMineInventories(playerData);
+
+        CompoundTag importedOffhand = itemAt(playerData.getList("Inventory", CompoundTag.class), -106);
+        assertEquals("minecraft:totem_of_undying", importedOffhand.getString("Name"));
+        assertEquals("speed", importedOffhand.getCompound("tag").getString("talismanId"));
+        assertEquals("minecraft:diamond_sword",
+                itemAt(playerData.getList("EnderItems", CompoundTag.class), 4).getString("Name"));
+        assertFalse(playerData.contains("OffHandItem"));
+        assertFalse(playerData.contains("EnderChestInventory"));
+        assertTrue(playerData.getBoolean(EntityHumanType.POCKETMINE_ENDER_IMPORT_PENDING));
+    }
+
+    @Test
+    void preservesExistingNukkitItemsAndUsesFreeSlots() {
+        ListTag<CompoundTag> inventory = new ListTag<CompoundTag>("Inventory")
+                .add(item("minecraft:shield", 1).putByte("Slot", -106))
+                .add(item("minecraft:diamond", 1).putByte("Slot", 9));
+        ListTag<CompoundTag> ender = new ListTag<CompoundTag>("EnderItems")
+                .add(item("minecraft:emerald", 1).putByte("Slot", 3));
+        CompoundTag playerData = new CompoundTag()
+                .putList(inventory)
+                .putCompound("OffHandItem", item("minecraft:totem_of_undying", 1))
+                .putList(ender)
+                .putList("EnderChestInventory", new ListTag<CompoundTag>()
+                        .add(item("minecraft:diamond_sword", 1).putByte("Slot", 3)));
+
+        EntityHumanType.importPocketMineInventories(playerData);
+
+        assertEquals("minecraft:shield", itemAt(inventory, -106).getString("Name"));
+        assertEquals("minecraft:totem_of_undying", itemAt(inventory, 10).getString("Name"));
+        assertEquals("minecraft:emerald", itemAt(ender, 3).getString("Name"));
+        assertEquals("minecraft:diamond_sword", itemAt(ender, 0).getString("Name"));
+        assertFalse(playerData.contains("OffHandItem"));
+        assertFalse(playerData.contains("EnderChestInventory"));
+        assertTrue(playerData.getBoolean(EntityHumanType.POCKETMINE_ENDER_IMPORT_PENDING));
+    }
+
+    @Test
+    void retainsLegacyTagsWhenBothInventoriesAreFull() {
+        ListTag<CompoundTag> inventory = new ListTag<CompoundTag>("Inventory")
+                .add(item("minecraft:shield", 1).putByte("Slot", -106));
+        for (int slot = 9; slot < 45; slot++) {
+            inventory.add(item("minecraft:stone", 64).putByte("Slot", slot));
+        }
+        ListTag<CompoundTag> ender = new ListTag<>("EnderItems");
+        for (int slot = 0; slot < 27; slot++) {
+            ender.add(item("minecraft:cobblestone", 64).putByte("Slot", slot));
+        }
+        CompoundTag playerData = new CompoundTag()
+                .putList(inventory)
+                .putCompound("OffHandItem", item("minecraft:totem_of_undying", 1))
+                .putList(ender)
+                .putList("EnderChestInventory", new ListTag<CompoundTag>()
+                        .add(item("minecraft:diamond_sword", 1).putByte("Slot", 4)));
+
+        EntityHumanType.importPocketMineInventories(playerData);
+
+        assertTrue(playerData.contains("OffHandItem"));
+        assertEquals(1, playerData.getList("EnderChestInventory", CompoundTag.class).size());
+        assertEquals(37, inventory.size());
+        assertEquals(27, ender.size());
+        assertFalse(playerData.getBoolean(EntityHumanType.POCKETMINE_ENDER_IMPORT_PENDING));
+    }
+
+    @Test
+    void movesEnderOverflowToTheMainInventoryBeforeRetainingItAsHiddenData() {
+        ListTag<CompoundTag> ender = new ListTag<>("EnderItems");
+        for (int slot = 0; slot < 27; slot++) {
+            ender.add(item("minecraft:cobblestone", 64).putByte("Slot", slot));
+        }
+        CompoundTag playerData = new CompoundTag()
+                .putList(ender)
+                .putList("EnderChestInventory", new ListTag<CompoundTag>()
+                        .add(item("minecraft:diamond_sword", 1).putByte("Slot", 4)));
+
+        EntityHumanType.importPocketMineInventories(playerData);
+
+        assertEquals("minecraft:diamond_sword",
+                itemAt(playerData.getList("Inventory", CompoundTag.class), 9).getString("Name"));
+        assertFalse(playerData.contains("EnderChestInventory"));
+        assertTrue(playerData.getBoolean(EntityHumanType.POCKETMINE_ENDER_IMPORT_PENDING));
+    }
+
+    @Test
+    void importIsIdempotent() {
+        CompoundTag playerData = new CompoundTag()
+                .putCompound("OffHandItem", item("minecraft:totem_of_undying", 1))
+                .putList("EnderChestInventory", new ListTag<CompoundTag>()
+                        .add(item("minecraft:diamond", 2).putByte("Slot", 8)));
+
+        EntityHumanType.importPocketMineInventories(playerData);
+        EntityHumanType.importPocketMineInventories(playerData);
+
+        assertEquals(1, playerData.getList("Inventory", CompoundTag.class).size());
+        assertEquals(1, playerData.getList("EnderItems", CompoundTag.class).size());
+    }
+
+    private static CompoundTag item(String name, int count) {
+        return new CompoundTag().putString("Name", name).putByte("Count", count).putShort("Damage", 0);
+    }
+
+    private static CompoundTag itemAt(ListTag<CompoundTag> items, int slot) {
+        return items.getAll().stream()
+                .filter(item -> item.getByte("Slot") == slot && item.getByte("Count") > 0)
+                .findFirst()
+                .orElseThrow();
+    }
+}


### PR DESCRIPTION
## Problem

A player profile written by PocketMine-MP stores the off-hand item as a separate `OffHandItem` compound and the ender chest as an `EnderChestInventory` list. Nukkit reads the off-hand from slot `-106` of the shared `Inventory` list and the ender chest from `EnderItems`. The main inventory shares the same layout, so a world migrated from PocketMine-MP loads with hotbar and armour intact while the off-hand item and the whole ender chest silently come up empty. Nothing is logged, and the original data is still in the profile.

## Fix

Translate both PocketMine-MP keys before the inventories are loaded:

* an `OffHandItem` compound becomes slot `-106` of `Inventory`;
* an `EnderChestInventory` list becomes `EnderItems`.

When the profile already carries a Nukkit value for a slot, the Nukkit slot wins and the legacy item is moved to a free slot of the ender chest, then of the main inventory; if there is no room anywhere, the legacy key is left in place so nothing is lost. Once translated, the legacy keys are removed, so a second login does not duplicate anything.

## Tests

`PocketMinePlayerInventoryImportTest` covers the plain import, a conflict on the off-hand slot, a full ender chest, an overflow into the main inventory, and a repeated login.
