### PR TITLE
fix(dispenser): place dyed shulker boxes and keep the slot when a behavior declines

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockDispenser.java
+++ b/src/main/java/cn/nukkit/block/BlockDispenser.java
@@ -230,7 +230,10 @@ public class BlockDispenser extends BlockSolidMeta implements Faceable, BlockEnt
         original = original.clone();
 
         DispenseBehavior behavior = DispenseBehaviorRegister.getBehavior(original);
-        Item result = behavior.dispense(this, facing, original);
+        // The behavior gets its own copy. Several behaviors answer "nothing happened, put it
+        // back" by returning the very item they were given; when that was the same object whose
+        // count is decremented below, the slot lost one item without dispensing anything.
+        Item result = behavior.dispense(this, facing, original.clone());
 
         pk.evid = LevelEventPacket.EVENT_SOUND_CLICK;
 

--- a/src/main/java/cn/nukkit/dispenser/FlintAndSteelDispenseBehavior.java
+++ b/src/main/java/cn/nukkit/dispenser/FlintAndSteelDispenseBehavior.java
@@ -18,14 +18,18 @@ public class FlintAndSteelDispenseBehavior extends DefaultDispenseBehavior {
                 boolean soulFire = down.getId() == Block.SOUL_SAND || down.getId() == Block.SOUL_SOIL;
                 block.level.setBlock(target, Block.get(soulFire ? BlockID.SOUL_FIRE : BlockID.FIRE));
             }
-            item.useOn(target);
         } else if (target.getId() == BlockID.TNT) {
             target.onActivate(item);
-            item.useOn(target);
         } else {
+            // Nothing was dispensed; returning the item keeps it in the slot.
             this.success = false;
+            return item;
         }
 
-        return null;
+        // A damaged copy takes the different-damage path in BlockDispenser and is added back,
+        // so the flint and steel stays in the slot with one durability spent; returning null
+        // would let the count-- there consume the whole item instead.
+        item.useOn(target);
+        return item.getDamage() >= item.getMaxDurability() ? null : item;
     }
 }

--- a/src/main/java/cn/nukkit/dispenser/ShulkerBoxDispenseBehavior.java
+++ b/src/main/java/cn/nukkit/dispenser/ShulkerBoxDispenseBehavior.java
@@ -12,33 +12,35 @@ public class ShulkerBoxDispenseBehavior extends DefaultDispenseBehavior {
 
     @Override
     public Item dispense(BlockDispenser block, BlockFace face, Item item) {
-        Block shulkerBox = Block.get(BlockID.SHULKER_BOX);
         Block target = block.getSide(face);
-
-        this.success = block.level.getCollidingEntities(shulkerBox.getBoundingBox()).length == 0;
-
-        if (this.success) {
-            BlockFace shulkerBoxFace = target.down().getId() == BlockID.AIR ? face : BlockFace.UP;
-
-            CompoundTag nbt = BlockEntity.getDefaultCompound(target, BlockEntity.SHULKER_BOX);
-            nbt.putByte("facing", shulkerBoxFace.getIndex());
-
-            if (item.hasCustomName()) {
-                nbt.putString("CustomName", item.getCustomName());
-            }
-
-            CompoundTag tag = item.getNamedTag();
-
-            if (tag != null) {
-                if (tag.contains("Items")) {
-                    nbt.putList(tag.getList("Items"));
-                }
-            }
-
-            BlockEntity.createBlockEntity(BlockEntity.SHULKER_BOX, block.level.getChunk(target.getChunkX(), target.getChunkZ()), nbt);
-            block.level.updateComparatorOutputLevel(target);
+        if (target.getId() != Block.AIR) {
+            // Same answer as the undyed box: nothing dispensed, the item stays in the slot.
+            return item;
         }
-
+        Block shulkerBox = Block.get(BlockID.SHULKER_BOX, item.getDamage());
+        shulkerBox.position(target);
+        this.success = block.level.getCollidingEntities(shulkerBox.getBoundingBox()).length == 0;
+        if (!this.success) {
+            return item;
+        }
+        BlockFace shulkerBoxFace = target.down().getId() == BlockID.AIR ? face : BlockFace.UP;
+        CompoundTag nbt = BlockEntity.getDefaultCompound(target, BlockEntity.SHULKER_BOX);
+        nbt.putByte("facing", shulkerBoxFace.getIndex());
+        if (item.hasCustomName()) {
+            nbt.putString("CustomName", item.getCustomName());
+        }
+        CompoundTag tag = item.getNamedTag();
+        if (tag != null) {
+            if (tag.contains("Items")) {
+                nbt.putList(tag.getList("Items"));
+            }
+        }
+        // The block itself was never written before this fix: the block entity with the
+        // contents was created on an air cell, the slot was emptied, and the next garbage
+        // collection or block placement discarded the entity together with everything inside.
+        block.level.setBlock(target, shulkerBox, true);
+        BlockEntity.createBlockEntity(BlockEntity.SHULKER_BOX, block.level.getChunk(target.getChunkX(), target.getChunkZ()), nbt);
+        block.level.updateComparatorOutputLevel(target);
         return null;
     }
 }


### PR DESCRIPTION
 behavior declines

A dyed shulker box (minecraft:shulker_box, id 218) in a dispenser was consumed without ever
being placed: ShulkerBoxDispenseBehavior created the block entity with the box contents on
an air cell and never wrote the block. The slot lost the box, the entity had no block under
it, and the next garbage collection or block placement discarded it together with up to 27
stacks inside. The undyed box already did this correctly; the dyed one now mirrors it,
including the collision check that used to run against an unpositioned block at 0,0,0.

BlockDispenser.dispense also decremented the count of the exact object it handed to the
behavior. Behaviors that decline (undyed shulker box facing a wall, water bottle on dirt
that refused, shears with nothing to shear) return that same object to say 'put it back',
so the slot came back one item short: an undyed shulker box fired at a wall vanished.
The behavior now receives its own copy; the same-id-and-damage branch keeps working for
behaviors that return a damaged copy (shears).
