### PR TITLE
fix(inventory): send durability correction only for durable items

### DIFF
--- a/src/main/java/cn/nukkit/inventory/request/CraftGrindstoneActionProcessor.java
+++ b/src/main/java/cn/nukkit/inventory/request/CraftGrindstoneActionProcessor.java
@@ -82,7 +82,7 @@ public class CraftGrindstoneActionProcessor implements ItemStackRequestActionPro
                 PlayerUIComponent.CREATED_ITEM_OUTPUT_UI_SLOT,
                 resultClone.getCount(), resultClone.getStackNetId(),
                 resultClone.hasCustomName() ? resultClone.getCustomName() : "",
-                resultClone.getDamage(), ""
+                ItemStackRequestActionProcessor.durabilityCorrection(resultClone), ""
         );
         return context.success(List.of(new ItemStackResponseContainer(
                 ContainerSlotType.CREATED_OUTPUT,

--- a/src/main/java/cn/nukkit/inventory/request/CraftLoomActionProcessor.java
+++ b/src/main/java/cn/nukkit/inventory/request/CraftLoomActionProcessor.java
@@ -144,7 +144,7 @@ public class CraftLoomActionProcessor implements ItemStackRequestActionProcessor
                 PlayerUIComponent.CREATED_ITEM_OUTPUT_UI_SLOT,
                 result.getCount(), result.getStackNetId(),
                 result.hasCustomName() ? result.getCustomName() : "",
-                result.getDamage(), ""
+                ItemStackRequestActionProcessor.durabilityCorrection(result), ""
         );
         return context.success(List.of(new ItemStackResponseContainer(
                 ContainerSlotType.CREATED_OUTPUT,

--- a/src/main/java/cn/nukkit/inventory/request/CraftRecipeActionProcessor.java
+++ b/src/main/java/cn/nukkit/inventory/request/CraftRecipeActionProcessor.java
@@ -161,7 +161,7 @@ public class CraftRecipeActionProcessor implements ItemStackRequestActionProcess
                 PlayerUIComponent.CREATED_ITEM_OUTPUT_UI_SLOT,
                 output.getCount(), output.getStackNetId(),
                 output.hasCustomName() ? output.getCustomName() : "",
-                output.getDamage(), ""
+                ItemStackRequestActionProcessor.durabilityCorrection(output), ""
         );
         return context.success(List.of(new ItemStackResponseContainer(
                 ContainerSlotType.CREATED_OUTPUT,
@@ -332,7 +332,7 @@ public class CraftRecipeActionProcessor implements ItemStackRequestActionProcess
                 PlayerUIComponent.CREATED_ITEM_OUTPUT_UI_SLOT,
                 output.getCount(), output.getStackNetId(),
                 output.hasCustomName() ? output.getCustomName() : "",
-                output.getDamage(), ""
+                ItemStackRequestActionProcessor.durabilityCorrection(output), ""
         );
         return context.success(List.of(new ItemStackResponseContainer(
                 ContainerSlotType.CREATED_OUTPUT,
@@ -754,7 +754,7 @@ public class CraftRecipeActionProcessor implements ItemStackRequestActionProcess
                 PlayerUIComponent.CREATED_ITEM_OUTPUT_UI_SLOT,
                 output.getCount(), output.getStackNetId(),
                 output.hasCustomName() ? output.getCustomName() : "",
-                output.getDamage(), ""
+                ItemStackRequestActionProcessor.durabilityCorrection(output), ""
         );
         return context.success(List.of(new ItemStackResponseContainer(
                 ContainerSlotType.CREATED_OUTPUT,

--- a/src/main/java/cn/nukkit/inventory/request/CraftRecipeAutoProcessor.java
+++ b/src/main/java/cn/nukkit/inventory/request/CraftRecipeAutoProcessor.java
@@ -135,7 +135,7 @@ public class CraftRecipeAutoProcessor implements ItemStackRequestActionProcessor
                 PlayerUIComponent.CREATED_ITEM_OUTPUT_UI_SLOT,
                 output.getCount(), output.getStackNetId(),
                 output.hasCustomName() ? output.getCustomName() : "",
-                output.getDamage(), ""
+                ItemStackRequestActionProcessor.durabilityCorrection(output), ""
         );
         return context.success(List.of(new ItemStackResponseContainer(
                 ContainerSlotType.CREATED_OUTPUT,

--- a/src/main/java/cn/nukkit/inventory/request/CraftRecipeOptionalProcessor.java
+++ b/src/main/java/cn/nukkit/inventory/request/CraftRecipeOptionalProcessor.java
@@ -128,7 +128,7 @@ public class CraftRecipeOptionalProcessor implements ItemStackRequestActionProce
                 PlayerUIComponent.CREATED_ITEM_OUTPUT_UI_SLOT,
                 result.getCount(), result.getStackNetId(),
                 result.hasCustomName() ? result.getCustomName() : "",
-                result.getDamage(), ""
+                ItemStackRequestActionProcessor.durabilityCorrection(result), ""
         );
         return context.success(List.of(new ItemStackResponseContainer(
                 ContainerSlotType.CREATED_OUTPUT,

--- a/src/main/java/cn/nukkit/inventory/request/CraftResultDeprecatedActionProcessor.java
+++ b/src/main/java/cn/nukkit/inventory/request/CraftResultDeprecatedActionProcessor.java
@@ -51,7 +51,7 @@ public class CraftResultDeprecatedActionProcessor implements ItemStackRequestAct
                         PlayerUIComponent.CREATED_ITEM_OUTPUT_UI_SLOT,
                         output.getCount(), output.getStackNetId(),
                         output.hasCustomName() ? output.getCustomName() : "",
-                        output.getDamage(), ""
+                        ItemStackRequestActionProcessor.durabilityCorrection(output), ""
                 );
                 return context.success(List.of(new ItemStackResponseContainer(
                         ContainerSlotType.CREATED_OUTPUT,

--- a/src/main/java/cn/nukkit/inventory/request/CreateActionProcessor.java
+++ b/src/main/java/cn/nukkit/inventory/request/CreateActionProcessor.java
@@ -97,7 +97,7 @@ public class CreateActionProcessor implements ItemStackRequestActionProcessor<Cr
                 PlayerUIComponent.CREATED_ITEM_OUTPUT_UI_SLOT,
                 output.getCount(), output.getStackNetId(),
                 output.hasCustomName() ? output.getCustomName() : "",
-                output.getDamage(), ""
+                ItemStackRequestActionProcessor.durabilityCorrection(output), ""
         );
         return context.success(List.of(new ItemStackResponseContainer(
                 ContainerSlotType.CREATED_OUTPUT,

--- a/src/main/java/cn/nukkit/inventory/request/ItemStackRequestActionProcessor.java
+++ b/src/main/java/cn/nukkit/inventory/request/ItemStackRequestActionProcessor.java
@@ -1,6 +1,8 @@
 package cn.nukkit.inventory.request;
 
 import cn.nukkit.Player;
+import cn.nukkit.item.Item;
+import cn.nukkit.item.ItemDurable;
 import cn.nukkit.network.protocol.types.inventory.itemstack.request.action.ItemStackRequestAction;
 import cn.nukkit.network.protocol.types.inventory.itemstack.request.action.ItemStackRequestActionType;
 import org.jetbrains.annotations.Nullable;
@@ -26,5 +28,16 @@ public interface ItemStackRequestActionProcessor<T extends ItemStackRequestActio
      */
     default boolean validateStackNetworkId(int serverNetId, int clientNetId) {
         return serverNetId > 0 && clientNetId > 0 && serverNetId != clientNetId;
+    }
+
+    /**
+     * Return the damage correction used by the Bedrock item-stack response protocol.
+     *
+     * <p>{@link Item#getDamage()} also stores legacy metadata for non-durable items. Sending
+     * that value as durability makes variants such as planks look damaged to the client and
+     * prevents otherwise identical crafted stacks from merging.</p>
+     */
+    static int durabilityCorrection(Item item) {
+        return item instanceof ItemDurable ? item.getDamage() : 0;
     }
 }

--- a/src/main/java/cn/nukkit/inventory/request/MineBlockActionProcessor.java
+++ b/src/main/java/cn/nukkit/inventory/request/MineBlockActionProcessor.java
@@ -55,7 +55,7 @@ public class MineBlockActionProcessor implements ItemStackRequestActionProcessor
                 itemInHand.isNull() ? 0 : itemInHand.getCount(),
                 itemInHand.getStackNetId(),
                 itemInHand.hasCustomName() ? itemInHand.getCustomName() : "",
-                itemInHand.getDamage(),
+                ItemStackRequestActionProcessor.durabilityCorrection(itemInHand),
                 ""
         );
         return context.success(List.of(new ItemStackResponseContainer(

--- a/src/main/java/cn/nukkit/inventory/request/TransferItemActionProcessor.java
+++ b/src/main/java/cn/nukkit/inventory/request/TransferItemActionProcessor.java
@@ -460,7 +460,7 @@ public abstract class TransferItemActionProcessor<T extends TransferItemStackReq
                 current.isNull() ? 0 : current.getCount(),
                 current.getStackNetId(),
                 current.hasCustomName() ? current.getCustomName() : "",
-                current.getDamage(),
+                ItemStackRequestActionProcessor.durabilityCorrection(current),
                 ""
         );
         FullContainerName name = new FullContainerName(slotData.getContainer(), slotData.getDynamicId());

--- a/src/test/java/cn/nukkit/inventory/request/ItemStackResponseDurabilityTest.java
+++ b/src/test/java/cn/nukkit/inventory/request/ItemStackResponseDurabilityTest.java
@@ -1,0 +1,114 @@
+package cn.nukkit.inventory.request;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.when;
+
+import cn.nukkit.MockServer;
+import cn.nukkit.Player;
+import cn.nukkit.inventory.CraftingManager;
+import cn.nukkit.inventory.PlayerUIComponent;
+import cn.nukkit.inventory.PlayerUIInventory;
+import cn.nukkit.inventory.ShapelessRecipe;
+import cn.nukkit.item.Item;
+import cn.nukkit.network.protocol.types.inventory.ContainerSlotType;
+import cn.nukkit.network.protocol.types.inventory.itemstack.request.ItemStackRequest;
+import cn.nukkit.network.protocol.types.inventory.itemstack.request.ItemStackRequestSlotData;
+import cn.nukkit.network.protocol.types.inventory.itemstack.request.action.ConsumeAction;
+import cn.nukkit.network.protocol.types.inventory.itemstack.request.action.CraftRecipeAction;
+import cn.nukkit.network.protocol.types.inventory.itemstack.request.action.ItemStackRequestAction;
+import cn.nukkit.plugin.PluginManager;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class ItemStackResponseDurabilityTest {
+
+    @BeforeAll
+    static void init() {
+        MockServer.init();
+    }
+
+    @BeforeEach
+    void resetServer() {
+        MockServer.reset();
+    }
+
+    @Test
+    void craftedPlankResponseDoesNotExposeWoodVariantAsDurability() {
+        Player player = Mockito.mock(Player.class);
+        PlayerUIInventory ui = new PlayerUIInventory(player);
+        CraftingManager craftingManager = Mockito.mock(CraftingManager.class);
+        PluginManager pluginManager = Mockito.mock(PluginManager.class);
+        when(player.getServer()).thenReturn(MockServer.get());
+        when(player.getName()).thenReturn("test");
+        when(player.getUIInventory()).thenReturn(ui);
+        when(player.getCraftingGrid()).thenReturn(ui.getCraftingGrid());
+        when(player.getTopWindow()).thenReturn(Optional.empty());
+        when(MockServer.get().getCraftingManager()).thenReturn(craftingManager);
+        when(MockServer.get().getPluginManager()).thenReturn(pluginManager);
+
+        ShapelessRecipe recipe = new ShapelessRecipe(
+                "test:acacia_planks",
+                10,
+                Item.get(Item.PLANKS, 4, 4),
+                List.of(Item.get(Item.STONE, 0, 1)));
+        when(craftingManager.getRecipeByNetworkId(recipe.getNetworkId())).thenReturn(recipe);
+        when(craftingManager.matchRecipe(anyList(), any(Item.class), anyList())).thenReturn(recipe);
+
+        Item stone = Item.get(Item.STONE, 0, 1);
+        stone.autoAssignStackNetworkId();
+        assertTrue(ui.getCraftingGrid().setItem(0, stone, false));
+        stone = ui.getCraftingGrid().getItem(0);
+
+        CraftRecipeAction craft = new CraftRecipeAction(recipe.getNetworkId(), 1);
+        ConsumeAction consume = new ConsumeAction(
+                1,
+                new ItemStackRequestSlotData(
+                        ContainerSlotType.CRAFTING_INPUT, 28, stone.getStackNetId(), null));
+        ItemStackRequestContext context = new ItemStackRequestContext(new ItemStackRequest(
+                1, new ItemStackRequestAction[]{craft, consume}, new String[0]));
+        context.setCurrentActionIndex(0);
+
+        ActionResponse response = new CraftRecipeActionProcessor().handle(craft, player, context);
+
+        assertNotNull(response);
+        assertTrue(response.success());
+        assertEquals(
+                0,
+                response.containers().get(0).getItems().get(0).getDurabilityCorrection());
+        assertEquals(
+                4,
+                ui.getItem(PlayerUIComponent.CREATED_ITEM_OUTPUT_UI_SLOT).getDamage(),
+                "the server still keeps the acacia variant");
+    }
+
+    @Test
+    void legacyBlockMetadataIsNotReportedAsDurability() {
+        Item acaciaPlanks = Item.get(Item.PLANKS, 4, 4);
+
+        assertEquals(4, acaciaPlanks.getDamage(), "legacy damage stores the wood variant");
+        assertEquals(0, ItemStackRequestActionProcessor.durabilityCorrection(acaciaPlanks));
+    }
+
+    @Test
+    void nonDurableItemMetadataIsNotReportedAsDurability() {
+        Item potion = Item.get(Item.POTION, 4, 1);
+
+        assertEquals(4, potion.getDamage(), "legacy damage stores the potion variant");
+        assertEquals(0, ItemStackRequestActionProcessor.durabilityCorrection(potion));
+    }
+
+    @Test
+    void actualDurabilityIsStillReported() {
+        Item pickaxe = Item.get(Item.DIAMOND_PICKAXE, 37, 1);
+
+        assertEquals(37, ItemStackRequestActionProcessor.durabilityCorrection(pickaxe));
+    }
+}


### PR DESCRIPTION
Item#getDamage stores both real wear and legacy variant metadata. Item stack responses sent that metadata as durability for every item, so clients treated separately crafted plank batches as different even though the server considered them equal.

Use ItemDurable as the protocol boundary in every response-slot builder. Non-durable variants now send zero while tools and armour retain their real damage. Add regressions for planks, potions and a damaged pickaxe.
