### PR TITLE
fix(level): save changed neighbours together with a chunk saved on unload

### DIFF
--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -4486,6 +4486,7 @@ public class Level implements ChunkManager, Metadatable {
                     if (chunk.hasChanged()) {
                         levelProvider.setChunk(x, z, chunk);
                         levelProvider.saveChunk(x, z);
+                        this.saveChangedNeighbours(levelProvider, x, z);
                     }
                 }
                 for (ChunkLoader loader : this.getChunkLoaders(x, z)) {
@@ -4500,6 +4501,37 @@ public class Level implements ChunkManager, Metadatable {
         }
 
         return true;
+    }
+
+    /**
+     * Writes the changed neighbours of a chunk that is being saved on unload.
+     *
+     * <p>A machine on a chunk border (a hopper feeding a chest across it, a double chest, a hopper
+     * chain) moves items between two chunks within one tick. Saving only the unloading chunk leaves
+     * its neighbour on disk in the state of the previous save, so a crash before that neighbour is
+     * written duplicates or loses everything moved since: a hopper that had pushed a stack into a
+     * chest across the border came back with the stack still inside AND the chest full. Saving the
+     * changed neighbours in the same pass lands both sides of the border on disk together; a chunk
+     * that did not change is skipped, so the extra work is bounded by what the unload queue would
+     * have written a moment later anyway.
+     */
+    private void saveChangedNeighbours(LevelProvider levelProvider, int x, int z) {
+        for (int dx = -1; dx <= 1; dx++) {
+            for (int dz = -1; dz <= 1; dz++) {
+                if (dx == 0 && dz == 0) {
+                    continue;
+                }
+                int nx = x + dx;
+                int nz = z + dz;
+                if (!this.isChunkLoaded(nx, nz)) {
+                    continue;
+                }
+                BaseFullChunk neighbour = this.getChunk(nx, nz, false);
+                if (neighbour != null && neighbour.hasChanged()) {
+                    levelProvider.saveChunk(nx, nz);
+                }
+            }
+        }
     }
 
     public boolean isSpawnChunk(int X, int Z) {


### PR DESCRIPTION
 unload

A machine on a chunk border moves items between two chunks within one tick: a hopper feeding
a chest across the border, a double chest whose halves sit in different chunks, a hopper
chain. When one of those chunks was saved on unload while the other stayed loaded, the disk
held the two halves of one transfer from different moments. A crash before the next save then
duplicated or lost everything moved in between: a hopper that had pushed a diamond into a
chest across the border came back after kill -9 with the diamond still inside and the chest
holding one too; a stack moved from the left half of a double chest to the right half came
back on both sides or on neither, depending on which chunk had been written last.

Level.unloadChunk now writes the changed neighbours of the unloading chunk in the same pass.
A neighbour that did not change is skipped, so the extra work is bounded by what the unload
queue would have written moments later anyway. The autosave path already writes every changed
chunk in one loop and is unchanged.
