### PR TITLE
fix(inventory): always validate the enchanting table result

### DIFF
--- a/src/main/java/cn/nukkit/inventory/transaction/EnchantTransaction.java
+++ b/src/main/java/cn/nukkit/inventory/transaction/EnchantTransaction.java
@@ -78,8 +78,9 @@ public class EnchantTransaction extends InventoryTransaction {
 
         return this.inputItem.equals(eInv.getInputSlot(), true, true)
                 && (this.inputItem.getId() == this.outputItem.getId() || (this.inputItem.getId() == Item.BOOK && this.outputItem.getId() == Item.ENCHANTED_BOOK))
-                && (this.inputItem.getCount() == this.outputItem.getCount() || (this.outputItem.getId() == Item.ENCHANTED_BOOK && this.outputItem.getCount() == 1)
-                && this.checkEnchantValid());
+                && (this.inputItem.getCount() == this.outputItem.getCount()
+                        || (this.outputItem.getId() == Item.ENCHANTED_BOOK && this.outputItem.getCount() == 1))
+                && this.checkEnchantValid();
     }
 
     @Override


### PR DESCRIPTION
## Problem

`EnchantTransaction.canExecute()` ended with

```java
&& (a || b && checkEnchantValid())
```

so `checkEnchantValid()` was bound to the right-hand side of the disjunction only. Whenever the input and output counts matched, which they always do for a tool, a piece of armour or a single book, the disjunction was already satisfied by the left operand and the validation never ran.

On the legacy transaction path the enchanting table result was therefore client-authored: enchantment ids, levels, treasure and curse entries, duplicates and incompatible combinations were accepted exactly as sent.

## Fix

Parenthesise the count check so the validation is a separate conjunct and runs for every enchanting transaction.
