### PR TITLE
fix: preserve active consumable use across premature repeated input

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -1105,6 +1105,36 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
         return this.getDataFlag(DATA_FLAGS, DATA_FLAG_ACTION) && this.startAction > -1;
     }
 
+    /**
+     * Whether a use transaction is only a repeat of a consumable that is still being used.
+     *
+     * <p>The client keeps sending {@code USE_ITEM_ACTION_CLICK_AIR} while the button is held down,
+     * and a player in a fight taps the button rather than holding it. Such a transaction arrives
+     * before the item is ready ({@code ticksUsed < useDuration}), so handing it to
+     * {@code Item#onUse} only gets the item refused - while the use state is already gone and the
+     * food is never eaten. Items without a use duration (bow, crossbow, shield) are released by the
+     * client and are not affected.
+     */
+    static boolean isRepeatedConsumableUse(int useDuration, int ticksUsed) {
+        return useDuration > 0 && ticksUsed < useDuration;
+    }
+
+    /**
+     * Whether a consumable is being used right now: food, a potion, milk or the ominous bottle.
+     *
+     * <p>Only these items carry a use duration and are finished by the server timer in
+     * {@link #processAutoCompletion()}. A bow, a crossbow or a shield keeps {@code useDuration == 0}
+     * and is finished by the client releasing the button, so they keep the old behaviour wherever
+     * this check guards a reset.
+     */
+    public boolean isConsumingItem() {
+        if (!this.isUsingItem() || this.inventory == null) {
+            return false;
+        }
+        Item held = this.inventory.getItemInHandFast();
+        return held != null && held.canRelease() && held.getUseDuration() > 0;
+    }
+
     public void setUsingItem(boolean value) {
         this.startAction = value ? this.server.getTick() : -1;
         this.setDataFlag(DATA_FLAGS, DATA_FLAG_ACTION, value);
@@ -4186,7 +4216,12 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                         this.needSendData = true;
                     } else {
                         this.setSprinting(true);
-                        this.setUsingItem(false);
+                        // Bedrock lets a player eat while sprinting, and sprint is toggled all the
+                        // time in a fight (knock-back, a released stick). Dropping the use state
+                        // here made the food silently never finish.
+                        if (!this.isConsumingItem()) {
+                            this.setUsingItem(false);
+                        }
                     }
                 }
 
@@ -4679,7 +4714,9 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                         break packetswitch;
                 }
 
-                this.setUsingItem(false);
+                if (!this.isConsumingItem()) {
+                    this.setUsingItem(false);
+                }
                 break;
             case ProtocolInfo.INTERACT_PACKET:
                 if (!this.spawned || !this.isAlive()) {
@@ -5605,6 +5642,13 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                                 }
 
                                 int ticksUsed = this.server.getTick() - this.startAction;
+                                if (isRepeatedConsumableUse(item.getUseDuration(), ticksUsed)) {
+                                    // The client repeats this transaction while the button is held
+                                    // down. Handing it to onUse() this early only gets the item
+                                    // refused, and the use state would be gone: the food is never
+                                    // eaten. Keep using it and let processAutoCompletion() finish.
+                                    break;
+                                }
                                 this.setUsingItem(false);
                                 if (!item.onUse(this, ticksUsed)) {
                                     this.inventory.sendContents(this);

--- a/src/test/java/cn/nukkit/PlayerConsumableUseTest.java
+++ b/src/test/java/cn/nukkit/PlayerConsumableUseTest.java
@@ -1,0 +1,35 @@
+package cn.nukkit;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A consumable is finished by the server timer, so a use transaction that repeats while the item is
+ * still being eaten must be ignored instead of cancelling the use.
+ */
+class PlayerConsumableUseTest {
+
+    @Test
+    @DisplayName("a repeat before the food is ready keeps the item in use")
+    void repeatBeforeReadyKeepsUsing() {
+        assertTrue(Player.isRepeatedConsumableUse(32, 0));
+        assertTrue(Player.isRepeatedConsumableUse(32, 31));
+    }
+
+    @Test
+    @DisplayName("the transaction that completes the food is handled as before")
+    void completedUseIsNotTreatedAsRepeat() {
+        assertFalse(Player.isRepeatedConsumableUse(32, 32));
+        assertFalse(Player.isRepeatedConsumableUse(32, 100));
+    }
+
+    @Test
+    @DisplayName("items released by the client keep the old behaviour")
+    void itemsWithoutUseDurationAreUntouched() {
+        assertFalse(Player.isRepeatedConsumableUse(0, 0));
+        assertFalse(Player.isRepeatedConsumableUse(0, 5));
+    }
+}


### PR DESCRIPTION
Repeated right-click/use transactions before a consumable's use duration expires clear the player's use state before `Item.onUse()` rejects the premature completion. Starting to sprint and unrelated legacy player actions also clear that state, preventing the server's automatic completion from finishing the food or drink.

Preserve an active consumable's use timer across premature repeated clicks, sprint starts, and the player-action fall-through. Bows, crossbows, shields, and other items without a timed use duration keep their existing release behavior. Transactions received at or after the required duration still complete normally.

Validation: 12 focused tests passed (3 consumable-use predicate tests, 7 food tests, 2 swimming tests). The new unit cases check the pre-completion condition, completion boundary, and items released by the client; they do not simulate the full packet sequence.
