### PR TITLE
fix(resourcepack): serve one immutable archive per runtime

### DIFF
--- a/src/main/java/cn/nukkit/resourcepacks/AbstractResourcePack.java
+++ b/src/main/java/cn/nukkit/resourcepacks/AbstractResourcePack.java
@@ -19,13 +19,19 @@ public abstract class AbstractResourcePack implements ResourcePack {
 
     /**
      * 除了字段存在性，还校验后续解析无条件读取的字段类型（getPackId、getPackVersion、
-     * ZippedBehaviourPack 的 modules 扫描）：构造成功之后的抛异常路径没有清理入口，
-     * 会泄漏快照 channel，所以凡是能通过本校验的 manifest 后续解析绝不能抛异常。
+     * getPackProtocol 的 min_engine_version、ZippedBehaviourPack 的 modules 扫描）：
+     * 构造成功之后的抛异常路径没有清理入口，会泄漏快照 channel，所以凡是能通过本校验
+     * 的 manifest，上述无条件读取绝不能抛异常。NetEase 包豁免 name/description，
+     * 因此 getPackName 仅在包提供 name 时可用，服务端路径不得无条件调用它。
      * <p>
      * Beyond presence, validates the types of fields that later parsing reads
-     * unconditionally: there is no cleanup path once construction has succeeded
-     * (an escaping exception would leak the snapshot channel), so any manifest
-     * accepted here must parse without throwing afterwards.
+     * unconditionally (getPackId, getPackVersion, getPackProtocol's
+     * min_engine_version, ZippedBehaviourPack's modules scan): there is no
+     * cleanup path once construction has succeeded (an escaping exception would
+     * leak the snapshot channel), so those unconditional reads must never throw
+     * for a manifest accepted here. NetEase packs are exempt from
+     * name/description, so getPackName is only usable when the pack provides a
+     * name — server paths must not call it unconditionally.
      */
     protected boolean verifyManifest() {
         if (!this.manifest.has("format_version") || !this.manifest.has("header") || !this.manifest.has("modules")) {
@@ -53,7 +59,37 @@ public abstract class AbstractResourcePack implements ResourcePack {
                 return false;
             }
         }
+        JsonElement minEngineVersion = header.get("min_engine_version");
+        if (minEngineVersion != null && !isNumericVersionArray(minEngineVersion)) {
+            return false;
+        }
         return supportType == SupportType.NETEASE || (header.has("description") && header.has("name"));
+    }
+
+    /**
+     * min_engine_version 可省略；存在时必须是长度 ≥3 的数字数组，否则
+     * {@link #getPackProtocol()} 经 ProtocolConverter.getAsInt 读取时抛异常
+     * （IllegalStateException / NumberFormatException，取决于具体取值）。
+     * <p>
+     * min_engine_version is optional; when present it must be an array of at
+     * least 3 numbers, otherwise {@link #getPackProtocol()} throws while
+     * reading it via ProtocolConverter.getAsInt (IllegalStateException /
+     * NumberFormatException depending on the value).
+     */
+    private static boolean isNumericVersionArray(JsonElement minEngineVersion) {
+        if (!minEngineVersion.isJsonArray()) {
+            return false;
+        }
+        JsonArray array = minEngineVersion.getAsJsonArray();
+        if (array.size() < 3) {
+            return false;
+        }
+        for (JsonElement part : array) {
+            if (!part.isJsonPrimitive() || !part.getAsJsonPrimitive().isNumber()) {
+                return false;
+            }
+        }
+        return true;
     }
 
     @Override

--- a/src/main/java/cn/nukkit/resourcepacks/AbstractResourcePack.java
+++ b/src/main/java/cn/nukkit/resourcepacks/AbstractResourcePack.java
@@ -2,6 +2,7 @@ package cn.nukkit.resourcepacks;
 
 import cn.nukkit.network.protocol.ProtocolInfo;
 import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 import java.util.UUID;
@@ -16,16 +17,43 @@ public abstract class AbstractResourcePack implements ResourcePack {
     private String cdnUrl = "";
     protected String encryptionKey = "";
 
+    /**
+     * 除了字段存在性，还校验后续解析无条件读取的字段类型（getPackId、getPackVersion、
+     * ZippedBehaviourPack 的 modules 扫描）：构造成功之后的抛异常路径没有清理入口，
+     * 会泄漏快照 channel，所以凡是能通过本校验的 manifest 后续解析绝不能抛异常。
+     * <p>
+     * Beyond presence, validates the types of fields that later parsing reads
+     * unconditionally: there is no cleanup path once construction has succeeded
+     * (an escaping exception would leak the snapshot channel), so any manifest
+     * accepted here must parse without throwing afterwards.
+     */
     protected boolean verifyManifest() {
-        if (this.manifest.has("format_version") && this.manifest.has("header") && this.manifest.has("modules")) {
-            JsonObject header = this.manifest.getAsJsonObject("header");
-            return (supportType == SupportType.NETEASE || (header.has("description") && header.has("name"))) &&
-                    header.has("uuid") &&
-                    header.has("version") &&
-                    header.getAsJsonArray("version").size() == 3;
-        } else {
+        if (!this.manifest.has("format_version") || !this.manifest.has("header") || !this.manifest.has("modules")) {
             return false;
         }
+        if (!this.manifest.get("header").isJsonObject() || !this.manifest.get("modules").isJsonArray()) {
+            return false;
+        }
+        JsonObject header = this.manifest.getAsJsonObject("header");
+        JsonElement uuid = header.get("uuid");
+        if (uuid == null || !uuid.isJsonPrimitive()) {
+            return false;
+        }
+        try {
+            UUID.fromString(uuid.getAsString());
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+        JsonElement version = header.get("version");
+        if (version == null || !version.isJsonArray() || version.getAsJsonArray().size() != 3) {
+            return false;
+        }
+        for (JsonElement part : version.getAsJsonArray()) {
+            if (!part.isJsonPrimitive()) {
+                return false;
+            }
+        }
+        return supportType == SupportType.NETEASE || (header.has("description") && header.has("name"));
     }
 
     @Override

--- a/src/main/java/cn/nukkit/resourcepacks/ResourcePackManager.java
+++ b/src/main/java/cn/nukkit/resourcepacks/ResourcePackManager.java
@@ -104,7 +104,19 @@ public class ResourcePackManager {
      * so no chunk read can be in flight while an old instance is closed).
      */
     public void reloadPacks() {
-        for (ResourcePack pack : this.allPacksById.values()) {
+        // Sets 去重依据 equals（按 packId），同 UUID 的后加载包会覆盖 allPacksById，
+        // 把先加载的实例挤到只在 resourcePacks/behaviorPacks 里 — 必须按身份取三个
+        // 容器的并集，否则被遮蔽的实例永远不会被 close（泄漏快照 channel）。
+        // <p>
+        // The sets dedupe by equals (packId): a later pack with the same UUID
+        // overwrites allPacksById, leaving the earlier instance only in
+        // resourcePacks/behaviorPacks — close the identity-union of all three
+        // containers or the shadowed instance is never closed (channel leak).
+        Set<ResourcePack> toClose = Collections.newSetFromMap(new IdentityHashMap<>());
+        toClose.addAll(this.allPacksById.values());
+        toClose.addAll(this.resourcePacks);
+        toClose.addAll(this.behaviorPacks);
+        for (ResourcePack pack : toClose) {
             closePackQuietly(pack);
         }
         this.allPacksById.clear();

--- a/src/main/java/cn/nukkit/resourcepacks/ResourcePackManager.java
+++ b/src/main/java/cn/nukkit/resourcepacks/ResourcePackManager.java
@@ -81,9 +81,37 @@ public class ResourcePackManager {
         this.loaders.add(loader);
     }
 
+    /**
+     * 重新加载所有资源包。正在下载资源包的预登录玩家不做专门处理：其客户端锁定的
+     * 旧实例 size/SHA-256 校验失败后自行报错，重连即按新实例重新下载。
+     * <p>
+     * Players mid-download (pre-login) are not handled specially: the transfer
+     * they pinned fails validation on the client and they re-download from the
+     * new instances on rejoin.
+     * <p>
+     * 必须先关闭旧实例再加载：释放快照文件句柄后，loader 才能物理删除并重建
+     * 快照（Windows 上被句柄占用的名字处于 delete-pending，同名重建会以
+     * ERROR_ACCESS_DENIED 失败），同时避免旧实例的 fd 与快照磁盘空间泄漏。
+     * <p>
+     * Old instances are then closed before loading: only with their snapshot
+     * handles released can the loaders physically delete and re-create snapshot
+     * files (on Windows a pinned name stays delete-pending and re-creation fails
+     * with ERROR_ACCESS_DENIED), and it prevents the old instances' file
+     * descriptors and snapshot disk space from leaking.
+     * <p>
+     * 应在主线程调用（与玩家资源包下载同线程，保证关闭时无在途读取）。
+     * Must be called on the main thread (same thread as player pack downloads,
+     * so no chunk read can be in flight while an old instance is closed).
+     */
     public void reloadPacks() {
+        for (ResourcePack pack : this.allPacksById.values()) {
+            closePackQuietly(pack);
+        }
+        this.allPacksById.clear();
         this.resourcePacksById.clear();
         this.resourcePacks.clear();
+        this.behaviorPacksById.clear();
+        this.behaviorPacks.clear();
         this.loaders.forEach(loader -> {
             var loadedPacks = loader.loadPacks();
             loadedPacks.forEach(pack -> {
@@ -102,6 +130,16 @@ public class ResourcePackManager {
         this.applyPackConfig();
 
         log.info(Server.getInstance().getLanguage().translateString("nukkit.resources.success", String.valueOf(this.resourcePacks.size())));
+    }
+
+    private static void closePackQuietly(ResourcePack pack) {
+        if (pack instanceof AutoCloseable closeable) {
+            try {
+                closeable.close();
+            } catch (Exception e) {
+                log.debug("Failed to close resource pack {}", pack.getPackId(), e);
+            }
+        }
     }
 
     /**

--- a/src/main/java/cn/nukkit/resourcepacks/ZippedBehaviourPack.java
+++ b/src/main/java/cn/nukkit/resourcepacks/ZippedBehaviourPack.java
@@ -51,7 +51,12 @@ public class ZippedBehaviourPack extends ZippedResourcePack {
                         }
                     }
                 } catch (Exception ignored) {
-                    log.error("Error while loading behaviour pack manifest: {}", this.getPackName(), ignored);
+                    // getPackId（uuid 已通过 verifyManifest 校验）而非 getPackName：
+                    // NetEase 包可无 name，后者会 NPE 并掩盖原始异常。
+                    // getPackId (uuid validated by verifyManifest), not getPackName:
+                    // NetEase packs may lack a name and getPackName would NPE,
+                    // masking the original error.
+                    log.error("Error while loading behaviour pack manifest: {}", this.getPackId(), ignored);
                 }
             }
     }

--- a/src/main/java/cn/nukkit/resourcepacks/ZippedBehaviourPack.java
+++ b/src/main/java/cn/nukkit/resourcepacks/ZippedBehaviourPack.java
@@ -3,6 +3,7 @@ package cn.nukkit.resourcepacks;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import lombok.extern.log4j.Log4j2;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.io.File;
 
@@ -24,7 +25,15 @@ public class ZippedBehaviourPack extends ZippedResourcePack {
     }
 
     public ZippedBehaviourPack(File file, SupportType supportType) {
-        super(file, supportType);
+        this(file, supportType, false);
+    }
+
+    /**
+     * @see ZippedResourcePack#ZippedResourcePack(File, SupportType, boolean)
+     */
+    @ApiStatus.Internal
+    public ZippedBehaviourPack(File file, SupportType supportType, boolean alreadySnapshot) {
+        super(file, supportType, alreadySnapshot);
         if (this.manifest.has("modules"))
             for (JsonElement moduleElement : this.manifest.getAsJsonArray("modules")) {
                 try {

--- a/src/main/java/cn/nukkit/resourcepacks/ZippedResourcePack.java
+++ b/src/main/java/cn/nukkit/resourcepacks/ZippedResourcePack.java
@@ -3,20 +3,22 @@ package cn.nukkit.resourcepacks;
 import cn.nukkit.Server;
 import com.google.gson.JsonParser;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.io.RandomAccessFile;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.security.MessageDigest;
+import java.util.Arrays;
 import java.util.Locale;
 import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
+import java.util.zip.ZipInputStream;
 
 public class ZippedResourcePack extends AbstractResourcePack {
 
     private File file;
+    private byte[] packBytes;
     private byte[] sha256;
 
     public ZippedResourcePack(File file) {
@@ -40,29 +42,12 @@ public class ZippedResourcePack extends AbstractResourcePack {
         this.file = file;
         this.setSupportType(packType);
 
-        try (ZipFile zip = new ZipFile(file)) {
-            ZipEntry entry = zip.getEntry("manifest.json");
-            if (entry == null) {
-                entry = zip.getEntry("pack_manifest.json");
-            }
-            if (entry == null) {
-                entry = zip.stream()
-                        .filter(e-> !e.isDirectory() &&
-                                (e.getName().toLowerCase(Locale.ROOT).endsWith("manifest.json") || e.getName().toLowerCase(Locale.ROOT).endsWith("pack_manifest.json")))
-                        .filter(e-> {
-                            File fe = new File(e.getName());
-                            if (!fe.getName().equalsIgnoreCase("manifest.json") && !fe.getName().equalsIgnoreCase("pack_manifest.json")) {
-                                return false;
-                            }
-                            return fe.getParent() == null || fe.getParentFile().getParent() == null;
-                        })
-                        .findFirst()
-                        .orElseThrow(()-> new IllegalArgumentException(
-                                Server.getInstance().getLanguage().translateString("nukkit.resources.zip.no-manifest")));
-            }
-
+        try {
+            this.packBytes = Files.readAllBytes(file.toPath());
+            byte[] manifestBytes = findManifest(this.packBytes);
             this.manifest = new JsonParser()
-                    .parse(new InputStreamReader(zip.getInputStream(entry), StandardCharsets.UTF_8))
+                    .parse(new InputStreamReader(
+                            new ByteArrayInputStream(manifestBytes), StandardCharsets.UTF_8))
                     .getAsJsonObject();
 
             File parentFolder = this.file.getParentFile();
@@ -81,16 +66,60 @@ public class ZippedResourcePack extends AbstractResourcePack {
         }
     }
 
+    private static byte[] findManifest(byte[] archive) throws IOException {
+        byte[] rootPackManifest = null;
+        byte[] nestedManifest = null;
+        try (ZipInputStream zip = new ZipInputStream(new ByteArrayInputStream(archive))) {
+            ZipEntry entry;
+            while ((entry = zip.getNextEntry()) != null) {
+                if (entry.isDirectory()) {
+                    continue;
+                }
+                String name = entry.getName();
+                if (name.equals("manifest.json")) {
+                    return zip.readAllBytes();
+                }
+                if (name.equals("pack_manifest.json")) {
+                    rootPackManifest = zip.readAllBytes();
+                    continue;
+                }
+                if (nestedManifest != null) {
+                    continue;
+                }
+                String lowerName = name.toLowerCase(Locale.ROOT);
+                if (!lowerName.endsWith("manifest.json")
+                        && !lowerName.endsWith("pack_manifest.json")) {
+                    continue;
+                }
+                File manifestFile = new File(name);
+                if (!manifestFile.getName().equalsIgnoreCase("manifest.json")
+                        && !manifestFile.getName().equalsIgnoreCase("pack_manifest.json")) {
+                    continue;
+                }
+                if (manifestFile.getParent() == null
+                        || manifestFile.getParentFile().getParent() == null) {
+                    nestedManifest = zip.readAllBytes();
+                }
+            }
+        }
+        byte[] result = rootPackManifest != null ? rootPackManifest : nestedManifest;
+        if (result == null) {
+            throw new IllegalArgumentException(Server.getInstance().getLanguage()
+                    .translateString("nukkit.resources.zip.no-manifest"));
+        }
+        return result;
+    }
+
     @Override
     public int getPackSize() {
-        return (int) this.file.length();
+        return this.packBytes.length;
     }
 
     @Override
     public byte[] getSha256() {
         if (this.sha256 == null) {
             try {
-                this.sha256 = MessageDigest.getInstance("SHA-256").digest(Files.readAllBytes(this.file.toPath()));
+                this.sha256 = MessageDigest.getInstance("SHA-256").digest(this.packBytes);
             } catch (Exception e) {
                 Server.getInstance().getLogger().logException(e);
             }
@@ -100,25 +129,14 @@ public class ZippedResourcePack extends AbstractResourcePack {
 
     @Override
     public byte[] getPackChunk(int off, int len) {
-        int size = this.getPackSize();
+        int size = this.packBytes.length;
         byte[] chunk;
         if (size - off > len) {
             chunk = new byte[len];
         } else {
             chunk = new byte[size - off];
         }
-
-        if (chunk.length == 0) {
-            return chunk;
-        }
-        try (RandomAccessFile raf = new RandomAccessFile(this.file, "r")) {
-            raf.seek(off);
-            raf.readFully(chunk);
-        } catch (Exception e) {
-            Server.getInstance().getLogger().logException(e);
-        }
-
-        return chunk;
+        return Arrays.copyOfRange(this.packBytes, off, off + chunk.length);
     }
 
     /**

--- a/src/main/java/cn/nukkit/resourcepacks/ZippedResourcePack.java
+++ b/src/main/java/cn/nukkit/resourcepacks/ZippedResourcePack.java
@@ -7,6 +7,7 @@ import org.jetbrains.annotations.ApiStatus;
 
 import java.io.*;
 import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
 import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -30,10 +31,11 @@ public class ZippedResourcePack extends AbstractResourcePack implements Closeabl
     /** Test injection point for the snapshot cache root; null = DATA_PATH default. */
     static volatile File cacheRootOverride;
 
-    private File file;
     private FileChannel snapshotChannel;
     private int packSize;
     private byte[] sha256;
+    /** Guards against a stack trace per chunk once reloadPacks() has closed the channel. */
+    private boolean channelCloseReported;
 
     public ZippedResourcePack(File file) {
         this(file, SupportType.UNIVERSAL);
@@ -52,8 +54,9 @@ public class ZippedResourcePack extends AbstractResourcePack implements Closeabl
     }
 
     /**
-     * @param alreadySnapshot file is already a fresh private snapshot (produced by
-     *                        {@code ZippedResourcePackLoader#loadDirectoryPack}); held without copying
+     * @param alreadySnapshot file is a fresh private snapshot (produced by
+     *                        {@code ZippedResourcePackLoader#loadDirectoryPack}); the constructor takes
+     *                        ownership of it: held without copying, deleted here on failure
      */
     @ApiStatus.Internal
     public ZippedResourcePack(File file, SupportType packType, boolean alreadySnapshot) {
@@ -62,10 +65,9 @@ public class ZippedResourcePack extends AbstractResourcePack implements Closeabl
                     .translateString("nukkit.resources.zip.not-found", file.getName()));
         }
 
-        this.file = file;
         this.setSupportType(packType);
 
-        File parentFolder = this.file.getParentFile();
+        File parentFolder = file.getParentFile();
         if (parentFolder == null || !parentFolder.isDirectory()) {
             throw new IllegalArgumentException("Invalid resource pack path");
         }
@@ -73,7 +75,11 @@ public class ZippedResourcePack extends AbstractResourcePack implements Closeabl
         File snapshotTmp = null;
         try {
             if (alreadySnapshot) {
-                this.packSize = (int) file.length();
+                long length = file.length();
+                if (length > Integer.MAX_VALUE) {
+                    throw new IOException("Resource pack too large (" + length + " bytes): " + file.getName());
+                }
+                this.packSize = (int) length;
                 this.sha256 = digestFile(file);
             } else {
                 snapshotTmp = copyToSnapshot(file);
@@ -86,26 +92,28 @@ public class ZippedResourcePack extends AbstractResourcePack implements Closeabl
                         .translateString("nukkit.resources.zip.invalid-manifest"));
             }
             if (snapshotTmp != null) {
-                promoteSnapshot(snapshotTmp, file.getName());
+                promoteSnapshot(snapshotTmp, new File(snapshotTmp.getParentFile(), file.getName()));
             }
         } catch (IOException e) {
-            close();
-            if (snapshotTmp != null) {
-                //noinspection ResultOfMethodCallIgnored
-                snapshotTmp.delete();
-            }
+            cleanupOnFailure(snapshotTmp, alreadySnapshot ? file : null);
             throw new IllegalArgumentException(
                     "Failed to load resource pack snapshot: " + file.getName(), e);
         } catch (RuntimeException e) {
-            close();
-            if (snapshotTmp != null) {
-                //noinspection ResultOfMethodCallIgnored
-                snapshotTmp.delete();
-            }
+            cleanupOnFailure(snapshotTmp, alreadySnapshot ? file : null);
             throw e;
         }
         // 加密密钥只能来自 packs.yml（由 ResourcePackManager.applyPackConfig 注入）。
         // Encryption keys now come exclusively from packs.yml (injected by ResourcePackManager.applyPackConfig).
+    }
+
+    /** Releases the channel and deletes the orphaned snapshot so it cannot outlive the failed instance. */
+    private void cleanupOnFailure(File snapshotTmp, File ownedSnapshot) {
+        close();
+        File orphan = snapshotTmp != null ? snapshotTmp : ownedSnapshot;
+        if (orphan != null) {
+            //noinspection ResultOfMethodCallIgnored
+            orphan.delete();
+        }
     }
 
     private void loadManifest(File snapshot) throws IOException {
@@ -171,19 +179,28 @@ public class ZippedResourcePack extends AbstractResourcePack implements Closeabl
 
     /**
      * Renames the temp snapshot to a stable name for inspection and orphan cleanup.
-     * A failed rename is harmless: the pinned channel keeps serving the temp file.
+     * A failed rename is harmless: callers keep serving from the temp file, and the
+     * next {@code cleanSnapshotCache} sweep removes it once no channel pins it
+     * (on Windows the stable name is unusable while an old channel is still open,
+     * because the delete leaves it in the pending state where re-creation fails).
+     *
+     * @return whether the rename succeeded
      */
-    private static void promoteSnapshot(File tmp, String stableName) {
-        File stable = new File(tmp.getParentFile(), stableName);
+    @ApiStatus.Internal
+    public static boolean promoteSnapshot(File tmp, File stable) {
         try {
             Files.move(tmp.toPath(), stable.toPath(),
                     StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+            return true;
         } catch (java.nio.file.AtomicMoveNotSupportedException e) {
             try {
                 Files.move(tmp.toPath(), stable.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                return true;
             } catch (IOException ignored) {
+                return false;
             }
         } catch (IOException ignored) {
+            return false;
         }
     }
 
@@ -245,6 +262,15 @@ public class ZippedResourcePack extends AbstractResourcePack implements Closeabl
                     break;
                 }
             }
+        } catch (ClosedChannelException e) {
+            // Expected after reloadPacks() closed this instance: pre-login players
+            // whose in-flight download still pins the old instance (their client
+            // fails validation and re-downloads on rejoin), or a stale reference
+            // held by a plugin. Report once instead of a stack trace per chunk.
+            if (!this.channelCloseReported) {
+                this.channelCloseReported = true;
+                Server.getInstance().getLogger().logException(e);
+            }
         } catch (Exception e) {
             Server.getInstance().getLogger().logException(e);
         }
@@ -252,7 +278,12 @@ public class ZippedResourcePack extends AbstractResourcePack implements Closeabl
         return chunk;
     }
 
-    /** Closes the snapshot channel; packs live for the process lifetime, so explicit close is rarely needed. */
+    /**
+     * Closes the snapshot channel. Called by {@link ResourcePackManager#reloadPacks()}
+     * before replacing this instance: releasing the handle first lets the snapshot
+     * file be physically deleted and re-created (on Windows a pinned name stays in
+     * delete-pending state, blocking re-creation with ERROR_ACCESS_DENIED).
+     */
     @Override
     public void close() {
         if (this.snapshotChannel != null) {
@@ -261,6 +292,12 @@ public class ZippedResourcePack extends AbstractResourcePack implements Closeabl
             } catch (IOException ignored) {
             }
         }
+    }
+
+    /** Monitoring/test hook: whether the snapshot channel is closed. */
+    @ApiStatus.Internal
+    boolean isSnapshotClosed() {
+        return this.snapshotChannel == null || !this.snapshotChannel.isOpen();
     }
 
     /**

--- a/src/main/java/cn/nukkit/resourcepacks/ZippedResourcePack.java
+++ b/src/main/java/cn/nukkit/resourcepacks/ZippedResourcePack.java
@@ -1,24 +1,38 @@
 package cn.nukkit.resourcepacks;
 
+import cn.nukkit.Nukkit;
 import cn.nukkit.Server;
 import com.google.gson.JsonParser;
+import org.jetbrains.annotations.ApiStatus;
 
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStreamReader;
+import java.io.*;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
 import java.security.MessageDigest;
-import java.util.Arrays;
+import java.security.NoSuchAlgorithmException;
 import java.util.Locale;
 import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
+import java.util.zip.ZipFile;
 
-public class ZippedResourcePack extends AbstractResourcePack {
+/**
+ * 构造时把源归档复制为磁盘快照，此后所有数据均从钉在该副本上的 FileChannel 读取。
+ * <p>
+ * The source archive is copied to a disk snapshot at construction; everything is
+ * then served from a FileChannel pinned to that copy, so replacing the source
+ * at runtime cannot mix identities.
+ */
+public class ZippedResourcePack extends AbstractResourcePack implements Closeable {
+
+    /** Test injection point for the snapshot cache root; null = DATA_PATH default. */
+    static volatile File cacheRootOverride;
 
     private File file;
-    private byte[] packBytes;
+    private FileChannel snapshotChannel;
+    private int packSize;
     private byte[] sha256;
 
     public ZippedResourcePack(File file) {
@@ -34,6 +48,15 @@ public class ZippedResourcePack extends AbstractResourcePack {
     }
 
     public ZippedResourcePack(File file, SupportType packType) {
+        this(file, packType, false);
+    }
+
+    /**
+     * @param alreadySnapshot file is already a fresh private snapshot (produced by
+     *                        {@code ZippedResourcePackLoader#loadDirectoryPack}); held without copying
+     */
+    @ApiStatus.Internal
+    public ZippedResourcePack(File file, SupportType packType, boolean alreadySnapshot) {
         if (!file.exists()) {
             throw new IllegalArgumentException(Server.getInstance().getLanguage()
                     .translateString("nukkit.resources.zip.not-found", file.getName()));
@@ -42,101 +65,202 @@ public class ZippedResourcePack extends AbstractResourcePack {
         this.file = file;
         this.setSupportType(packType);
 
-        try {
-            this.packBytes = Files.readAllBytes(file.toPath());
-            byte[] manifestBytes = findManifest(this.packBytes);
-            this.manifest = new JsonParser()
-                    .parse(new InputStreamReader(
-                            new ByteArrayInputStream(manifestBytes), StandardCharsets.UTF_8))
-                    .getAsJsonObject();
-
-            File parentFolder = this.file.getParentFile();
-            if (parentFolder == null || !parentFolder.isDirectory()) {
-                throw new IOException("Invalid resource pack path");
-            }
-            // 加密密钥只能来自 packs.yml（由 ResourcePackManager.applyPackConfig 注入）。
-            // Encryption keys now come exclusively from packs.yml (injected by ResourcePackManager.applyPackConfig).
-        } catch (IOException e) {
-            Server.getInstance().getLogger().logException(e);
+        File parentFolder = this.file.getParentFile();
+        if (parentFolder == null || !parentFolder.isDirectory()) {
+            throw new IllegalArgumentException("Invalid resource pack path");
         }
 
-        if (!this.verifyManifest()) {
-            throw new IllegalArgumentException(Server.getInstance().getLanguage()
-                    .translateString("nukkit.resources.zip.invalid-manifest"));
+        File snapshotTmp = null;
+        try {
+            if (alreadySnapshot) {
+                this.packSize = (int) file.length();
+                this.sha256 = digestFile(file);
+            } else {
+                snapshotTmp = copyToSnapshot(file);
+            }
+            File snapshot = snapshotTmp != null ? snapshotTmp : file;
+            this.snapshotChannel = FileChannel.open(snapshot.toPath(), StandardOpenOption.READ);
+            loadManifest(snapshot);
+            if (!this.verifyManifest()) {
+                throw new IllegalArgumentException(Server.getInstance().getLanguage()
+                        .translateString("nukkit.resources.zip.invalid-manifest"));
+            }
+            if (snapshotTmp != null) {
+                promoteSnapshot(snapshotTmp, file.getName());
+            }
+        } catch (IOException e) {
+            close();
+            if (snapshotTmp != null) {
+                //noinspection ResultOfMethodCallIgnored
+                snapshotTmp.delete();
+            }
+            throw new IllegalArgumentException(
+                    "Failed to load resource pack snapshot: " + file.getName(), e);
+        } catch (RuntimeException e) {
+            close();
+            if (snapshotTmp != null) {
+                //noinspection ResultOfMethodCallIgnored
+                snapshotTmp.delete();
+            }
+            throw e;
+        }
+        // 加密密钥只能来自 packs.yml（由 ResourcePackManager.applyPackConfig 注入）。
+        // Encryption keys now come exclusively from packs.yml (injected by ResourcePackManager.applyPackConfig).
+    }
+
+    private void loadManifest(File snapshot) throws IOException {
+        try (ZipFile zip = new ZipFile(snapshot)) {
+            ZipEntry entry = zip.getEntry("manifest.json");
+            if (entry == null) {
+                entry = zip.getEntry("pack_manifest.json");
+            }
+            if (entry == null) {
+                entry = zip.stream()
+                        .filter(e -> !e.isDirectory() &&
+                                (e.getName().toLowerCase(Locale.ROOT).endsWith("manifest.json") || e.getName().toLowerCase(Locale.ROOT).endsWith("pack_manifest.json")))
+                        .filter(e -> {
+                            File fe = new File(e.getName());
+                            if (!fe.getName().equalsIgnoreCase("manifest.json") && !fe.getName().equalsIgnoreCase("pack_manifest.json")) {
+                                return false;
+                            }
+                            return fe.getParent() == null || fe.getParentFile().getParent() == null;
+                        })
+                        .findFirst()
+                        .orElseThrow(() -> new IllegalArgumentException(
+                                Server.getInstance().getLanguage().translateString("nukkit.resources.zip.no-manifest")));
+            }
+
+            this.manifest = new JsonParser()
+                    .parse(new InputStreamReader(zip.getInputStream(entry), StandardCharsets.UTF_8))
+                    .getAsJsonObject();
         }
     }
 
-    private static byte[] findManifest(byte[] archive) throws IOException {
-        byte[] rootPackManifest = null;
-        byte[] nestedManifest = null;
-        try (ZipInputStream zip = new ZipInputStream(new ByteArrayInputStream(archive))) {
-            ZipEntry entry;
-            while ((entry = zip.getNextEntry()) != null) {
-                if (entry.isDirectory()) {
-                    continue;
-                }
-                String name = entry.getName();
-                if (name.equals("manifest.json")) {
-                    return zip.readAllBytes();
-                }
-                if (name.equals("pack_manifest.json")) {
-                    rootPackManifest = zip.readAllBytes();
-                    continue;
-                }
-                if (nestedManifest != null) {
-                    continue;
-                }
-                String lowerName = name.toLowerCase(Locale.ROOT);
-                if (!lowerName.endsWith("manifest.json")
-                        && !lowerName.endsWith("pack_manifest.json")) {
-                    continue;
-                }
-                File manifestFile = new File(name);
-                if (!manifestFile.getName().equalsIgnoreCase("manifest.json")
-                        && !manifestFile.getName().equalsIgnoreCase("pack_manifest.json")) {
-                    continue;
-                }
-                if (manifestFile.getParent() == null
-                        || manifestFile.getParentFile().getParent() == null) {
-                    nestedManifest = zip.readAllBytes();
-                }
+    /** Stream-copies the source to a temp cache file, computing size and SHA-256 in the same pass. */
+    private File copyToSnapshot(File source) throws IOException {
+        File cacheDir = new File(snapshotCacheRoot(), source.getParentFile().getName());
+        Files.createDirectories(cacheDir.toPath());
+        File tmp = new File(cacheDir,
+                source.getName() + "." + Long.toUnsignedString(System.nanoTime(), 36) + ".tmp");
+        MessageDigest digest = sha256Digest();
+        long total = 0;
+        try (InputStream in = Files.newInputStream(source.toPath());
+             OutputStream out = Files.newOutputStream(tmp.toPath(),
+                     StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE)) {
+            byte[] buffer = new byte[64 * 1024];
+            int read;
+            while ((read = in.read(buffer)) != -1) {
+                digest.update(buffer, 0, read);
+                out.write(buffer, 0, read);
+                total += read;
+            }
+        } catch (IOException e) {
+            //noinspection ResultOfMethodCallIgnored
+            tmp.delete();
+            throw e;
+        }
+        if (total > Integer.MAX_VALUE) {
+            //noinspection ResultOfMethodCallIgnored
+            tmp.delete();
+            throw new IOException("Resource pack too large (" + total + " bytes): " + source.getName());
+        }
+        this.packSize = (int) total;
+        this.sha256 = digest.digest();
+        return tmp;
+    }
+
+    /**
+     * Renames the temp snapshot to a stable name for inspection and orphan cleanup.
+     * A failed rename is harmless: the pinned channel keeps serving the temp file.
+     */
+    private static void promoteSnapshot(File tmp, String stableName) {
+        File stable = new File(tmp.getParentFile(), stableName);
+        try {
+            Files.move(tmp.toPath(), stable.toPath(),
+                    StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+        } catch (java.nio.file.AtomicMoveNotSupportedException e) {
+            try {
+                Files.move(tmp.toPath(), stable.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            } catch (IOException ignored) {
+            }
+        } catch (IOException ignored) {
+        }
+    }
+
+    private static byte[] digestFile(File file) throws IOException {
+        MessageDigest digest = sha256Digest();
+        try (InputStream in = Files.newInputStream(file.toPath())) {
+            byte[] buffer = new byte[64 * 1024];
+            int read;
+            while ((read = in.read(buffer)) != -1) {
+                digest.update(buffer, 0, read);
             }
         }
-        byte[] result = rootPackManifest != null ? rootPackManifest : nestedManifest;
-        if (result == null) {
-            throw new IllegalArgumentException(Server.getInstance().getLanguage()
-                    .translateString("nukkit.resources.zip.no-manifest"));
+        return digest.digest();
+    }
+
+    private static MessageDigest sha256Digest() {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 digest unavailable", e);
         }
-        return result;
+    }
+
+    /** Snapshot cache root; the package-private {@link #cacheRootOverride} is for tests only. */
+    @ApiStatus.Internal
+    public static File snapshotCacheRoot() {
+        return cacheRootOverride != null ? cacheRootOverride
+                : new File(Nukkit.DATA_PATH, "cache/resourcepacks");
     }
 
     @Override
     public int getPackSize() {
-        return this.packBytes.length;
+        return this.packSize;
     }
 
     @Override
     public byte[] getSha256() {
-        if (this.sha256 == null) {
-            try {
-                this.sha256 = MessageDigest.getInstance("SHA-256").digest(this.packBytes);
-            } catch (Exception e) {
-                Server.getInstance().getLogger().logException(e);
-            }
-        }
         return this.sha256;
     }
 
     @Override
     public byte[] getPackChunk(int off, int len) {
-        int size = this.packBytes.length;
+        int size = this.packSize;
         byte[] chunk;
         if (size - off > len) {
             chunk = new byte[len];
         } else {
             chunk = new byte[size - off];
         }
-        return Arrays.copyOfRange(this.packBytes, off, off + chunk.length);
+
+        if (chunk.length == 0) {
+            return chunk;
+        }
+        try {
+            ByteBuffer buffer = ByteBuffer.wrap(chunk);
+            while (buffer.hasRemaining()) {
+                // positional read: thread-safe, independent of the channel position
+                if (this.snapshotChannel.read(buffer, off + buffer.position()) < 0) {
+                    break;
+                }
+            }
+        } catch (Exception e) {
+            Server.getInstance().getLogger().logException(e);
+        }
+
+        return chunk;
+    }
+
+    /** Closes the snapshot channel; packs live for the process lifetime, so explicit close is rarely needed. */
+    @Override
+    public void close() {
+        if (this.snapshotChannel != null) {
+            try {
+                this.snapshotChannel.close();
+            } catch (IOException ignored) {
+            }
+        }
     }
 
     /**

--- a/src/main/java/cn/nukkit/resourcepacks/loader/ZippedBehaviourPackLoader.java
+++ b/src/main/java/cn/nukkit/resourcepacks/loader/ZippedBehaviourPackLoader.java
@@ -32,6 +32,7 @@ public class ZippedBehaviourPackLoader extends ZippedResourcePackLoader {
 
     @Override
     public List<ResourcePack> loadPacks() {
+        cleanSnapshotCache();
         BaseLang baseLang = Server.getInstance().getLanguage();
         List<ResourcePack> loadedResourcePacks = new ArrayList<>();
         for (File pack : this.path.listFiles()) {
@@ -45,7 +46,7 @@ public class ZippedBehaviourPackLoader extends ZippedResourcePackLoader {
                 if (pack.isDirectory()) {
                     File file = loadDirectoryPack(pack);
                     if (file != null)
-                        resourcePack = new ZippedBehaviourPack(file, packType);
+                        resourcePack = new ZippedBehaviourPack(file, packType, true);
                 } else {
                     switch (fileExt) {
                         case "zip":

--- a/src/main/java/cn/nukkit/resourcepacks/loader/ZippedBehaviourPackLoader.java
+++ b/src/main/java/cn/nukkit/resourcepacks/loader/ZippedBehaviourPackLoader.java
@@ -62,7 +62,9 @@ public class ZippedBehaviourPackLoader extends ZippedResourcePackLoader {
                     loadedResourcePacks.add(resourcePack);
                     log.info(baseLang.translateString("nukkit.resources.zip.loaded", pack.getName()));
                 }
-            } catch (IllegalArgumentException e) {
+            } catch (RuntimeException e) {
+                // IllegalArgumentException = bad pack (skip); RuntimeException also covers
+                // loadDirectoryPack I/O failures, so one broken pack cannot abort the whole load
                 log.warn(baseLang.translateString("nukkit.resources.fail", pack.getName(), e.getMessage()), e);
             }
         }

--- a/src/main/java/cn/nukkit/resourcepacks/loader/ZippedResourcePackLoader.java
+++ b/src/main/java/cn/nukkit/resourcepacks/loader/ZippedResourcePackLoader.java
@@ -71,6 +71,7 @@ public class ZippedResourcePackLoader implements ResourcePackLoader {
 
     @Override
     public List<ResourcePack> loadPacks() {
+        cleanSnapshotCache();
         var baseLang = Server.getInstance().getLanguage();
         List<ResourcePack> loadedResourcePacks = new ArrayList<>();
         for (File pack : path.listFiles()) {
@@ -84,7 +85,7 @@ public class ZippedResourcePackLoader implements ResourcePackLoader {
                 if (pack.isDirectory()) {
                     File file = loadDirectoryPack(pack);
                     if (file != null) {
-                        resourcePack = new ZippedResourcePack(file, packType);
+                        resourcePack = new ZippedResourcePack(file, packType, true);
                     }
                 } else {
                     switch (fileExt) {
@@ -103,6 +104,24 @@ public class ZippedResourcePackLoader implements ResourcePackLoader {
         return loadedResourcePacks;
     }
 
+    /**
+     * Wipes this loader's snapshot cache dir: crash leftovers ({@code *.tmp}) and
+     * orphans of removed packs. Instances still holding a channel keep serving
+     * until it closes (POSIX: inode stays alive; Windows: deferred delete).
+     */
+    protected void cleanSnapshotCache() {
+        File cacheDir = new File(ZippedResourcePack.snapshotCacheRoot(), this.path.getName());
+        File[] children = cacheDir.listFiles();
+        if (children == null) {
+            return;
+        }
+        for (File child : children) {
+            if (!child.delete()) {
+                log.debug("Failed to delete resource pack snapshot cache entry: {}", child);
+            }
+        }
+    }
+
     protected static File loadDirectoryPack(File directory) {
         File manifestFile = new File(directory, "manifest.json");
         if (!manifestFile.exists() || !manifestFile.isFile()) {
@@ -112,13 +131,20 @@ public class ZippedResourcePackLoader implements ResourcePackLoader {
             }
         }
 
-        File tempFile;
+        File snapshotFile;
         try {
-            tempFile = File.createTempFile("pack", ".zip");
-            tempFile.deleteOnExit();
+            // Written straight into the snapshot cache: already a fresh private
+            // snapshot, and safe from /tmp reapers on long-running servers.
+            File parent = directory.getParentFile();
+            File cacheDir = parent != null
+                    ? new File(ZippedResourcePack.snapshotCacheRoot(), parent.getName())
+                    : ZippedResourcePack.snapshotCacheRoot();
+            //noinspection ResultOfMethodCallIgnored
+            cacheDir.mkdirs();
+            snapshotFile = new File(cacheDir, directory.getName() + ".zip");
 
             FileTime time = FileTime.fromMillis(0);
-            try (ZipOutputStream stream = new ZipOutputStream(new FileOutputStream(tempFile))) {
+            try (ZipOutputStream stream = new ZipOutputStream(new FileOutputStream(snapshotFile))) {
                 stream.setLevel(Deflater.BEST_COMPRESSION);
                 Collection<File> files = new TreeSet<>(FileUtils.listFiles(directory)); // todo: add further checks
                 for (File file : files) {
@@ -146,7 +172,7 @@ public class ZippedResourcePackLoader implements ResourcePackLoader {
         } catch (IOException e) {
             throw new RuntimeException("Unable to create temporary mcpack file", e);
         }
-        return tempFile;
+        return snapshotFile;
     }
 
     protected static List<File> getDirectoryFiles(File directory) {

--- a/src/main/java/cn/nukkit/resourcepacks/loader/ZippedResourcePackLoader.java
+++ b/src/main/java/cn/nukkit/resourcepacks/loader/ZippedResourcePackLoader.java
@@ -97,7 +97,9 @@ public class ZippedResourcePackLoader implements ResourcePackLoader {
                     loadedResourcePacks.add(resourcePack);
                     log.info(baseLang.translateString("nukkit.resources.zip.loaded", pack.getName()));
                 }
-            } catch (IllegalArgumentException e) {
+            } catch (RuntimeException e) {
+                // IllegalArgumentException = bad pack (skip); RuntimeException also covers
+                // loadDirectoryPack I/O failures, so one broken pack cannot abort the whole load
                 log.warn(baseLang.translateString("nukkit.resources.fail", pack.getName(), e.getMessage()), e);
             }
         }
@@ -106,8 +108,11 @@ public class ZippedResourcePackLoader implements ResourcePackLoader {
 
     /**
      * Wipes this loader's snapshot cache dir: crash leftovers ({@code *.tmp}) and
-     * orphans of removed packs. Instances still holding a channel keep serving
-     * until it closes (POSIX: inode stays alive; Windows: deferred delete).
+     * orphans of removed packs. Instances still holding a channel keep serving from
+     * the unlinked inode (POSIX); on Windows, because channels open files with
+     * FILE_SHARE_DELETE, the delete succeeds but stays pending until the channel
+     * closes — which is why {@code ResourcePackManager.reloadPacks()} closes old
+     * instances before reloading.
      */
     protected void cleanSnapshotCache() {
         File cacheDir = new File(ZippedResourcePack.snapshotCacheRoot(), this.path.getName());
@@ -131,7 +136,7 @@ public class ZippedResourcePackLoader implements ResourcePackLoader {
             }
         }
 
-        File snapshotFile;
+        File snapshotFile = null;
         try {
             // Written straight into the snapshot cache: already a fresh private
             // snapshot, and safe from /tmp reapers on long-running servers.
@@ -141,7 +146,11 @@ public class ZippedResourcePackLoader implements ResourcePackLoader {
                     : ZippedResourcePack.snapshotCacheRoot();
             //noinspection ResultOfMethodCallIgnored
             cacheDir.mkdirs();
-            snapshotFile = new File(cacheDir, directory.getName() + ".zip");
+            // Unique temp name: if a previous instance still pins the stable name
+            // (Windows delete-pending), re-creating it would fail — the tmp file is
+            // always creatable, and promotion to the stable name degrades gracefully.
+            snapshotFile = new File(cacheDir,
+                    directory.getName() + ".zip." + Long.toUnsignedString(System.nanoTime(), 36) + ".tmp");
 
             FileTime time = FileTime.fromMillis(0);
             try (ZipOutputStream stream = new ZipOutputStream(new FileOutputStream(snapshotFile))) {
@@ -170,9 +179,14 @@ public class ZippedResourcePackLoader implements ResourcePackLoader {
                 }
             }
         } catch (IOException e) {
+            if (snapshotFile != null) {
+                //noinspection ResultOfMethodCallIgnored
+                snapshotFile.delete();
+            }
             throw new RuntimeException("Unable to create temporary mcpack file", e);
         }
-        return snapshotFile;
+        File stable = new File(snapshotFile.getParentFile(), directory.getName() + ".zip");
+        return ZippedResourcePack.promoteSnapshot(snapshotFile, stable) ? stable : snapshotFile;
     }
 
     protected static List<File> getDirectoryFiles(File directory) {

--- a/src/test/java/cn/nukkit/resourcepacks/ResourcePackManagerReloadTest.java
+++ b/src/test/java/cn/nukkit/resourcepacks/ResourcePackManagerReloadTest.java
@@ -1,0 +1,157 @@
+package cn.nukkit.resourcepacks;
+
+import cn.nukkit.GameVersion;
+import cn.nukkit.MockServer;
+import cn.nukkit.Server;
+import cn.nukkit.lang.BaseLang;
+import cn.nukkit.resourcepacks.loader.ResourcePackLoader;
+import cn.nukkit.resourcepacks.loader.ZippedBehaviourPackLoader;
+import cn.nukkit.resourcepacks.loader.ZippedResourcePackLoader;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * reloadPacks() 语义：close-before-load 顺序、重载不累积条目。
+ * <p>
+ * reloadPacks() semantics: close-before-load ordering and no entry
+ * accumulation across reloads.
+ */
+class ResourcePackManagerReloadTest {
+
+    private static final String VALID_UUID = "12345678-1234-1234-1234-123456789012";
+
+    @TempDir
+    Path tempDir;
+
+    private File resourcePacksDir;
+    private File behaviourPacksDir;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        MockServer.reset();
+        BaseLang language = mock(BaseLang.class);
+        when(language.translateString(any(String.class), any(Object[].class))).thenReturn("loaded");
+        when(Server.getInstance().getLanguage()).thenReturn(language);
+        resourcePacksDir = Files.createDirectories(tempDir.resolve("resource_packs")).toFile();
+        behaviourPacksDir = Files.createDirectories(tempDir.resolve("behaviour_packs")).toFile();
+        ZippedResourcePack.cacheRootOverride = tempDir.resolve("snapshot-cache").toFile();
+    }
+
+    @AfterEach
+    void tearDown() {
+        ZippedResourcePack.cacheRootOverride = null;
+    }
+
+    private void createPackZip(File dir, String name, String moduleType) throws Exception {
+        String manifest = "{\"format_version\":2,\"header\":{\"name\":\"T\",\"description\":\"d\","
+                + "\"uuid\":\"" + VALID_UUID + "\",\"version\":[1,0,0],\"min_engine_version\":[1,21,0]},"
+                + "\"modules\":[{\"type\":\"" + moduleType + "\","
+                + "\"uuid\":\"87654321-4321-4321-4321-210987654321\",\"version\":[1,0,0]}]}";
+        File packFile = new File(dir, name + ".zip");
+        try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(packFile))) {
+            zos.putNextEntry(new ZipEntry("manifest.json"));
+            zos.write(manifest.getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+        }
+    }
+
+    private ResourcePackManager newManager(ResourcePackLoader... loaders) {
+        return new ResourcePackManager(Set.of(loaders), tempDir.resolve("packs.yml").toFile());
+    }
+
+    @Test
+    void reloadClosesOldInstancesBeforeLoadingNewOnes() throws Exception {
+        File packFile = new File(resourcePacksDir, "reloadable.zip");
+        createPackZip(resourcePacksDir, "reloadable", "resources");
+
+        class OrderRecordingLoader implements ResourcePackLoader {
+            ZippedResourcePack lastLoaded;
+
+            @Override
+            public List<ResourcePack> loadPacks() {
+                if (this.lastLoaded != null && !this.lastLoaded.isSnapshotClosed()) {
+                    throw new AssertionError("old pack instance must be closed before loaders run "
+                            + "(Windows: a pinned snapshot name cannot be re-created)");
+                }
+                this.lastLoaded = new ZippedResourcePack(packFile);
+                return List.of(this.lastLoaded);
+            }
+        }
+        OrderRecordingLoader loader = new OrderRecordingLoader();
+        ResourcePackManager manager = newManager(loader);
+        ZippedResourcePack first = loader.lastLoaded;
+        assertNotNull(first);
+        assertFalse(first.isSnapshotClosed());
+
+        manager.reloadPacks();
+
+        assertTrue(first.isSnapshotClosed(), "old instance must be closed after reload");
+        assertNotSame(first, loader.lastLoaded);
+        assertFalse(loader.lastLoaded.isSnapshotClosed(), "new instance must keep serving");
+        assertSame(loader.lastLoaded, manager.getPackById(first.getPackId()),
+                "reload must re-register the new instance under the same pack id");
+    }
+
+    @Test
+    void reloadClosesInstancesShadowedByDuplicatePackId() throws Exception {
+        // 两个同 UUID 的包：allPacksById 只保留后加载者，resourcePacks set 按 equals
+        // （packId）去重只保留先加载者 — 后者不在 map 里，漏关即泄漏快照 channel。
+        // <p>
+        // Two packs sharing a UUID: allPacksById keeps only the later one, while
+        // the resourcePacks set (deduped by equals = packId) keeps only the
+        // earlier one — the shadowed instance is absent from the map, so missing
+        // it on close leaks the snapshot channel.
+        createPackZip(resourcePacksDir, "dup-a", "resources");
+        createPackZip(resourcePacksDir, "dup-b", "resources");
+        ResourcePackManager manager = newManager(new ZippedResourcePackLoader(resourcePacksDir));
+
+        // 与 listFiles 顺序无关：set 持有先加载者，map 持有后加载者，二者必为不同实例
+        ZippedResourcePack fromStack = (ZippedResourcePack) manager.getResourceStack(GameVersion.getLastVersion())[0];
+        ZippedResourcePack fromMap = (ZippedResourcePack) manager.getPackById(UUID.fromString(VALID_UUID));
+        assertNotSame(fromStack, fromMap, "same-UUID packs must yield two distinct live instances");
+        assertFalse(fromStack.isSnapshotClosed());
+        assertFalse(fromMap.isSnapshotClosed());
+
+        manager.reloadPacks();
+
+        assertTrue(fromStack.isSnapshotClosed(), "shadowed instance (set-only) must be closed on reload");
+        assertTrue(fromMap.isSnapshotClosed(), "winning instance (map) must be closed on reload");
+    }
+
+    @Test
+    void reloadDoesNotAccumulatePackEntries() throws Exception {
+        createPackZip(resourcePacksDir, "plain", "resources");
+        createPackZip(behaviourPacksDir, "behaviour", "data");
+        ResourcePackManager manager = newManager(
+                new ZippedResourcePackLoader(resourcePacksDir),
+                new ZippedBehaviourPackLoader(behaviourPacksDir));
+        GameVersion version = GameVersion.getLastVersion();
+        assertEquals(1, manager.getResourceStack(version).length);
+        assertEquals(1, manager.getBehaviorStack(version).length);
+
+        manager.reloadPacks();
+
+        assertEquals(1, manager.getResourceStack(version).length,
+                "resource pack entries must not accumulate across reloads");
+        assertEquals(1, manager.getBehaviorStack(version).length,
+                "behaviour pack entries must not accumulate across reloads");
+    }
+}

--- a/src/test/java/cn/nukkit/resourcepacks/ZippedResourcePackChunkIntegrityTest.java
+++ b/src/test/java/cn/nukkit/resourcepacks/ZippedResourcePackChunkIntegrityTest.java
@@ -3,6 +3,7 @@ package cn.nukkit.resourcepacks;
 import cn.nukkit.MockServer;
 import cn.nukkit.Server;
 import cn.nukkit.lang.BaseLang;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -40,6 +41,12 @@ class ZippedResourcePackChunkIntegrityTest {
         BaseLang language = mock(BaseLang.class);
         when(language.translateString(any(String.class), any(Object[].class))).thenReturn("loaded");
         when(Server.getInstance().getLanguage()).thenReturn(language);
+        ZippedResourcePack.cacheRootOverride = tempDir.resolve("snapshot-cache").toFile();
+    }
+
+    @AfterEach
+    void tearDown() {
+        ZippedResourcePack.cacheRootOverride = null;
     }
 
     @Test
@@ -124,5 +131,42 @@ class ZippedResourcePackChunkIntegrityTest {
         }
         assertArrayEquals(expectedArchive, reassembled.toByteArray(),
                 "a running server must not mix a startup manifest with replacement bytes");
+    }
+
+    @Test
+    void sourceRemovedAfterLoadStillServesSnapshotFromCache() throws Exception {
+        String manifest = "{\"format_version\":2,\"header\":{\"name\":\"T\",\"description\":\"d\","
+                + "\"uuid\":\"12345678-1234-1234-1234-123456789012\",\"version\":[1,0,0],"
+                + "\"min_engine_version\":[1,21,0]},\"modules\":[{\"type\":\"resources\","
+                + "\"uuid\":\"87654321-4321-4321-4321-210987654321\",\"version\":[1,0,0]}]}";
+        File packFile = tempDir.resolve("removable.zip").toFile();
+        try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(packFile))) {
+            zos.putNextEntry(new ZipEntry("manifest.json"));
+            zos.write(manifest.getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+            zos.putNextEntry(new ZipEntry("data/blob.bin"));
+            zos.write(new byte[150 * 1024]);
+            zos.closeEntry();
+        }
+        byte[] expectedArchive = Files.readAllBytes(packFile.toPath());
+
+        ZippedResourcePack pack = new ZippedResourcePack(packFile);
+
+        // Source deleted at runtime (deployment cleanup); serving must not be affected
+        Files.delete(packFile.toPath());
+
+        assertEquals(expectedArchive.length, pack.getPackSize());
+        java.io.ByteArrayOutputStream reassembled = new java.io.ByteArrayOutputStream();
+        for (int off = 0; off < pack.getPackSize(); off += 100 * 1024) {
+            reassembled.write(pack.getPackChunk(off, 100 * 1024));
+        }
+        assertArrayEquals(expectedArchive, reassembled.toByteArray());
+
+        // The snapshot copy must live under the injected cache root, not DATA_PATH
+        try (var snapshots = Files.walk(tempDir.resolve("snapshot-cache"))) {
+            assertTrue(snapshots.filter(Files::isRegularFile)
+                            .anyMatch(p -> p.getFileName().toString().startsWith("removable.zip")),
+                    "snapshot copy should exist under the cache root");
+        }
     }
 }

--- a/src/test/java/cn/nukkit/resourcepacks/ZippedResourcePackChunkIntegrityTest.java
+++ b/src/test/java/cn/nukkit/resourcepacks/ZippedResourcePackChunkIntegrityTest.java
@@ -169,4 +169,47 @@ class ZippedResourcePackChunkIntegrityTest {
                     "snapshot copy should exist under the cache root");
         }
     }
+
+    @Test
+    void malformedManifestsAreRejectedWithoutLeakingSnapshot() throws Exception {
+        // 每个变体此前都能通过旧的 verifyManifest（只查字段存在性），随后在构造成功
+        // 之后的解析点抛异常（ZippedBehaviourPack 的 modules 扫描、getPackId）——那条
+        // 路径没有清理入口，会泄漏已打开的快照 channel。现在必须在 verify 阶段拒绝，
+        // 且失败清理不得留下快照文件。
+        String[] malformedManifests = {
+                // "modules" present but not an array
+                "{\"format_version\":2,\"header\":{\"name\":\"T\",\"description\":\"d\","
+                        + "\"uuid\":\"12345678-1234-1234-1234-123456789012\",\"version\":[1,0,0]},"
+                        + "\"modules\":\"oops\"}",
+                // header present but not an object
+                "{\"format_version\":2,\"header\":\"oops\",\"modules\":[]}",
+                // uuid present but unparseable (getPackId would throw later in the manager)
+                "{\"format_version\":2,\"header\":{\"name\":\"T\",\"description\":\"d\","
+                        + "\"uuid\":\"not-a-uuid\",\"version\":[1,0,0]},\"modules\":[]}",
+                // uuid not a string at all
+                "{\"format_version\":2,\"header\":{\"name\":\"T\",\"description\":\"d\","
+                        + "\"uuid\":12345,\"version\":[1,0,0]},\"modules\":[]}",
+                // version present but not a 3-element array
+                "{\"format_version\":2,\"header\":{\"name\":\"T\",\"description\":\"d\","
+                        + "\"uuid\":\"12345678-1234-1234-1234-123456789012\",\"version\":\"1.0.0\"},"
+                        + "\"modules\":[]}",
+        };
+        for (String manifest : malformedManifests) {
+            File packFile = tempDir.resolve("malformed.zip").toFile();
+            try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(packFile))) {
+                zos.putNextEntry(new ZipEntry("manifest.json"));
+                zos.write(manifest.getBytes(StandardCharsets.UTF_8));
+                zos.closeEntry();
+            }
+
+            assertThrows(IllegalArgumentException.class,
+                    () -> new ZippedBehaviourPack(packFile, ResourcePack.SupportType.UNIVERSAL),
+                    "manifest must be rejected at verify time: " + manifest);
+
+            try (var leftovers = Files.walk(tempDir.resolve("snapshot-cache"))) {
+                assertFalse(leftovers.filter(Files::isRegularFile).findAny().isPresent(),
+                        "rejected manifest must not leave a snapshot file behind: " + manifest);
+            }
+        }
+    }
 }

--- a/src/test/java/cn/nukkit/resourcepacks/ZippedResourcePackChunkIntegrityTest.java
+++ b/src/test/java/cn/nukkit/resourcepacks/ZippedResourcePackChunkIntegrityTest.java
@@ -91,4 +91,38 @@ class ZippedResourcePackChunkIntegrityTest {
         assertArrayEquals(expectedSha, MessageDigest.getInstance("SHA-256").digest(reassembledBytes),
                 "reassembled SHA-256 mismatch (client would reject this pack)");
     }
+
+    @Test
+    void replacementAfterLoadKeepsOneConsistentArchive() throws Exception {
+        String manifest = "{\"format_version\":2,\"header\":{\"name\":\"T\",\"description\":\"d\","
+                + "\"uuid\":\"12345678-1234-1234-1234-123456789012\",\"version\":[1,0,0],"
+                + "\"min_engine_version\":[1,21,0]},\"modules\":[{\"type\":\"resources\","
+                + "\"uuid\":\"87654321-4321-4321-4321-210987654321\",\"version\":[1,0,0]}]}";
+        File packFile = tempDir.resolve("replaceable.zip").toFile();
+        try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(packFile))) {
+            zos.putNextEntry(new ZipEntry("manifest.json"));
+            zos.write(manifest.getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+            zos.putNextEntry(new ZipEntry("textures/icon.png"));
+            zos.write(new byte[] {1, 2, 3, 4});
+            zos.closeEntry();
+        }
+
+        byte[] expectedArchive = Files.readAllBytes(packFile.toPath());
+        byte[] expectedSha = MessageDigest.getInstance("SHA-256").digest(expectedArchive);
+        ZippedResourcePack pack = new ZippedResourcePack(packFile);
+
+        Files.writeString(packFile.toPath(), "a different archive was deployed while the server stayed online");
+
+        assertEquals(expectedArchive.length, pack.getPackSize());
+        assertEquals("1.0.0", pack.getPackVersion());
+        assertArrayEquals(expectedSha, pack.getSha256());
+        java.io.ByteArrayOutputStream reassembled = new java.io.ByteArrayOutputStream();
+        int chunkSize = 17;
+        for (int off = 0; off < pack.getPackSize(); off += chunkSize) {
+            reassembled.write(pack.getPackChunk(off, chunkSize));
+        }
+        assertArrayEquals(expectedArchive, reassembled.toByteArray(),
+                "a running server must not mix a startup manifest with replacement bytes");
+    }
 }

--- a/src/test/java/cn/nukkit/resourcepacks/ZippedResourcePackChunkIntegrityTest.java
+++ b/src/test/java/cn/nukkit/resourcepacks/ZippedResourcePackChunkIntegrityTest.java
@@ -193,6 +193,20 @@ class ZippedResourcePackChunkIntegrityTest {
                 "{\"format_version\":2,\"header\":{\"name\":\"T\",\"description\":\"d\","
                         + "\"uuid\":\"12345678-1234-1234-1234-123456789012\",\"version\":\"1.0.0\"},"
                         + "\"modules\":[]}",
+                // min_engine_version not an array (getPackProtocol would throw IllegalStateException
+                // on the login path — after construction succeeded)
+                "{\"format_version\":2,\"header\":{\"name\":\"T\",\"description\":\"d\","
+                        + "\"uuid\":\"12345678-1234-1234-1234-123456789012\",\"version\":[1,0,0],"
+                        + "\"min_engine_version\":\"1.21.0\"},\"modules\":[]}",
+                // min_engine_version with a non-numeric element (ProtocolConverter.getAsInt
+                // would throw NumberFormatException)
+                "{\"format_version\":2,\"header\":{\"name\":\"T\",\"description\":\"d\","
+                        + "\"uuid\":\"12345678-1234-1234-1234-123456789012\",\"version\":[1,0,0],"
+                        + "\"min_engine_version\":[true,0,0]},\"modules\":[]}",
+                // min_engine_version too short (convertToProtocol requires >= 3 elements)
+                "{\"format_version\":2,\"header\":{\"name\":\"T\",\"description\":\"d\","
+                        + "\"uuid\":\"12345678-1234-1234-1234-123456789012\",\"version\":[1,0,0],"
+                        + "\"min_engine_version\":[1,21]},\"modules\":[]}",
         };
         for (String manifest : malformedManifests) {
             File packFile = tempDir.resolve("malformed.zip").toFile();

--- a/src/test/java/cn/nukkit/resourcepacks/ZippedResourcePackLoaderTest.java
+++ b/src/test/java/cn/nukkit/resourcepacks/ZippedResourcePackLoaderTest.java
@@ -111,6 +111,17 @@ class ZippedResourcePackLoaderTest {
                 "crash leftover should be wiped");
         assertFalse(Files.exists(cacheDir.resolve("removed-pack.zip")),
                 "orphaned snapshot should be wiped");
-        assertTrue(Files.isRegularFile(cacheDir.resolve("MyDirPack.zip")));
+        // Windows 降级路径：首个实例的 channel 仍钉住 stable 名（delete-pending）时
+        // promoteSnapshot 失败，快照保留 .tmp 名 — 两种名字都算加载成功。
+        // Windows degradation: while the first instance's channel still pins the
+        // stable name, promotion fails and the snapshot keeps its .tmp name.
+        try (var snapshots = Files.list(cacheDir)) {
+            assertTrue(snapshots.filter(Files::isRegularFile).anyMatch(p -> {
+                        String name = p.getFileName().toString();
+                        return name.equals("MyDirPack.zip")
+                                || (name.startsWith("MyDirPack.zip.") && name.endsWith(".tmp"));
+                    }),
+                    "directory pack snapshot should exist (stable or tmp-fallback name)");
+        }
     }
 }

--- a/src/test/java/cn/nukkit/resourcepacks/ZippedResourcePackLoaderTest.java
+++ b/src/test/java/cn/nukkit/resourcepacks/ZippedResourcePackLoaderTest.java
@@ -1,0 +1,116 @@
+package cn.nukkit.resourcepacks;
+
+import cn.nukkit.MockServer;
+import cn.nukkit.Server;
+import cn.nukkit.lang.BaseLang;
+import cn.nukkit.resourcepacks.loader.ZippedResourcePackLoader;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Loader × snapshot cache: directory packs are zipped into the cache dir,
+ * loadPacks wipes leftovers/orphans, and wiped instances keep serving.
+ */
+class ZippedResourcePackLoaderTest {
+
+    private static final String MANIFEST = "{\"format_version\":2,\"header\":{\"name\":\"T\","
+            + "\"description\":\"d\",\"uuid\":\"12345678-1234-1234-1234-123456789012\","
+            + "\"version\":[1,0,0],\"min_engine_version\":[1,21,0]},\"modules\":[{\"type\":"
+            + "\"resources\",\"uuid\":\"87654321-4321-4321-4321-210987654321\",\"version\":[1,0,0]}]}";
+
+    @TempDir
+    Path tempDir;
+
+    private File packsDir;
+    private File cacheRoot;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        MockServer.reset();
+        BaseLang language = mock(BaseLang.class);
+        when(language.translateString(any(String.class), any(Object[].class))).thenReturn("loaded");
+        when(Server.getInstance().getLanguage()).thenReturn(language);
+
+        packsDir = Files.createDirectories(tempDir.resolve("resource_packs")).toFile();
+        cacheRoot = tempDir.resolve("snapshot-cache").toFile();
+        ZippedResourcePack.cacheRootOverride = cacheRoot;
+    }
+
+    @AfterEach
+    void tearDown() {
+        ZippedResourcePack.cacheRootOverride = null;
+    }
+
+    private void createDirectoryPack(String name) throws Exception {
+        Path dir = Files.createDirectories(packsDir.toPath().resolve(name));
+        Files.writeString(dir.resolve("manifest.json"), MANIFEST, StandardCharsets.UTF_8);
+        Files.createDirectories(dir.resolve("textures"));
+        Files.write(dir.resolve("textures/blob.bin"), new byte[128 * 1024]);
+    }
+
+    @Test
+    void directoryPackIsZippedIntoSnapshotCacheAndSurvivesSourceRemoval() throws Exception {
+        createDirectoryPack("MyDirPack");
+        ZippedResourcePackLoader loader = new ZippedResourcePackLoader(packsDir);
+
+        List<ResourcePack> packs = loader.loadPacks();
+
+        assertEquals(1, packs.size());
+        ZippedResourcePack pack = (ZippedResourcePack) packs.get(0);
+        assertEquals("1.0.0", pack.getPackVersion());
+
+        // Directory pack zip must live in the snapshot cache, not system temp
+        Path snapshot = cacheRoot.toPath().resolve("resource_packs/MyDirPack.zip");
+        assertTrue(Files.isRegularFile(snapshot), "directory pack zip should live in snapshot cache");
+
+        // Serving survives source removal (channel pinned to the snapshot inode)
+        try (var walk = Files.walk(packsDir.toPath().resolve("MyDirPack"))) {
+            for (Path p : walk.sorted(java.util.Comparator.reverseOrder()).toList()) {
+                Files.delete(p);
+            }
+        }
+        java.io.ByteArrayOutputStream reassembled = new java.io.ByteArrayOutputStream();
+        for (int off = 0; off < pack.getPackSize(); off += 100 * 1024) {
+            reassembled.write(pack.getPackChunk(off, 100 * 1024));
+        }
+        assertEquals(pack.getPackSize(), reassembled.size());
+        assertArrayEquals(pack.getSha256(),
+                MessageDigest.getInstance("SHA-256").digest(reassembled.toByteArray()));
+    }
+
+    @Test
+    void loadPacksWipesOrphanedAndCrashLeftoverCacheEntries() throws Exception {
+        createDirectoryPack("MyDirPack");
+        ZippedResourcePackLoader loader = new ZippedResourcePackLoader(packsDir);
+        List<ResourcePack> first = loader.loadPacks();
+        assertEquals(1, first.size());
+
+        // Simulate crash leftovers (.tmp) and an orphan of a removed pack
+        Path cacheDir = cacheRoot.toPath().resolve("resource_packs");
+        Files.write(cacheDir.resolve("crash-leftover.zip.abc123.tmp"), new byte[] {1});
+        Files.write(cacheDir.resolve("removed-pack.zip"), new byte[] {2});
+
+        List<ResourcePack> second = loader.loadPacks();
+
+        assertEquals(1, second.size());
+        assertFalse(Files.exists(cacheDir.resolve("crash-leftover.zip.abc123.tmp")),
+                "crash leftover should be wiped");
+        assertFalse(Files.exists(cacheDir.resolve("removed-pack.zip")),
+                "orphaned snapshot should be wiped");
+        assertTrue(Files.isRegularFile(cacheDir.resolve("MyDirPack.zip")));
+    }
+}


### PR DESCRIPTION
Deployment replaces resource-pack archives while gameplay servers wait for
their nightly restart. ZippedResourcePack cached the manifest at startup but
read size, SHA-256 and every chunk from the live pathname later. A replacement
therefore mixed the old identity with new bytes, and clients split between a
stale cache and an invalid download.

Snapshot each small archive when the runtime loads it. The running process now
keeps serving one internally consistent pack; the next process picks up the
new archive after the normal restart.
