### PR TITLE
fix(entity): replenish absorption when a stronger effect remains

### DIFF
--- a/src/main/java/cn/nukkit/entity/Entity.java
+++ b/src/main/java/cn/nukkit/entity/Entity.java
@@ -1092,6 +1092,18 @@ public abstract class Entity extends Location implements Metadatable {
 
         if (oldEffect != null && (oldEffect.getAmplifier() > effect.getAmplifier()
             || (oldEffect.getAmplifier() == effect.getAmplifier() && oldEffect.getDuration() >= effect.getDuration()))) {
+            // A weaker/shorter absorption effect must not replace the stronger icon or its
+            // duration, but consuming the item still replenishes the amount granted by that
+            // item. Without this, a normal golden apple eaten while enchanted-apple
+            // Absorption IV is still visible gives zero yellow hearts after the old pool was
+            // depleted: addEffect returns before Effect.add can refill anything.
+            if (effect.getId() == Effect.ABSORPTION
+                    && cause == EntityPotionEffectEvent.Cause.FOOD) {
+                float grantedAbsorption = (effect.getAmplifier() + 1) << 2;
+                if (grantedAbsorption > this.getAbsorption()) {
+                    this.setAbsorption(grantedAbsorption);
+                }
+            }
             return;
         }
 

--- a/src/test/java/cn/nukkit/entity/ArmorDamageReductionTest.java
+++ b/src/test/java/cn/nukkit/entity/ArmorDamageReductionTest.java
@@ -20,6 +20,7 @@ import cn.nukkit.nbt.tag.CompoundTag;
 import cn.nukkit.nbt.tag.DoubleTag;
 import cn.nukkit.nbt.tag.FloatTag;
 import cn.nukkit.nbt.tag.ListTag;
+import cn.nukkit.potion.Effect;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -45,6 +46,7 @@ public class ArmorDamageReductionTest {
     @BeforeAll
     static void initServer() {
         MockServer.init();
+        Effect.init();
     }
 
     /** 同包直接访问 protected static / direct call (same package, protected static) */
@@ -695,6 +697,54 @@ public class ArmorDamageReductionTest {
                 "Legacy should keep ctor-pre-computed RESISTANCE for non-HumanType entities");
     }
 
+    @Test
+    public void testWeakerAbsorptionRefillsItsOwnHeartsWithoutReplacingStrongerEffect() {
+        Level level = newMockLevel();
+        TestHuman target = new TestHuman(newMockChunk(level), baseNbt());
+        target.addEffect(Effect.getEffect(Effect.ABSORPTION).setAmplifier(3).setDuration(6000));
+        target.setAbsorption(0f);
+
+        target.addEffect(
+                Effect.getEffect(Effect.ABSORPTION).setAmplifier(0).setDuration(2400),
+                cn.nukkit.event.entity.EntityPotionEffectEvent.Cause.FOOD);
+
+        assertEquals(4f, target.getAbsorption(), 0.001f,
+                "A normal golden apple must refill its four absorption points");
+        assertEquals(3, target.getEffect(Effect.ABSORPTION).getAmplifier(),
+                "The weaker apple must not replace enchanted-apple Absorption IV");
+        assertEquals(6000, target.getEffect(Effect.ABSORPTION).getDuration(),
+                "The weaker apple must not shorten the stronger effect");
+    }
+
+    @Test
+    public void testRejectedAbsorptionRefreshNeverReducesRemainingHearts() {
+        Level level = newMockLevel();
+        TestHuman target = new TestHuman(newMockChunk(level), baseNbt());
+        target.addEffect(Effect.getEffect(Effect.ABSORPTION).setAmplifier(3).setDuration(6000));
+        target.setAbsorption(10f);
+
+        target.addEffect(
+                Effect.getEffect(Effect.ABSORPTION).setAmplifier(0).setDuration(2400),
+                cn.nukkit.event.entity.EntityPotionEffectEvent.Cause.FOOD);
+
+        assertEquals(10f, target.getAbsorption(), 0.001f);
+    }
+
+    @Test
+    public void testRejectedNonFoodAbsorptionDoesNotRefillHearts() {
+        Level level = newMockLevel();
+        TestHuman target = new TestHuman(newMockChunk(level), baseNbt());
+        target.addEffect(Effect.getEffect(Effect.ABSORPTION).setAmplifier(3).setDuration(6000));
+        target.setAbsorption(0f);
+
+        target.addEffect(
+                Effect.getEffect(Effect.ABSORPTION).setAmplifier(0).setDuration(2400),
+                cn.nukkit.event.entity.EntityPotionEffectEvent.Cause.UNKNOWN);
+
+        assertEquals(0f, target.getAbsorption(), 0.001f,
+                "Only consumed food may replenish a rejected absorption effect");
+    }
+
     private static Item prot4(int id) {
         Item item = Item.get(id);
         item.addEnchantment(Enchantment.getEnchantment(Enchantment.ID_PROTECTION_ALL).setLevel(4));
@@ -706,6 +756,7 @@ public class ArmorDamageReductionTest {
         damager.chunk = chunk;
         damager.speed = new Vector3(0, 1, 0);
         lenient().when(damager.getLevel()).thenReturn(level);
+        lenient().when(damager.getAdventureSettings()).thenReturn(new cn.nukkit.AdventureSettings(damager));
         lenient().when(damager.getBoundingBox()).thenReturn(new SimpleAxisAlignedBB(0, 0, 0, 1, 2, 1));
         lenient().when(damager.isOnGround()).thenReturn(false);
         return damager;


### PR DESCRIPTION
## Problem

`Entity.addEffect` returns early when an effect with a higher amplifier or a longer duration is already active. For Absorption that skipped the refill as well: a player still showing enchanted-apple Absorption IV who ate a normal golden apple after the yellow hearts had been used up received no absorption at all, because `Effect.add` is what refills the pool and it never ran.

Bedrock keeps the stronger icon and its duration but still lets the consumed food replenish the hearts it grants.

## Fix

When a food-caused Absorption effect is rejected in favour of a stronger one, raise the absorption to what the consumed item grants (`(amplifier + 1) * 4`) if the current value is lower. The existing effect, its amplifier and its duration stay untouched, and the current absorption is never lowered. Only `EntityPotionEffectEvent.Cause.FOOD` triggers this; a rejected potion or command effect still does nothing.

## Tests

Three cases in `ArmorDamageReductionTest`: a weaker apple refills its four points under Absorption IV, an already higher pool is not reduced, and a non-food cause does not refill.
