### PR TITLE
fix: replay block destruction endings before starting the next block

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -4064,8 +4064,16 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                     return;
                 }
 
-                if (!authPacket.getBlockActionData().isEmpty()) {
-                    for (PlayerBlockActionData action : orderBlockActions(authPacket.getBlockActionData().values())) {
+                // A creative client can finish several blocks in one input tick. Replaying the
+                // legacy map silently loses all but the last action of each type, leaving blocks
+                // hidden on the client without ever asking the level to break or restore them.
+                // Only map-only packets need the ordering repair; decoded actions have wire order.
+                List<PlayerBlockActionData> blockActions = authPacket.getDecodedBlockActions();
+                if (blockActions.isEmpty()) {
+                    blockActions = orderBlockActions(authPacket.getBlockActionData().values());
+                }
+                if (!blockActions.isEmpty()) {
+                    for (PlayerBlockActionData action : blockActions) {
                         BlockVector3 blockPos = action.getPosition();
                         if (blockPos == null) {
                             continue;

--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -4065,7 +4065,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                 }
 
                 if (!authPacket.getBlockActionData().isEmpty()) {
-                    for (PlayerBlockActionData action : authPacket.getBlockActionData().values()) {
+                    for (PlayerBlockActionData action : orderBlockActions(authPacket.getBlockActionData().values())) {
                         BlockVector3 blockPos = action.getPosition();
                         if (blockPos == null) {
                             continue;
@@ -4080,7 +4080,9 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                         if (lastBreakPos != null && (lastBreakPos.getX() != blockPos.getX() ||
                                 lastBreakPos.getY() != blockPos.getY() || lastBreakPos.getZ() != blockPos.getZ())) {
                             this.onBlockBreakAbort(lastBreakPos.asVector3(), BlockFace.DOWN);
-                            this.onBlockBreakStart(blockPos.asVector3(), blockFace);
+                            if (!endsBlockDestruction(action.getAction())) {
+                                this.onBlockBreakStart(blockPos.asVector3(), blockFace);
+                            }
                         }
 
                         switch (action.getAction()) {
@@ -5931,6 +5933,40 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
             this.needSendInventory = true;
             return false;
         }
+    }
+
+    /**
+     * Replays the block actions of a single input tick in causal order.
+     *
+     * <p>{@link cn.nukkit.network.protocol.PlayerAuthInputPacket} collects the block actions of a
+     * tick into an {@link java.util.EnumMap}, so the order in which the client sent them is lost and
+     * the values are iterated by {@link PlayerActionType} ordinal instead. The client finishes a
+     * block and reaches for the next one in one tick, sending
+     * {@code PREDICT_DESTROY_BLOCK(finished)} followed by {@code START_DESTROY_BLOCK(next)}; the
+     * ordinals replay that backwards, because {@code START_DESTROY_BLOCK} is the first constant of
+     * the enum and {@code PREDICT_DESTROY_BLOCK} is close to the last. Starting the next block first
+     * moves {@code lastBreak} to the current millisecond, and the completion that follows is then
+     * judged against a timer that started an instant ago: {@link cn.nukkit.level.Level#useBreakOn}
+     * reports {@code fastBreak} and the finished block is refused and sent back to the player.
+     *
+     * <p>Actions that END a destruction therefore run before the ones that begin or continue one.
+     * The sort is stable, so actions of the same group keep the order they already had.
+     */
+    static List<PlayerBlockActionData> orderBlockActions(Collection<PlayerBlockActionData> actions) {
+        List<PlayerBlockActionData> ordered = new ArrayList<>(actions);
+        if (ordered.size() > 1) {
+            ordered.sort(Comparator.comparingInt(action -> endsBlockDestruction(action.getAction()) ? 0 : 1));
+        }
+        return ordered;
+    }
+
+    /**
+     * Does this action end the destruction of a block rather than begin or continue one?
+     */
+    static boolean endsBlockDestruction(PlayerActionType action) {
+        return action == PlayerActionType.PREDICT_DESTROY_BLOCK
+                || action == PlayerActionType.ABORT_DESTROY_BLOCK
+                || action == PlayerActionType.STOP_DESTROY_BLOCK;
     }
 
     private void onBlockBreakContinue(Vector3 pos, BlockFace face) {

--- a/src/main/java/cn/nukkit/network/protocol/PlayerAuthInputPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/PlayerAuthInputPacket.java
@@ -13,8 +13,10 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
+import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -49,6 +51,10 @@ public class PlayerAuthInputPacket extends DataPacket {
     private InventoryTransactionPacket itemUseTransaction;
     private ItemStackRequest itemStackRequest;
     private Map<PlayerActionType, PlayerBlockActionData> blockActionData = new EnumMap<>(PlayerActionType.class);
+    /** All decoded actions in wire order; the legacy map can retain only the last of each type. */
+    private final List<PlayerBlockActionData> decodedBlockActions = new ArrayList<>();
+    @Getter(lombok.AccessLevel.NONE)
+    private final Map<PlayerActionType, PlayerBlockActionData> decodedBlockActionSnapshot = new EnumMap<>(PlayerActionType.class);
     /**
      * @since v748
      */
@@ -94,6 +100,9 @@ public class PlayerAuthInputPacket extends DataPacket {
 
     @Override
     public void decode() {
+        this.blockActionData.clear();
+        this.decodedBlockActions.clear();
+        this.decodedBlockActionSnapshot.clear();
         this.pitch = this.getLFloat();
         this.yaw = this.getLFloat();
         this.position = this.getVector3f();
@@ -227,7 +236,7 @@ public class PlayerAuthInputPacket extends DataPacket {
                 if (type == null) {
                     continue;
                 }
-                this.blockActionData.put(type, new PlayerBlockActionData(type, position, facing));
+                this.addDecodedBlockAction(new PlayerBlockActionData(type, position, facing));
             } else {
                 // pre-v2168: 仅 5 种动作携带 position+face / only 5 action types carry position+face
                 if (type == null) {
@@ -239,13 +248,47 @@ public class PlayerAuthInputPacket extends DataPacket {
                     case CRACK_BLOCK:
                     case PREDICT_DESTROY_BLOCK:
                     case CONTINUE_DESTROY_BLOCK:
-                        this.blockActionData.put(type, new PlayerBlockActionData(type, this.getSignedBlockPosition(), this.getVarInt()));
+                        this.addDecodedBlockAction(new PlayerBlockActionData(type, this.getSignedBlockPosition(), this.getVarInt()));
                         break;
                     default:
-                        this.blockActionData.put(type, new PlayerBlockActionData(type, null, -1));
+                        this.addDecodedBlockAction(new PlayerBlockActionData(type, null, -1));
                 }
             }
         }
+        // Packet listeners may mutate the legacy map, its actions or their coordinates.
+        // Preserve those filters instead of replaying an unfiltered decoded sequence.
+        this.blockActionData.forEach((type, action) ->
+                this.decodedBlockActionSnapshot.put(type, copyBlockAction(action)));
+    }
+
+    /**
+     * Returns a read-only snapshot of the decoded sequence for replay, or an empty list when a
+     * legacy map edit requires fallback. Snapshot actions and positions are defensive copies;
+     * packet listeners should use {@link #getBlockActionData()} or {@link #setBlockActionData(Map)}
+     * to filter or replace actions.
+     */
+    public List<PlayerBlockActionData> getDecodedBlockActions() {
+        return this.blockActionData.equals(this.decodedBlockActionSnapshot)
+                ? this.decodedBlockActions.stream().map(PlayerAuthInputPacket::copyBlockAction).toList()
+                : List.of();
+    }
+
+    private static PlayerBlockActionData copyBlockAction(PlayerBlockActionData action) {
+        BlockVector3 pos = action.getPosition();
+        return new PlayerBlockActionData(action.getAction(),
+                pos == null ? null : new BlockVector3(pos.x, pos.y, pos.z), action.getFacing());
+    }
+
+    private void addDecodedBlockAction(PlayerBlockActionData action) {
+        this.decodedBlockActions.add(action);
+        this.blockActionData.put(action.getAction(), action);
+    }
+
+    /** Replacing the legacy map explicitly also replaces the decoded action sequence. */
+    public void setBlockActionData(Map<PlayerActionType, PlayerBlockActionData> actions) {
+        this.decodedBlockActions.clear();
+        this.decodedBlockActionSnapshot.clear();
+        this.blockActionData = actions;
     }
 
     private InventoryTransactionPacket readItemUseTransaction() {

--- a/src/test/java/cn/nukkit/PlayerAuthInputBlockActionsTest.java
+++ b/src/test/java/cn/nukkit/PlayerAuthInputBlockActionsTest.java
@@ -1,0 +1,303 @@
+package cn.nukkit;
+
+import cn.nukkit.block.BlockStone;
+import cn.nukkit.event.player.PlayerInteractEvent;
+import cn.nukkit.event.server.DataPacketReceiveEvent;
+import cn.nukkit.inventory.PlayerInventory;
+import cn.nukkit.item.Item;
+import cn.nukkit.level.Level;
+import cn.nukkit.math.BlockFace;
+import cn.nukkit.math.BlockVector3;
+import cn.nukkit.math.Vector3;
+import cn.nukkit.network.SourceInterface;
+import cn.nukkit.network.protocol.DataPacket;
+import cn.nukkit.network.protocol.PlayerAuthInputPacket;
+import cn.nukkit.network.protocol.UpdateBlockPacket;
+import cn.nukkit.network.protocol.regression.AbstractPacketRegressionTest;
+import cn.nukkit.network.protocol.types.PlayerActionType;
+import cn.nukkit.network.protocol.types.PlayerBlockActionData;
+import cn.nukkit.network.session.NetworkPlayerSession;
+import cn.nukkit.plugin.PluginManager;
+import org.cloudburstmc.math.vector.Vector2f;
+import org.cloudburstmc.math.vector.Vector3f;
+import org.cloudburstmc.math.vector.Vector3i;
+import org.cloudburstmc.protocol.bedrock.data.ClientPlayMode;
+import org.cloudburstmc.protocol.bedrock.data.InputInteractionModel;
+import org.cloudburstmc.protocol.bedrock.data.InputMode;
+import org.cloudburstmc.protocol.bedrock.data.PlayerAuthInputData;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mockito;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.cloudburstmc.protocol.bedrock.data.PlayerActionType.BLOCK_PREDICT_DESTROY;
+import static org.cloudburstmc.protocol.bedrock.data.PlayerActionType.START_BREAK;
+
+/** Exercises reference-encoded input through the real player handler and its authoritative break path. */
+class PlayerAuthInputBlockActionsTest extends AbstractPacketRegressionTest {
+
+    private static Stream<Arguments> rejectedBlocks() {
+        return Stream.of(589, 844, 2168, 2169)
+                .flatMap(protocol -> Stream.of(Arguments.of(protocol, 1), Arguments.of(protocol, 2)));
+    }
+
+    @ParameterizedTest(name = "v{0}, rejected block {1}")
+    @MethodSource("rejectedBlocks")
+    void everyPredictedBreakIsJudgedAndOnlyRejectedBlockIsRestored(int protocol, int rejectedX) {
+        Harness harness = new Harness(protocol, rejectedX);
+        PlayerAuthInputPacket packet = input(protocol,
+                action(BLOCK_PREDICT_DESTROY, 1), action(BLOCK_PREDICT_DESTROY, 2));
+
+        harness.player.handleDataPacket(packet);
+
+        assertEquals(List.of(1, 2), harness.breaks,
+                "Both predicted removals must reach the authoritative break check, including repeated action types");
+        assertEquals(List.of(rejectedX), harness.restored,
+                "A rejected prediction must resend that block without restoring the accepted neighbor");
+    }
+
+    @ParameterizedTest(name = "v{0}")
+    @ValueSource(ints = {589, 844, 2168, 2169})
+    void interleavedStartsStayBetweenTheBreaksTheySeparate(int protocol) {
+        Harness harness = new Harness(protocol, -1);
+        PlayerAuthInputPacket packet = input(protocol,
+                action(BLOCK_PREDICT_DESTROY, 1), action(START_BREAK, 2),
+                action(BLOCK_PREDICT_DESTROY, 2), action(START_BREAK, 3));
+
+        harness.player.handleDataPacket(packet);
+
+        assertEquals(List.of("break:1", "start:2", "break:2", "start:3"), harness.trace,
+                "Grouping all completions first must not move the second completion ahead of its own start");
+        assertEquals(List.of(), harness.restored);
+    }
+
+    @ParameterizedTest(name = "legacy map v{0}")
+    @ValueSource(ints = {589, 844, 2168, 2169})
+    void manuallyPopulatedLegacyMapStillCompletesBeforeStartingNextBlock(int protocol) {
+        Harness harness = new Harness(protocol, 1);
+        PlayerAuthInputPacket packet = new PlayerAuthInputPacket();
+        packet.setPosition(new cn.nukkit.math.Vector3f(0, 65.62f, 0));
+        packet.getBlockActionData().put(PlayerActionType.START_DESTROY_BLOCK,
+                new PlayerBlockActionData(PlayerActionType.START_DESTROY_BLOCK, new BlockVector3(2, 64, 0), 1));
+        packet.getBlockActionData().put(PlayerActionType.PREDICT_DESTROY_BLOCK,
+                new PlayerBlockActionData(PlayerActionType.PREDICT_DESTROY_BLOCK, new BlockVector3(1, 64, 0), 1));
+
+        harness.player.handleDataPacket(packet);
+
+        assertEquals(List.of("break:1", "start:2"), harness.trace);
+        assertEquals(List.of(1), harness.restored);
+    }
+
+    @ParameterizedTest(name = "decoded snapshot v{0}")
+    @ValueSource(ints = {589, 844, 2168, 2169})
+    void decodedSequenceIsAReadOnlySnapshotWithoutMutablePacketAliases(int protocol) {
+        Harness harness = new Harness(protocol, -1);
+        PlayerAuthInputPacket packet = input(protocol, action(BLOCK_PREDICT_DESTROY, 1),
+                action(BLOCK_PREDICT_DESTROY, 2), action(START_BREAK, 3));
+        List<PlayerBlockActionData> snapshot = packet.getDecodedBlockActions();
+        assertThrows(UnsupportedOperationException.class, snapshot::clear);
+        assertThrows(UnsupportedOperationException.class, () -> snapshot.remove(snapshot.size() - 1));
+        snapshot.get(0).getPosition().setComponents(4, 64, 0);
+        snapshot.get(1).setPosition(new BlockVector3(5, 64, 0));
+        snapshot.get(2).setAction(PlayerActionType.PREDICT_DESTROY_BLOCK);
+
+        assertEquals(List.of(1, 2, 3), packet.getDecodedBlockActions().stream()
+                .map(action -> action.getPosition().getX()).toList());
+        assertEquals(2, packet.getBlockActionData().get(PlayerActionType.PREDICT_DESTROY_BLOCK)
+                .getPosition().getX(), "snapshot mutations must not alias the legacy map");
+        harness.player.handleDataPacket(packet);
+        assertEquals(List.of("break:1", "break:2", "start:3"), harness.trace,
+                "snapshot mutations must not change replay or trigger lossy legacy-map fallback");
+    }
+
+    private static Stream<Arguments> legacyMapEdits() {
+        return Stream.of(589, 844, 2168, 2169)
+                .flatMap(protocol -> Stream.of(LegacyMapEdit.values()).map(edit -> Arguments.of(protocol, edit)));
+    }
+
+    @ParameterizedTest(name = "legacy listener v{0}: {1}")
+    @MethodSource("legacyMapEdits")
+    void receiveListenersCanStillChangeDecodedActionsThroughLegacyMap(int protocol, LegacyMapEdit edit) {
+        Harness harness = new Harness(protocol, 4);
+        PlayerAuthInputPacket packet = input(protocol, action(BLOCK_PREDICT_DESTROY, 1),
+                action(BLOCK_PREDICT_DESTROY, 2), action(START_BREAK, 3));
+        harness.packetListener = received -> {
+            PlayerBlockActionData replacement = new PlayerBlockActionData(
+                    PlayerActionType.PREDICT_DESTROY_BLOCK, new BlockVector3(4, 64, 0), 1);
+            switch (edit) {
+                case CLEAR -> received.getBlockActionData().clear();
+                case REMOVE -> received.getBlockActionData().remove(PlayerActionType.PREDICT_DESTROY_BLOCK);
+                case PUT -> received.getBlockActionData().put(PlayerActionType.PREDICT_DESTROY_BLOCK, replacement);
+                case SET_MAP -> {
+                    var replacementMap = new EnumMap<PlayerActionType, PlayerBlockActionData>(PlayerActionType.class);
+                    replacementMap.put(PlayerActionType.PREDICT_DESTROY_BLOCK, replacement);
+                    received.setBlockActionData(replacementMap);
+                }
+                case SET_POSITION -> received.getBlockActionData().get(PlayerActionType.PREDICT_DESTROY_BLOCK)
+                        .setPosition(new BlockVector3(4, 64, 0));
+                case MUTATE_POSITION -> received.getBlockActionData().get(PlayerActionType.PREDICT_DESTROY_BLOCK)
+                        .getPosition().setComponents(4, 64, 0);
+            }
+        };
+
+        harness.player.handleDataPacket(packet);
+
+        List<String> expectedTrace = switch (edit) {
+            case CLEAR -> List.of();
+            case REMOVE -> List.of("start:3");
+            case SET_MAP -> List.of("break:4");
+            default -> List.of("break:4", "start:3");
+        };
+        List<Integer> expectedBreaks = edit == LegacyMapEdit.CLEAR || edit == LegacyMapEdit.REMOVE
+                ? List.of() : List.of(4);
+        assertEquals(expectedTrace, harness.trace,
+                "An event listener's map edit must override the decoded actions before execution");
+        assertEquals(expectedBreaks, harness.breaks, "Removed or replaced predictions must never execute");
+        assertEquals(expectedBreaks, harness.restored, "The replacement still uses the authoritative rejection path");
+    }
+
+    private enum LegacyMapEdit {
+        CLEAR, REMOVE, PUT, SET_MAP, SET_POSITION, MUTATE_POSITION
+    }
+
+    private PlayerAuthInputPacket input(int protocol,
+            org.cloudburstmc.protocol.bedrock.data.PlayerBlockActionData... actions) {
+        var packet = new org.cloudburstmc.protocol.bedrock.packet.PlayerAuthInputPacket();
+        packet.setRotation(Vector3f.ZERO);
+        packet.setPosition(Vector3f.from(0, 65.62f, 0));
+        packet.setMotion(Vector2f.ZERO);
+        packet.setInputMode(InputMode.MOUSE);
+        packet.setPlayMode(ClientPlayMode.NORMAL);
+        packet.setInputInteractionModel(InputInteractionModel.CROSSHAIR);
+        packet.setTick(100);
+        packet.setDelta(Vector3f.ZERO);
+        packet.setAnalogMoveVector(Vector2f.ZERO);
+        packet.setInteractRotation(Vector2f.ZERO);
+        packet.setCameraOrientation(Vector3f.ZERO);
+        packet.setRawMoveVector(Vector2f.ZERO);
+        packet.getInputData().add(PlayerAuthInputData.PERFORM_BLOCK_ACTIONS);
+        packet.getPlayerActions().addAll(List.of(actions));
+
+        // Cloudburst currently exposes 2168, not 2169; their auth-input wire shape is shared.
+        PlayerAuthInputPacket decoded = crossEncode(packet, PlayerAuthInputPacket::new,
+                protocol == 2169 ? 2168 : protocol);
+        if (protocol == 2169) {
+            PlayerAuthInputPacket latest = new PlayerAuthInputPacket();
+            latest.protocol = protocol;
+            latest.gameVersion = GameVersion.byProtocol(protocol, false);
+            latest.setBuffer(decoded.getBuffer());
+            latest.getUnsignedVarInt();
+            latest.decode();
+            decoded = latest;
+        }
+        assertEquals(decoded.getCount(), decoded.getOffset(), "The complete input payload must be consumed");
+        return decoded;
+    }
+
+    private static org.cloudburstmc.protocol.bedrock.data.PlayerBlockActionData action(
+            org.cloudburstmc.protocol.bedrock.data.PlayerActionType type, int x) {
+        var action = new org.cloudburstmc.protocol.bedrock.data.PlayerBlockActionData();
+        action.setAction(type);
+        action.setBlockPosition(Vector3i.from(x, 64, 0));
+        action.setFace(1);
+        return action;
+    }
+
+    private static final class Harness {
+        final TestPlayer player;
+        final List<Integer> breaks = new ArrayList<>();
+        final List<Integer> restored = new ArrayList<>();
+        final List<String> trace = new ArrayList<>();
+        Consumer<PlayerAuthInputPacket> packetListener = packet -> {};
+
+        Harness(int protocol, int rejectedX) {
+            MockServer.reset();
+            Server server = MockServer.get();
+            server.serverAuthoritativeMovementMode = 1;
+            Level level = Mockito.mock(Level.class);
+            PluginManager manager = server.getPluginManager();
+            Mockito.when(server.getDefaultLevel()).thenReturn(level);
+            Mockito.when(level.getBlock(Mockito.any(Vector3.class))).thenAnswer(invocation -> {
+                Vector3 position = invocation.getArgument(0);
+                BlockStone block = new BlockStone();
+                block.setComponents(position.x, position.y, position.z);
+                return block;
+            });
+            Mockito.doAnswer(invocation -> {
+                if (invocation.getArgument(0) instanceof DataPacketReceiveEvent event
+                        && event.getPacket() instanceof PlayerAuthInputPacket packet) {
+                    packetListener.accept(packet);
+                }
+                if (invocation.getArgument(0) instanceof PlayerInteractEvent event) {
+                    String start = "start:" + event.getBlock().getFloorX();
+                    // The handler can call start twice consecutively when the target changes.
+                    // Only the causal position of the start matters, not its millisecond throttle.
+                    if (trace.isEmpty() || !start.equals(trace.get(trace.size() - 1))) {
+                        trace.add(start);
+                    }
+                }
+                return null;
+            }).when(manager).callEvent(Mockito.any());
+
+            SourceInterface source = Mockito.mock(SourceInterface.class);
+            NetworkPlayerSession session = Mockito.mock(NetworkPlayerSession.class);
+            Mockito.when(source.getSession(Mockito.any(InetSocketAddress.class)))
+                    .thenReturn(session);
+            player = new TestPlayer(source, protocol);
+            Mockito.when(level.useBreakOn(Mockito.any(Vector3.class), Mockito.eq(BlockFace.UP),
+                    Mockito.any(Item.class), Mockito.same(player), Mockito.eq(true))).thenAnswer(invocation -> {
+                Vector3 position = invocation.getArgument(0);
+                int x = position.getFloorX();
+                breaks.add(x);
+                trace.add("break:" + x);
+                return x == rejectedX ? null : invocation.getArgument(2);
+            });
+            Mockito.doAnswer(invocation -> {
+                Player[] recipients = invocation.getArgument(0);
+                assertEquals(List.of(player), List.of(recipients));
+                Vector3[] positions = invocation.getArgument(1);
+                for (Vector3 position : positions) {
+                    assertEquals(64, position.getFloorY());
+                    assertEquals(0, position.getFloorZ());
+                    restored.add(position.getFloorX());
+                }
+                return null;
+            }).when(level).sendBlocks(Mockito.any(Player[].class), Mockito.any(Vector3[].class),
+                    Mockito.eq(UpdateBlockPacket.FLAG_ALL_PRIORITY));
+        }
+    }
+
+    private static final class TestPlayer extends Player {
+        TestPlayer(SourceInterface source, int protocol) {
+            super(source, 1L, new InetSocketAddress("127.0.0.1", 19132));
+            this.protocol = protocol;
+            this.gameVersion = GameVersion.byProtocol(protocol, false);
+            this.spawned = true;
+            this.loggedIn = true;
+            this.loginVerified = true;
+            this.gamemode = Player.CREATIVE;
+            this.health = 20;
+            this.y = 64;
+            this.temporalVector = new Vector3();
+            this.inventory = Mockito.mock(PlayerInventory.class);
+            Item handItem = Item.get(Item.AIR);
+            Mockito.when(this.inventory.getItemInHand()).thenReturn(handItem);
+            this.adventureSettings = new AdventureSettings(this);
+        }
+
+        @Override
+        public boolean dataPacket(DataPacket packet) {
+            return true;
+        }
+    }
+}

--- a/src/test/java/cn/nukkit/PlayerBlockActionOrderTest.java
+++ b/src/test/java/cn/nukkit/PlayerBlockActionOrderTest.java
@@ -1,0 +1,116 @@
+package cn.nukkit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import cn.nukkit.math.BlockVector3;
+import cn.nukkit.network.protocol.types.PlayerActionType;
+import cn.nukkit.network.protocol.types.PlayerBlockActionData;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A player who holds the dig button finishes one block and reaches for the next one inside a single
+ * input tick. {@code PlayerAuthInputPacket} keeps the block actions of that tick in an
+ * {@link EnumMap}, so they are replayed by {@link PlayerActionType} ordinal and the start of the
+ * next block overtakes the completion of the current one. That order restarts the dig timer an
+ * instant before the completion is judged, and the finished block is refused as a fast break.
+ */
+class PlayerBlockActionOrderTest {
+
+    private static PlayerBlockActionData action(PlayerActionType type, int x, int y, int z) {
+        return new PlayerBlockActionData(type, new BlockVector3(x, y, z), 1);
+    }
+
+    /** The tick as the packet hands it over: iteration follows the enum, not the wire. */
+    private static Map<PlayerActionType, PlayerBlockActionData> tick(PlayerBlockActionData... actions) {
+        Map<PlayerActionType, PlayerBlockActionData> map = new EnumMap<>(PlayerActionType.class);
+        for (PlayerBlockActionData action : actions) {
+            map.put(action.getAction(), action);
+        }
+        return map;
+    }
+
+    private static List<PlayerActionType> types(List<PlayerBlockActionData> actions) {
+        List<PlayerActionType> types = new ArrayList<>(actions.size());
+        for (PlayerBlockActionData action : actions) {
+            types.add(action.getAction());
+        }
+        return types;
+    }
+
+    @Test
+    @DisplayName("completion runs before the next block starts")
+    void completionRunsBeforeTheNextStart() {
+        Map<PlayerActionType, PlayerBlockActionData> tick = tick(
+                action(PlayerActionType.PREDICT_DESTROY_BLOCK, 10, 64, 10),
+                action(PlayerActionType.START_DESTROY_BLOCK, 11, 64, 10));
+
+        // Without the fix the map alone would replay the start first: it is the first enum constant.
+        assertEquals(
+                List.of(PlayerActionType.START_DESTROY_BLOCK, PlayerActionType.PREDICT_DESTROY_BLOCK),
+                types(new ArrayList<>(tick.values())));
+
+        assertEquals(
+                List.of(PlayerActionType.PREDICT_DESTROY_BLOCK, PlayerActionType.START_DESTROY_BLOCK),
+                types(Player.orderBlockActions(tick.values())));
+    }
+
+    @Test
+    @DisplayName("ending the old block runs before starting the new block")
+    void abortRunsBeforeTheNextStart() {
+        Map<PlayerActionType, PlayerBlockActionData> tick = tick(
+                action(PlayerActionType.ABORT_DESTROY_BLOCK, 10, 64, 10),
+                action(PlayerActionType.STOP_DESTROY_BLOCK, 10, 64, 10),
+                action(PlayerActionType.START_DESTROY_BLOCK, 11, 64, 10),
+                action(PlayerActionType.CONTINUE_DESTROY_BLOCK, 11, 64, 10));
+
+        assertEquals(
+                List.of(
+                        PlayerActionType.ABORT_DESTROY_BLOCK,
+                        PlayerActionType.STOP_DESTROY_BLOCK,
+                        PlayerActionType.START_DESTROY_BLOCK,
+                        PlayerActionType.CONTINUE_DESTROY_BLOCK),
+                types(Player.orderBlockActions(tick.values())));
+    }
+
+    @Test
+    @DisplayName("actions within the same group keep their order")
+    void theSortIsStableInsideAGroup() {
+        Map<PlayerActionType, PlayerBlockActionData> tick = tick(
+                action(PlayerActionType.START_DESTROY_BLOCK, 1, 64, 1),
+                action(PlayerActionType.CONTINUE_DESTROY_BLOCK, 1, 64, 1));
+
+        assertEquals(
+                List.of(PlayerActionType.START_DESTROY_BLOCK, PlayerActionType.CONTINUE_DESTROY_BLOCK),
+                types(Player.orderBlockActions(tick.values())));
+    }
+
+    @Test
+    @DisplayName("a single action is returned unchanged")
+    void aSingleActionIsReturnedAsIs() {
+        Map<PlayerActionType, PlayerBlockActionData> tick =
+                tick(action(PlayerActionType.CONTINUE_DESTROY_BLOCK, 1, 64, 1));
+
+        assertEquals(
+                List.of(PlayerActionType.CONTINUE_DESTROY_BLOCK),
+                types(Player.orderBlockActions(tick.values())));
+    }
+
+    @Test
+    @DisplayName("only destruction-ending actions are classified as endings")
+    void onlyDestructionEndingActionsCount() {
+        assertTrue(Player.endsBlockDestruction(PlayerActionType.PREDICT_DESTROY_BLOCK));
+        assertTrue(Player.endsBlockDestruction(PlayerActionType.ABORT_DESTROY_BLOCK));
+        assertTrue(Player.endsBlockDestruction(PlayerActionType.STOP_DESTROY_BLOCK));
+
+        assertFalse(Player.endsBlockDestruction(PlayerActionType.START_DESTROY_BLOCK));
+        assertFalse(Player.endsBlockDestruction(PlayerActionType.CONTINUE_DESTROY_BLOCK));
+        assertFalse(Player.endsBlockDestruction(PlayerActionType.CRACK_BLOCK));
+    }
+}


### PR DESCRIPTION
`PlayerAuthInputPacket` receives a sequence of block actions but stores it in an `EnumMap`. This loses all but the last action of each type and reorders the remaining actions by enum ordinal. Multiple predicted creative breaks in one input tick can therefore disappear before reaching the level's authoritative checks. Starting the next block before completing the previous one can also reset the dig timer and cause a false fast-break rejection.

Keep every decoded action in wire order and replay that sequence through the existing player handler. Each prediction still reaches the normal interaction, game-mode, and level checks; rejected predictions restore the corresponding block. Destruction-ending actions at another position no longer start a new dig timer.

Retain the legacy map API for plugins and manually constructed packets. A deep snapshot detects map filters, replacements, action changes, and coordinate mutations from packet listeners. If the map was changed, replay its current contents using the completion-before-start ordering repair; untouched decoded packets use their original sequence. The new decoded-sequence getter returns a read-only defensive snapshot; mutable packet filtering remains on the legacy map API. No outgoing packet layout changes.

Validation: reference-encoded packets exercise the real player handler on protocols 589, 844, 2168, and 2169, covering duplicate predictions, rejection of either position, interleaved starts and completions, manually populated maps, six kinds of receive-listener map edits, and defensive snapshot isolation. The five existing ordering tests remain in place. Protocol 2169 decoding is checked against the shared 2168 auth-input wire shape because the reference codec currently exposes 2168.
