### PR TITLE
fix: preserve rolled server logs beyond seven restarts per day

### DIFF
--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -10,6 +10,16 @@
                 <TimeBasedTriggeringPolicy/>
                 <OnStartupTriggeringPolicy/>
             </Policies>
+            <!-- Keep every rolled log. The default strategy caps the index at 7 per day and
+                 renumbers on rollover, so the eighth restart of a day silently deletes the
+                 oldest archive. Prune only when the archives together exceed 1 GB. -->
+            <DefaultRolloverStrategy fileIndex="nomax">
+                <Delete basePath="logs" maxDepth="1">
+                    <IfFileName glob="*.log.gz">
+                        <IfAccumulatedFileSize exceeds="1 GB"/>
+                    </IfFileName>
+                </Delete>
+            </DefaultRolloverStrategy>
         </RollingRandomAccessFile>
     </Appenders>
     <Loggers>


### PR DESCRIPTION
The rolling file appender uses Log4j's default seven-index archive limit. More than seven restarts or rollovers in a day silently delete that day's earliest logs, even when total log storage is small.

Use monotonically increasing archive indices and prune compressed log archives by a 1 GB aggregate limit. The existing daily/startup triggers and file formats are unchanged; the deletion condition only matches *.log.gz directly under logs.

Validation: exercised the real Log4j rolling appender with nine rollovers in an isolated temporary directory. The original configuration retained 7 archives; the proposed configuration retained all 9. An unrelated file survived both runs. The 1 GB retention threshold is explicit configuration policy, not a protocol requirement.
