### PR TITLE
fix(item): track the goat horn cool down on the player

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -310,7 +310,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
 
     protected final Map<UUID, Player> hiddenPlayers = new HashMap<>();
     /** Server tick at which the cool down of an item category ends. */
-    protected final Map<String, Integer> itemCoolDownEnds = new HashMap<>(2);
+    protected final Map<String, Integer> itemCoolDownEnds = new ConcurrentHashMap<>(2);
 
     /**
      * 已向本观察者下发 PlayerList(ADD) 的玩家型实体 UUID，用于去重防网易客户端隐形；
@@ -6452,7 +6452,8 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
             return 0;
         }
         if (this.server.getTick() >= end) {
-            this.itemCoolDownEnds.remove(itemCategory);
+            // remove(key, value): an unconditional remove could clobber a cool down recorded concurrently
+            this.itemCoolDownEnds.remove(itemCategory, end);
             return 0;
         }
         return end;

--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -309,6 +309,8 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
     private static final double FOV_DEGREES = 100.0;
 
     protected final Map<UUID, Player> hiddenPlayers = new HashMap<>();
+    /** Server tick at which the cool down of an item category ends. */
+    protected final Map<String, Integer> itemCoolDownEnds = new HashMap<>(2);
 
     /**
      * 已向本观察者下发 PlayerList(ADD) 的玩家型实体 UUID，用于去重防网易客户端隐形；
@@ -6410,14 +6412,22 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
     }
 
     /**
-     * 设置指定itemCategory物品的冷却显示效果，注意该方法仅为客户端显示效果，冷却逻辑实现仍需自己实现
+     * 设置指定itemCategory物品的冷却：服务端记录冷却结束的tick，同时把冷却显示效果发给客户端
      * <p>
-     * Set the cooling display effect of the specified itemCategory items, note that this method is only for client-side display effect, cooling logic implementation still needs to be implemented by itself
+     * Start a cool down for the given item category. The end tick is tracked server side, so
+     * {@link #isItemCoolDownEnd(String)} stays authoritative even when the client ignores the
+     * display packet, and the packet is still sent to clients that understand it.
      *
-     * @param coolDown     the cool down
+     * @param coolDown     the cool down, in ticks; zero or less clears the cool down
      * @param itemCategory the item category
      */
     public void setItemCoolDown(int coolDown, String itemCategory) {
+        if (coolDown > 0) {
+            this.itemCoolDownEnds.put(itemCategory, this.server.getTick() + coolDown);
+        } else {
+            this.itemCoolDownEnds.remove(itemCategory);
+        }
+
         if (this.protocol < ProtocolInfo.v1_18_10) {
             return;
         }
@@ -6425,6 +6435,41 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
         pk.setCoolDownDuration(coolDown);
         pk.setItemCategory(itemCategory);
         this.dataPacket(pk);
+    }
+
+    /**
+     * 获取指定itemCategory冷却结束的tick，没有冷却时返回0
+     * <p>
+     * Gets the server tick at which the cool down of the given item category ends, or {@code 0}
+     * when this player has no running cool down for it.
+     *
+     * @param itemCategory the item category
+     * @return the end tick, or 0
+     */
+    public int getItemCoolDownEnd(String itemCategory) {
+        Integer end = this.itemCoolDownEnds.get(itemCategory);
+        if (end == null) {
+            return 0;
+        }
+        if (this.server.getTick() >= end) {
+            this.itemCoolDownEnds.remove(itemCategory);
+            return 0;
+        }
+        return end;
+    }
+
+    /**
+     * 判断指定itemCategory的冷却是否已经结束
+     * <p>
+     * Whether the cool down of the given item category has ended. Item behaviours must ask this
+     * before acting: the cool down belongs to the player, not to a single item stack, so two
+     * identical items in the inventory share one cool down.
+     *
+     * @param itemCategory the item category
+     * @return true when the item may be used again
+     */
+    public boolean isItemCoolDownEnd(String itemCategory) {
+        return this.getItemCoolDownEnd(itemCategory) == 0;
     }
 
     /**

--- a/src/main/java/cn/nukkit/item/ItemGoatHorn.java
+++ b/src/main/java/cn/nukkit/item/ItemGoatHorn.java
@@ -8,11 +8,7 @@ import cn.nukkit.network.protocol.ProtocolInfo;
 
 public class ItemGoatHorn extends StringItemBase {
 
-    /**
-     * Item category the vanilla client shows the cool down for. The cool down is shared by every
-     * goat horn a player carries, so it is tracked on the player and not on the item stack.
-     */
-    private static final String COOL_DOWN_CATEGORY = "goat_horn";
+    public static final String COOL_DOWN_CATEGORY = "goat_horn";
 
     protected int coolDownTick = 140;
 

--- a/src/main/java/cn/nukkit/item/ItemGoatHorn.java
+++ b/src/main/java/cn/nukkit/item/ItemGoatHorn.java
@@ -2,19 +2,19 @@ package cn.nukkit.item;
 
 import cn.nukkit.GameVersion;
 import cn.nukkit.Player;
-import cn.nukkit.Server;
 import cn.nukkit.level.Sound;
 import cn.nukkit.math.Vector3;
 import cn.nukkit.network.protocol.ProtocolInfo;
-import cn.nukkit.plugin.InternalPlugin;
-
-import java.util.concurrent.atomic.AtomicBoolean;
 
 public class ItemGoatHorn extends StringItemBase {
 
-    protected int coolDownTick = 140;
+    /**
+     * Item category the vanilla client shows the cool down for. The cool down is shared by every
+     * goat horn a player carries, so it is tracked on the player and not on the item stack.
+     */
+    private static final String COOL_DOWN_CATEGORY = "goat_horn";
 
-    private final AtomicBoolean banUse = new AtomicBoolean(false);
+    protected int coolDownTick = 140;
 
     public ItemGoatHorn() {
         this(0);
@@ -37,14 +37,12 @@ public class ItemGoatHorn extends StringItemBase {
 
     @Override
     public boolean onClickAir(Player player, Vector3 directionVector) {
-        if (!this.banUse.getAndSet(true)) {
-            playSound(player);
-            Server.getInstance().getScheduler().scheduleDelayedTask(InternalPlugin.INSTANCE, () -> this.banUse.set(false), this.coolDownTick);
-            player.setItemCoolDown(this.coolDownTick, "goat_horn");
-            return true;
-        } else {
+        if (!player.isItemCoolDownEnd(COOL_DOWN_CATEGORY)) {
             return false;
         }
+        playSound(player);
+        player.setItemCoolDown(this.coolDownTick, COOL_DOWN_CATEGORY);
+        return true;
     }
 
     /**


### PR DESCRIPTION
Two goat horns in the same inventory can be sounded back to back with no wait.

`ItemGoatHorn` kept its cool down in an `AtomicBoolean` field of the item itself, so the cool down belonged to one item stack instead of to the player: the second stack is a different `Item` object with its own flag. On top of that `BaseInventory#getItem` returns a clone, so the flag on the stack in the slot is not reliably the one that was flipped. `PlayerStartItemCoolDownPacket` does not save it either — it is a client-side display effect, and the server checked nothing.

Cool downs are a property of the player, so track them there:

* `Player#setItemCoolDown` records the end tick per item category next to the packet it already sent (and a cool down of `0` or less clears it);
* new `Player#isItemCoolDownEnd(String)` / `Player#getItemCoolDownEnd(String)` answer whether the category may be used again;
* `ItemGoatHorn#onClickAir` asks the player instead of its own field, which also drops the delayed task that was scheduled on every single use.

Clients below `v1_18_10` still get no display packet, but the server-side cool down now applies to them as well.

**How to reproduce on master:** put two goat horns in the hotbar, sound the first one, switch slot and sound the second — it plays immediately instead of waiting the 7 s cool down.