### PR TITLE
feat(network): add NetEase zlibstream compression

### DIFF
--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -578,6 +578,7 @@ public class Server {
      * Using Snappy compression
      */
     public boolean useSnappy;
+    public boolean useNeteaseZlibStream;
     /**
      * 1.19.30+ Using Client Spectator Mode
      * Because some servers may require the use of the inventory in spectator mode
@@ -3887,6 +3888,7 @@ public class Server {
         // Network
         this.networkCompressionThreshold = config.networkSettings().compressionThreshold();
         this.useSnappy = config.networkSettings().useSnappyCompression();
+        this.useNeteaseZlibStream = config.networkSettings().useNeteaseZlibStreamCompression();
         this.rakPacketLimit = config.networkSettings().rakPacketLimit();
         this.networkLoginTimeoutMilliseconds = config.networkSettings().timeoutMilliseconds();
         this.rakCookieMode = parseRakCookieMode(config.networkSettings().rakCookieMode());

--- a/src/main/java/cn/nukkit/network/NetEaseZlibStreamCompression.java
+++ b/src/main/java/cn/nukkit/network/NetEaseZlibStreamCompression.java
@@ -1,0 +1,63 @@
+package cn.nukkit.network;
+
+import cn.nukkit.utils.BinaryStream;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.zip.Deflater;
+import java.util.zip.Inflater;
+
+public class NetEaseZlibStreamCompression implements CompressionProvider {
+
+    private static final int CHUNK = 8192;
+    private static final int MAX_DECOMPRESSED_BYTES = 3 * 1024 * 1024;
+
+    private final Deflater deflater = new Deflater(7, true);
+    private final Inflater inflater = new Inflater(true);
+
+    @Override
+    public synchronized byte[] compress(BinaryStream packet, int level) throws Exception {
+        byte[] data = packet.getBuffer();
+        this.deflater.setInput(data);
+        ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+        byte[] buf = new byte[CHUNK];
+        while (!this.deflater.needsInput()) {
+            int written = this.deflater.deflate(buf, 0, buf.length, Deflater.SYNC_FLUSH);
+            if (written > 0) outBuf.write(buf, 0, written);
+        }
+        while (true) {
+            int written = this.deflater.deflate(buf, 0, buf.length, Deflater.SYNC_FLUSH);
+            if (written == 0) break;
+            outBuf.write(buf, 0, written);
+        }
+        return outBuf.toByteArray();
+    }
+
+    @Override
+    public synchronized byte[] decompress(byte[] compressed) throws Exception {
+        return this.decompress(compressed, MAX_DECOMPRESSED_BYTES);
+    }
+
+    @Override
+    public synchronized byte[] decompress(byte[] compressed, int maxSize) throws Exception {
+        this.inflater.setInput(compressed);
+        ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+        byte[] buf = new byte[CHUNK];
+        int total = 0;
+        while (!this.inflater.needsInput()) {
+            int written = this.inflater.inflate(buf, 0, buf.length);
+            if (written == 0) break;
+            outBuf.write(buf, 0, written);
+            total += written;
+            if (total > maxSize) {
+                throw new IOException("Decompressed data exceeds maximum size");
+            }
+        }
+        return outBuf.toByteArray();
+    }
+
+    @Override
+    public byte getPrefix() {
+        return (byte) 0x02;
+    }
+}

--- a/src/main/java/cn/nukkit/network/process/processor/v554/RequestNetworkSettingsProcessor_v554.java
+++ b/src/main/java/cn/nukkit/network/process/processor/v554/RequestNetworkSettingsProcessor_v554.java
@@ -5,6 +5,7 @@ import cn.nukkit.Player;
 import cn.nukkit.PlayerHandle;
 import cn.nukkit.Server;
 import cn.nukkit.network.CompressionProvider;
+import cn.nukkit.network.NetEaseZlibStreamCompression;
 import cn.nukkit.network.process.DataPacketProcessor;
 import cn.nukkit.network.protocol.DataPacket;
 import cn.nukkit.network.protocol.NetworkSettingsPacket;
@@ -40,9 +41,10 @@ public class RequestNetworkSettingsProcessor_v554 extends DataPacketProcessor<Re
             return;
         }
 
-        if (player.raknetProtocol == 8
+        boolean netEaseClient = player.raknetProtocol == 8
                 && Server.getInstance().netEaseMode
-                && pk.protocolVersion >= GameVersion.V1_20_50_NETEASE.getProtocol()) {
+                && pk.protocolVersion >= GameVersion.V1_20_50_NETEASE.getProtocol();
+        if (netEaseClient) {
             playerHandle.setGameVersion(GameVersion.byProtocol(pk.protocolVersion, true));
             playerHandle.getNetworkSession().setCompressionOut(CompressionProvider.NONE);
         } else {
@@ -52,15 +54,23 @@ public class RequestNetworkSettingsProcessor_v554 extends DataPacketProcessor<Re
             playerHandle.getNetworkSession().getState().getLogin().setPhase(SessionLoginPhase.NETWORK_SETTINGS_NEGOTIATED);
         }
 
+        boolean neteaseZlibStream = netEaseClient && Server.getInstance().useNeteaseZlibStream;
+
         NetworkSettingsPacket settingsPacket = new NetworkSettingsPacket();
         PacketCompressionAlgorithm algorithm;
-        if (player.getServer().useSnappy && player.protocol >= ProtocolInfo.v1_19_30_23) {
+        if (neteaseZlibStream) {
+            algorithm = PacketCompressionAlgorithm.ZLIBSTREAM;
+        } else if (player.getServer().useSnappy && player.protocol >= ProtocolInfo.v1_19_30_23) {
             algorithm = PacketCompressionAlgorithm.SNAPPY;
         } else {
             algorithm = PacketCompressionAlgorithm.ZLIB;
         }
-        CompressionProvider negotiatedCompression = CompressionProvider.from(algorithm, player.raknetProtocol);
-        playerHandle.getNetworkSession().beginLegacyInboundCompressionGraceWindow(negotiatedCompression);
+        CompressionProvider negotiatedCompression = neteaseZlibStream
+                ? new NetEaseZlibStreamCompression()
+                : CompressionProvider.from(algorithm, player.raknetProtocol);
+        if (!neteaseZlibStream) {
+            playerHandle.getNetworkSession().beginLegacyInboundCompressionGraceWindow(negotiatedCompression);
+        }
         settingsPacket.compressionAlgorithm = algorithm;
         settingsPacket.compressionThreshold = 1; // compress everything
         player.forceDataPacket(settingsPacket, () -> {

--- a/src/main/java/cn/nukkit/network/protocol/types/PacketCompressionAlgorithm.java
+++ b/src/main/java/cn/nukkit/network/protocol/types/PacketCompressionAlgorithm.java
@@ -2,5 +2,6 @@ package cn.nukkit.network.protocol.types;
 
 public enum PacketCompressionAlgorithm {
     ZLIB,
-    SNAPPY
+    SNAPPY,
+    ZLIBSTREAM
 }

--- a/src/main/java/cn/nukkit/network/session/RakNetPlayerSession.java
+++ b/src/main/java/cn/nukkit/network/session/RakNetPlayerSession.java
@@ -5,6 +5,7 @@ import cn.nukkit.Nukkit;
 import cn.nukkit.Player;
 import cn.nukkit.Server;
 import cn.nukkit.network.CompressionProvider;
+import cn.nukkit.network.NetEaseZlibStreamCompression;
 import cn.nukkit.network.Network;
 import cn.nukkit.network.RakNetInterface;
 import cn.nukkit.network.protocol.BatchPacket;
@@ -16,6 +17,8 @@ import cn.nukkit.network.session.login.SessionLoginPhase;
 import cn.nukkit.plugin.InternalPlugin;
 import cn.nukkit.utils.Binary;
 import cn.nukkit.utils.BinaryStream;
+import cn.nukkit.utils.SnappyCompression;
+import cn.nukkit.utils.Zlib;
 import com.google.common.base.Preconditions;
 import com.nukkitx.natives.sha256.Sha256;
 import com.nukkitx.natives.util.Natives;
@@ -36,6 +39,7 @@ import org.cloudburstmc.netty.handler.codec.raknet.common.RakSessionCodec;
 
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
+import java.io.IOException;
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -334,7 +338,7 @@ public class RakNetPlayerSession extends SimpleChannelInboundHandler<RakMessage>
                         toBatch.clear();
                     }
 
-                    this.sendPacket(((BatchPacket) packet).payload);
+                    this.sendBatchPacket((BatchPacket) packet);
                 } else {
                     toBatch.add(packet);
                 }
@@ -432,6 +436,34 @@ public class RakNetPlayerSession extends SimpleChannelInboundHandler<RakMessage>
         }
 
         return this.channel.writeAndFlush(finalPayload);
+    }
+
+    private void sendBatchPacket(BatchPacket batch) {
+        byte[] payload = batch.payload;
+        if (!(this.compressionOut instanceof NetEaseZlibStreamCompression)) {
+            this.sendPacket(payload);
+            return;
+        }
+        try {
+            byte[] plaintext = inflateStandaloneBatch(payload);
+            byte[] compressed = this.compressionOut.compress(new BinaryStream(plaintext),
+                    Server.getInstance().networkCompressionLevel);
+            this.sendPacket(compressed);
+        } catch (Exception e) {
+            log.error("Unable to send cached batch through zlibstream for {}", playerLabel(), e);
+        }
+    }
+
+    private static byte[] inflateStandaloneBatch(byte[] payload) throws IOException {
+        try {
+            return Zlib.inflateRaw(payload, 64 * 1024 * 1024);
+        } catch (IOException ignored) {
+        }
+        try {
+            return Zlib.inflate(payload, 64 * 1024 * 1024);
+        } catch (IOException ignored) {
+        }
+        return SnappyCompression.decompress(payload, 64 * 1024 * 1024);
     }
 
     @Override
@@ -580,7 +612,8 @@ public class RakNetPlayerSession extends SimpleChannelInboundHandler<RakMessage>
         int protocol = this.getBedrockProtocol();
         return this.state.getSecurity().isCompressionInitialized()
                 && protocol != Integer.MAX_VALUE
-                && protocol >= ProtocolInfo.v1_20_60;
+                && protocol >= ProtocolInfo.v1_20_60
+                && !(this.compressionOut instanceof NetEaseZlibStreamCompression);
     }
 
     private boolean shouldUsePrefixedCompressionAfterNegotiation() {

--- a/src/main/java/cn/nukkit/utils/serverconfig/category/NetworkSettings.java
+++ b/src/main/java/cn/nukkit/utils/serverconfig/category/NetworkSettings.java
@@ -35,6 +35,10 @@ public class NetworkSettings extends OkaeriConfig {
     @CustomKey("use-snappy-compression")
     private boolean useSnappyCompression = false;
 
+    @Comment("Use zlibstream compression for NetEase clients")
+    @CustomKey("use-netease-zlibstream-compression")
+    private boolean useNeteaseZlibStreamCompression = false;
+
     @Comment("Max RakNet packets per 10ms per IP")
     @CustomKey("rak-packet-limit")
     private int rakPacketLimit = 2000;

--- a/src/main/resources/lang/chs/config_comments.properties
+++ b/src/main/resources/lang/chs/config_comments.properties
@@ -33,6 +33,7 @@ networkSettings.compressionLevel=压缩等级 (1-9, 越高=越耗CPU, 数据包�
 networkSettings.chunkCompressionLevel=区块压缩等级 (1-9, 越高=越耗CPU, 区块数据越小)
 networkSettings.compressionThreshold=压缩阈值 (字节)
 networkSettings.useSnappyCompression=使用Snappy压缩代替ZLIB
+networkSettings.useNeteaseZlibStreamCompression=为网易客户端使用zlibstream压缩
 networkSettings.rakPacketLimit=每个IP每10ms的RakNet数据包上限
 networkSettings.rakCookieMode=RakNet Cookie模式 (active, offloaded, offloaded_psk, off, none, stateless)
 networkSettings.timeoutMilliseconds=客户端超时时间 (毫秒)

--- a/src/main/resources/lang/deu/config_comments.properties
+++ b/src/main/resources/lang/deu/config_comments.properties
@@ -33,6 +33,7 @@ networkSettings.compressionLevel=Komprimierungsstufe (1-9, hoeher = mehr CPU, kl
 networkSettings.chunkCompressionLevel=Chunk-Komprimierungsstufe (1-9, hoeher = mehr CPU, kleinere Chunks)
 networkSettings.compressionThreshold=Komprimierungsschwelle in Bytes
 networkSettings.useSnappyCompression=Snappy-Komprimierung anstelle von ZLIB verwenden
+networkSettings.useNeteaseZlibStreamCompression=Zlibstream-Komprimierung für NetEase-Clients verwenden
 networkSettings.rakPacketLimit=Max. RakNet-Pakete pro 10 ms pro IP
 networkSettings.rakCookieMode=RakNet-Cookie-Modus (active, offloaded, offloaded_psk, off, none, stateless)
 networkSettings.timeoutMilliseconds=Client-Timeout in Millisekunden

--- a/src/main/resources/lang/eng/config_comments.properties
+++ b/src/main/resources/lang/eng/config_comments.properties
@@ -33,6 +33,7 @@ networkSettings.compressionLevel=Compression level (1-9, higher = more CPU, smal
 networkSettings.chunkCompressionLevel=Chunk compression level (1-9, higher = more CPU, smaller chunks)
 networkSettings.compressionThreshold=Compression threshold in bytes
 networkSettings.useSnappyCompression=Use Snappy compression instead of ZLIB
+networkSettings.useNeteaseZlibStreamCompression=Use zlibstream compression for NetEase clients
 networkSettings.rakPacketLimit=Max RakNet packets per 10ms per IP
 networkSettings.rakCookieMode=RakNet cookie mode (active, offloaded, offloaded_psk, off, none, stateless)
 networkSettings.timeoutMilliseconds=Client timeout in milliseconds

--- a/src/main/resources/lang/jpn/config_comments.properties
+++ b/src/main/resources/lang/jpn/config_comments.properties
@@ -33,6 +33,7 @@ networkSettings.compressionLevel=圧縮レベル（1～9、高いほどCPU使用
 networkSettings.chunkCompressionLevel=チャンク圧縮レベル（1～9、高いほどCPU使用量が増え、チャンクサイズが小さくなる）
 networkSettings.compressionThreshold=圧縮を適用するしきい値（バイト）
 networkSettings.useSnappyCompression=ZLIBの代わりにSnappy圧縮を使用
+networkSettings.useNeteaseZlibStreamCompression=NetEaseクライアントにzlibstream圧縮を使用
 networkSettings.rakPacketLimit=IPごとの10msあたりのRakNetパケット最大数
 networkSettings.rakCookieMode=RakNet Cookieモード（active、offloaded、offloaded_psk、off、none、stateless）
 networkSettings.timeoutMilliseconds=クライアントのタイムアウト時間（ミリ秒）

--- a/src/main/resources/lang/rus/config_comments.properties
+++ b/src/main/resources/lang/rus/config_comments.properties
@@ -33,6 +33,7 @@ networkSettings.compressionLevel=Уровень сжатия (1-9, выше = б
 networkSettings.chunkCompressionLevel=Уровень сжатия чанков (1-9, выше = больше CPU, меньше чанки)
 networkSettings.compressionThreshold=Порог сжатия в байтах
 networkSettings.useSnappyCompression=Использовать сжатие Snappy вместо ZLIB
+networkSettings.useNeteaseZlibStreamCompression=Использовать сжатие zlibstream для клиентов NetEase
 networkSettings.rakPacketLimit=Макс. число RakNet-пакетов за 10 мс с одного IP
 networkSettings.rakCookieMode=Режим cookie RakNet (active, offloaded, offloaded_psk, off, none, stateless)
 networkSettings.timeoutMilliseconds=Таймаут клиента в миллисекундах

--- a/src/main/resources/lang/vie/config_comments.properties
+++ b/src/main/resources/lang/vie/config_comments.properties
@@ -33,6 +33,7 @@ networkSettings.compressionLevel=Compression level (1-9, higher = more CPU, smal
 networkSettings.chunkCompressionLevel=Chunk compression level (1-9, higher = more CPU, smaller chunks)
 networkSettings.compressionThreshold=Compression threshold in bytes
 networkSettings.useSnappyCompression=Use Snappy compression instead of ZLIB
+networkSettings.useNeteaseZlibStreamCompression=Sử dụng nén zlibstream cho khách NetEase
 networkSettings.rakPacketLimit=Max RakNet packets per 10ms per IP
 networkSettings.rakCookieMode=RakNet cookie mode (active, offloaded, offloaded_psk, off, none, stateless)
 networkSettings.timeoutMilliseconds=Client timeout in milliseconds


### PR DESCRIPTION
This change adds support for NetEase's proprietary "zlibstream" compression (protocol algorithm 2), controlled by the new use-netease-zlibstream-compression setting. zlibstream is a compression scheme unique to the NetEase ecosystem and is fundamentally different from the per-frame compression used in standard Bedrock — the two wire formats are incompatible and cannot be mixed, and this server previously did not support it.

zlibstream treats the data of an entire session as a single never-ending raw deflate stream: compression is performed without a zlib header or trailer, and each transmitted segment is finished with a SYNC_FLUSH — the output is aligned to a byte boundary and decodable up to that point, yet the stream is never closed, so the sliding-window dictionary is shared across segments and later data can still reference earlier content for better compression. On the receive side, a single persistent Inflater is fed continuously and no end-of-stream marker is required. In the implementation, every session entering this mode keeps a persistent Deflater/Inflater pair, one for each direction; after compressing each segment, all pending output is fully drained so that one message always corresponds to exactly one complete batch plus a sync point. Sessions in this mode never carry a compression prefix byte, and the receive path handles the stream accordingly; pre-compressed cached payloads such as chunks and biome definitions are first restored to plaintext and then fed through the session stream so the peer's stream state is never corrupted.