### PR TITLE
fix: measure melee reach to large entities from their bounding boxes

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -3170,12 +3170,38 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
     }
 
     private boolean canInteractEntity(Vector3 pos, double maxDistance) {
-        if (this.distanceSquared(pos) > Math.pow(maxDistance, 2)) {
+        double pointX = pos.x;
+        double pointZ = pos.z;
+        double distanceSquared;
+        if (pos instanceof Entity entity && !(entity instanceof Player) && entity.boundingBox != null) {
+            // A big body puts its visible head and tail far away from the centre point: the
+            // bounding box can extend well beyond the entity position. Measured from the
+            // centre, a hit on the head was farther than the
+            // reach even though the sword touched the model, and the facing check refused a
+            // player who faced the head while the centre was behind his back. The hit is
+            // measured to the nearest point of the bounding box instead; a player standing
+            // inside the body is at distance zero. Players keep the centre measurement so the
+            // PvP reach does not change by a single block.
+            AxisAlignedBB box = entity.boundingBox;
+            double eyeY = this.y + this.getEyeHeight();
+            double nearestX = NukkitMath.clamp(this.x, box.getMinX(), box.getMaxX());
+            double nearestY = NukkitMath.clamp(eyeY, box.getMinY(), box.getMaxY());
+            double nearestZ = NukkitMath.clamp(this.z, box.getMinZ(), box.getMaxZ());
+            double dx = nearestX - this.x;
+            double dy = nearestY - eyeY;
+            double dz = nearestZ - this.z;
+            distanceSquared = dx * dx + dy * dy + dz * dz;
+            pointX = nearestX;
+            pointZ = nearestZ;
+        } else {
+            distanceSquared = this.distanceSquared(pos);
+        }
+        if (distanceSquared > maxDistance * maxDistance) {
             return false;
         }
 
         Vector2 dV = this.getDirectionPlane();
-        return (dV.dot(new Vector2(pos.x, pos.z)) - dV.dot(new Vector2(this.x, this.z))) >= -0.87;
+        return (dV.dot(new Vector2(pointX, pointZ)) - dV.dot(new Vector2(this.x, this.z))) >= -0.87;
     }
 
     protected void processLogin() {

--- a/src/test/java/cn/nukkit/PlayerEntityReachTest.java
+++ b/src/test/java/cn/nukkit/PlayerEntityReachTest.java
@@ -1,0 +1,79 @@
+package cn.nukkit;
+
+import cn.nukkit.entity.Entity;
+import cn.nukkit.math.SimpleAxisAlignedBB;
+import cn.nukkit.math.Vector2;
+import cn.nukkit.math.Vector3;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class PlayerEntityReachTest {
+    @Test
+    void nearbyFaceOfLargeBodyCanBeHitDespiteDistantCentre() throws Exception {
+        assertTrue(canReach(entity(20, 2, 30, 0, 8), 3));
+    }
+
+    @Test
+    void attackerInsideLargeBodyCanHitIt() throws Exception {
+        assertTrue(canReach(entity(20, -2, 30, 0, 8), 3));
+    }
+
+    @Test
+    void nearestFaceBeyondReachStillRefusesTheHit() throws Exception {
+        assertFalse(canReach(entity(20, 3.01, 30, 0, 8), 3));
+    }
+
+    @Test
+    void nearestFaceBehindAttackerStillRefusesTheHit() throws Exception {
+        assertFalse(canReach(entity(-8, -12, -2, 0, 8), 3));
+    }
+
+    @Test
+    void verticalDistanceIsMeasuredFromTheAttackersEyes() throws Exception {
+        assertTrue(canReach(entity(1, 0, 2, 4.5, 8), 3));
+        assertFalse(canReach(entity(1, 0, 2, 4.7, 8), 3));
+    }
+
+    @Test
+    void playerTargetsKeepCentreBasedReachEvenWithALargeBox() throws Exception {
+        Player target = mock(Player.class);
+        target.x = 4;
+        target.boundingBox = new SimpleAxisAlignedBB(0, 0, -1, 10, 8, 1);
+        assertFalse(canReach(target, 3));
+        target.x = 3;
+        assertTrue(canReach(target, 3));
+    }
+
+    @Test
+    void plainPositionsAndEntitiesWithoutABoxKeepTheOldChecks() throws Exception {
+        assertTrue(canReach(new Vector3(3, 0, 0), 3));
+        assertFalse(canReach(new Vector3(3.01, 0, 0), 3));
+        Entity target = mock(Entity.class);
+        target.x = 3;
+        assertTrue(canReach(target, 3));
+        target.x = -3;
+        assertFalse(canReach(target, 3));
+    }
+
+    private static Entity entity(double centreX, double minX, double maxX, double minY, double maxY) {
+        Entity target = mock(Entity.class);
+        target.x = centreX;
+        target.boundingBox = new SimpleAxisAlignedBB(minX, minY, -1, maxX, maxY, 1);
+        return target;
+    }
+
+    private static boolean canReach(Vector3 target, double reach) throws Exception {
+        Player player = mock(Player.class);
+        when(player.getEyeHeight()).thenReturn(1.62f);
+        when(player.getDirectionPlane()).thenReturn(new Vector2(1, 0));
+        doCallRealMethod().when(player).distanceSquared(any(Vector3.class));
+        Method method = Player.class.getDeclaredMethod("canInteractEntity", Vector3.class, double.class);
+        method.setAccessible(true);
+        return (boolean) method.invoke(player, target, reach);
+    }
+}


### PR DESCRIPTION
Melee interaction measures reach and facing against an entity's position. For large or scaled entities, a player can stand next to the visible body while that position remains beyond reach or behind the attacker, so the server silently rejects the hit.

Measure non-player targets to the nearest point on their bounding box from the attacker's eyes, using that same point for the facing check. Preserve the existing centre-based checks for players, plain positions, and entities without a bounding box; PvP reach is unchanged.

Validation: all 7 PlayerEntityReachTest cases pass, covering near/far faces, standing inside the body, facing away, vertical reach, player targets, and the fallback path.
