### PR TITLE
fix: bound inbound network decoding, queues, and per-tick processing

### DIFF
--- a/src/main/java/cn/nukkit/network/Network.java
+++ b/src/main/java/cn/nukkit/network/Network.java
@@ -262,14 +262,15 @@ public class Network {
     }
 
     public boolean processBatch(byte[] payload, Collection<DataPacket> packets, CompressionProvider compression, int raknetProtocol, Player player) {
-        return this.processBatch(payload, packets, compression, raknetProtocol, player, true);
+        return this.processBatchMeasured(payload, packets, compression, raknetProtocol, player, true).success();
     }
 
     public boolean processBatchQuietly(byte[] payload, Collection<DataPacket> packets, CompressionProvider compression, int raknetProtocol, Player player) {
-        return this.processBatch(payload, packets, compression, raknetProtocol, player, false);
+        return this.processBatchMeasured(payload, packets, compression, raknetProtocol, player, false).success();
     }
 
-    private boolean processBatch(byte[] payload, Collection<DataPacket> packets, CompressionProvider compression, int raknetProtocol, Player player, boolean warnOnFailure) {
+    public BatchProcessResult processBatchMeasured(byte[] payload, Collection<DataPacket> packets, CompressionProvider compression,
+                                                   int raknetProtocol, Player player, boolean warnOnFailure) {
         int maxSize = 3145728; // 3 * 1024 * 1024
         if (player != null && player.getSkin() == null) {
             maxSize = 6291456; // 6 * 1024 * 1024
@@ -283,7 +284,16 @@ public class Network {
             } else if (log.isDebugEnabled()) {
                 log.debug("Exception while decompressing batch packet (compression={}, {} bytes)", compression, payload.length, e);
             }
-            return false;
+            return BatchProcessResult.failed(maxSize, MAX_BATCH_PACKET_COUNT, e);
+        }
+
+        // Providers such as NONE do not enforce the requested decompression limit themselves.
+        if (data.length > maxSize) {
+            ProtocolException failure = new ProtocolException("Decompressed batch exceeds " + maxSize + " bytes");
+            if (warnOnFailure) {
+                log.warn("Rejected oversized decoded batch (compression={}, decompressed={} bytes)", compression, data.length);
+            }
+            return BatchProcessResult.failed(data.length, 0, failure);
         }
 
         BinaryStream stream = new BinaryStream(data);
@@ -365,9 +375,24 @@ public class Network {
                 log.debug("Error whilst decoding batch packet (decoded {} packets, compression={}, decompressed={} bytes)",
                         count, compression, data.length, e);
             }
-            return false;
+            return BatchProcessResult.failed(data.length, Math.min(count, MAX_BATCH_PACKET_COUNT), e);
         }
-        return count > 0;
+        if (count == 0) {
+            return BatchProcessResult.failed(data.length, 0, null);
+        }
+        return BatchProcessResult.success(data.length, count);
+    }
+
+    /** Work performed while decoding one compressed batch, including frames with unknown packet IDs. */
+    public record BatchProcessResult(boolean success, int decompressedBytes, int framedPackets, Throwable failure) {
+
+        static BatchProcessResult success(int decompressedBytes, int framedPackets) {
+            return new BatchProcessResult(true, decompressedBytes, framedPackets, null);
+        }
+
+        static BatchProcessResult failed(int decompressedBytes, int framedPackets, Throwable failure) {
+            return new BatchProcessResult(false, decompressedBytes, framedPackets, failure);
+        }
     }
 
     /**

--- a/src/main/java/cn/nukkit/network/RakNetInterface.java
+++ b/src/main/java/cn/nukkit/network/RakNetInterface.java
@@ -45,6 +45,9 @@ import java.util.concurrent.TimeUnit;
 @Log4j2
 public class RakNetInterface implements AdvancedSourceInterface {
 
+    static final int MAX_INBOUND_PACKETS_PER_INTERFACE_TICK = 2048;
+    static final long MAX_INBOUND_BYTES_PER_INTERFACE_TICK = 6L * 1024L * 1024L;
+
     private final Server server;
     private Network network;
 
@@ -56,6 +59,7 @@ public class RakNetInterface implements AdvancedSourceInterface {
     private final Set<RakNetPlayerSession> pendingSessions = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
     private final long serverId = ThreadLocalRandom.current().nextLong();
+    private int inboundRoundRobinCursor;
 
     public RakNetInterface(Server server) {
         this.server = server;
@@ -200,6 +204,7 @@ public class RakNetInterface implements AdvancedSourceInterface {
             }
         }
 
+        List<RakNetPlayerSession> activeSessions = new ArrayList<>(this.sessions.size());
         Iterator<RakNetPlayerSession> iterator = this.sessions.values().iterator();
         while (iterator.hasNext()) {
             RakNetPlayerSession nukkitSession = iterator.next();
@@ -214,10 +219,32 @@ public class RakNetInterface implements AdvancedSourceInterface {
                 this.clearProxyProtocolMapping(nukkitSession);
                 iterator.remove();
             } else {
-                nukkitSession.serverTick();
+                activeSessions.add(nukkitSession);
             }
         }
+        this.drainInboundFairly(activeSessions);
         return true;
+    }
+
+    void drainInboundFairly(List<RakNetPlayerSession> activeSessions) {
+        if (activeSessions.isEmpty()) {
+            this.inboundRoundRobinCursor = 0;
+            return;
+        }
+        int size = activeSessions.size();
+        int start = Math.floorMod(this.inboundRoundRobinCursor, size);
+        int remainingPackets = MAX_INBOUND_PACKETS_PER_INTERFACE_TICK;
+        long remainingBytes = MAX_INBOUND_BYTES_PER_INTERFACE_TICK;
+        int visited = 0;
+        while (visited < size && remainingPackets > 0 && remainingBytes > 0L) {
+            RakNetPlayerSession nukkitSession = activeSessions.get((start + visited) % size);
+            RakNetPlayerSession.InboundDrain drained =
+                    nukkitSession.serverTick(remainingPackets, remainingBytes);
+            remainingPackets -= drained.packets();
+            remainingBytes -= drained.bytes();
+            visited++;
+        }
+        this.inboundRoundRobinCursor = (start + (visited < size ? visited : 1)) % size;
     }
 
     public void queueSessionForPlayerCreation(RakNetPlayerSession session) {

--- a/src/main/java/cn/nukkit/network/session/RakNetPlayerSession.java
+++ b/src/main/java/cn/nukkit/network/session/RakNetPlayerSession.java
@@ -38,11 +38,7 @@ import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
-import java.util.ArrayDeque;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.Queue;
+import java.util.*;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -62,6 +58,8 @@ public class RakNetPlayerSession extends SimpleChannelInboundHandler<RakMessage>
     static final long MAX_QUEUED_INBOUND_BYTES = 6L * 1024L * 1024L;
     private static final int INBOUND_LOW_WATER_PACKETS = MAX_QUEUED_INBOUND_PACKETS / 2;
     private static final long INBOUND_LOW_WATER_BYTES = MAX_QUEUED_INBOUND_BYTES / 2;
+    /** 单个 0xfe 帧的硬性线上尺寸上限，超出即关闭会话。 Hard wire cap for one encapsulated frame. */
+    static final int MAX_INBOUND_WIRE_BYTES = 12582912; // 12 MiB
     /**
      * Permit short bursts of small movement and interaction batches while bounding sustained
      * wire traffic. Decode bytes and framed-packet tokens independently limit processing work.
@@ -77,7 +75,7 @@ public class RakNetPlayerSession extends SimpleChannelInboundHandler<RakMessage>
     private static final double INGRESS_FRAME_TOKENS_PER_SECOND = 1300D;
     private static final double FRAME_TOKENS_RESERVATION = 2600D;
     /** How many malformed batches a playing session may send inside the sliding window. */
-    private static final int MAX_MALFORMED_BATCHES_WHILE_PLAYING = 32;
+    static final int MAX_MALFORMED_BATCHES_WHILE_PLAYING = 32;
     static final long MALFORMED_BATCH_WINDOW_NANOS = TimeUnit.MINUTES.toNanos(5);
     private static final long DIAGNOSTIC_LOG_INTERVAL_NANOS = TimeUnit.SECONDS.toNanos(30);
 
@@ -145,12 +143,15 @@ public class RakNetPlayerSession extends SimpleChannelInboundHandler<RakMessage>
 
     @Override
     protected void channelRead0(ChannelHandlerContext channelHandlerContext, RakMessage msg) throws Exception {
+        if (this.disconnectReason != null) {
+            return;
+        }
         ByteBuf buffer = msg.content();
         short packetId = buffer.readUnsignedByte();
         if (packetId == 0xfe) {
             int len = buffer.readableBytes();
-            if (len > 12582912) {
-                this.rejectWireIngress(len);
+            if (len > MAX_INBOUND_WIRE_BYTES) {
+                this.rejectOversizedWirePacket(len);
                 return;
             }
 
@@ -222,7 +223,7 @@ public class RakNetPlayerSession extends SimpleChannelInboundHandler<RakMessage>
             }
             if (this.isPlayingSession()) {
                 if (!this.keepPlayingSessionAfterMalformedBatch(ingressNowNanos)) {
-                    this.exhaustIngressDecodeBudget();
+                    this.disconnect("Sent malformed packet");
                 }
                 return;
             }
@@ -412,10 +413,6 @@ public class RakNetPlayerSession extends SimpleChannelInboundHandler<RakMessage>
         } catch (Throwable e) {
             log.error("[{}] Failed to tick RakNetPlayerSession", this.channel.remoteAddress(), e);
         }
-    }
-
-    public void serverTick() {
-        this.serverTick(MAX_INBOUND_PACKETS_PER_SERVER_TICK, MAX_INBOUND_BYTES_PER_SERVER_TICK);
     }
 
     public InboundDrain serverTick(int packetBudget, long byteBudget) {
@@ -807,8 +804,10 @@ public class RakNetPlayerSession extends SimpleChannelInboundHandler<RakMessage>
     }
 
     /**
-     * Isolate malformed batches after login and apply decode backpressure to repeated failures.
-     * Successful traffic does not clear the sliding failure window. Login stays fail-closed.
+     * 登录后的畸形批次在滑动窗口预算内隔离，超窗则断连；正常流量不清空窗口，登录前保持快速失败。
+     * <p>
+     * Isolate malformed batches after login up to a sliding-window budget; exceeding it disconnects.
+     * Successful traffic does not clear the window. Login stays fail-closed.
      */
     boolean keepPlayingSessionAfterMalformedBatch(long nowNanos) {
         if (this.player == null
@@ -915,15 +914,17 @@ public class RakNetPlayerSession extends SimpleChannelInboundHandler<RakMessage>
                 && this.state.getLogin().getPhase() != SessionLoginPhase.DISCONNECTED;
     }
 
-    private void exhaustIngressDecodeBudget() {
-        this.ingressDecodeBytes = 0D;
-        this.ingressFrameTokens = 0D;
-    }
-
     private void rejectWireIngress(int wireBytes) {
         log.warn("[{}] Wire ingress budget exhausted (wireBytes={}); closing before decrypt",
                 this.playerLabel(), wireBytes);
         this.disconnect("Too much inbound data");
+        this.channel.close();
+    }
+
+    private void rejectOversizedWirePacket(int wireBytes) {
+        log.warn("[{}] Closing session: inbound frame of {} bytes exceeds hard limit {}",
+                this.playerLabel(), wireBytes, MAX_INBOUND_WIRE_BYTES);
+        this.disconnect("Too big packet");
         this.channel.close();
     }
 

--- a/src/main/java/cn/nukkit/network/session/RakNetPlayerSession.java
+++ b/src/main/java/cn/nukkit/network/session/RakNetPlayerSession.java
@@ -38,12 +38,14 @@ import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
+import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 @Log4j2
@@ -51,11 +53,40 @@ public class RakNetPlayerSession extends SimpleChannelInboundHandler<RakMessage>
 
     private static final ThreadLocal<Sha256> HASH_LOCAL = ThreadLocal.withInitial(Natives.SHA_256);
     private static final ThreadLocal<byte[]> CHECKSUM_LOCAL = ThreadLocal.withInitial(() -> new byte[8]);
+    /** Maximum packet work one player may force onto one server tick. The tail stays queued. */
+    static final int MAX_INBOUND_PACKETS_PER_SERVER_TICK = 120;
+    /** Maximum decoded payload work one player may force onto one server tick. */
+    static final long MAX_INBOUND_BYTES_PER_SERVER_TICK = 6L * 1024L * 1024L;
+    /** One maximum-size legal decoded batch may wait per session. */
+    static final int MAX_QUEUED_INBOUND_PACKETS = 1300;
+    static final long MAX_QUEUED_INBOUND_BYTES = 6L * 1024L * 1024L;
+    private static final int INBOUND_LOW_WATER_PACKETS = MAX_QUEUED_INBOUND_PACKETS / 2;
+    private static final long INBOUND_LOW_WATER_BYTES = MAX_QUEUED_INBOUND_BYTES / 2;
+    /**
+     * Permit short bursts of small movement and interaction batches while bounding sustained
+     * wire traffic. Decode bytes and framed-packet tokens independently limit processing work.
+     */
+    private static final double MAX_INGRESS_BATCH_TOKENS = 1200D;
+    private static final double INGRESS_BATCH_TOKENS_PER_SECOND = 300D;
+    private static final double MAX_INGRESS_COMPRESSED_BYTES = 48D * 1024D * 1024D;
+    private static final double INGRESS_COMPRESSED_BYTES_PER_SECOND = 6D * 1024D * 1024D;
+    private static final double MAX_INGRESS_DECODE_BYTES = 24D * 1024D * 1024D;
+    private static final double INGRESS_DECODE_BYTES_PER_SECOND = 6D * 1024D * 1024D;
+    private static final double DECODE_BYTES_RESERVATION = 12D * 1024D * 1024D;
+    private static final double MAX_INGRESS_FRAME_TOKENS = 5200D;
+    private static final double INGRESS_FRAME_TOKENS_PER_SECOND = 1300D;
+    private static final double FRAME_TOKENS_RESERVATION = 2600D;
+    /** How many malformed batches a playing session may send inside the sliding window. */
+    private static final int MAX_MALFORMED_BATCHES_WHILE_PLAYING = 32;
+    static final long MALFORMED_BATCH_WINDOW_NANOS = TimeUnit.MINUTES.toNanos(5);
+    private static final long DIAGNOSTIC_LOG_INTERVAL_NANOS = TimeUnit.SECONDS.toNanos(30);
 
     private final RakNetInterface server;
     private final RakChildChannel channel;
 
     private final Queue<DataPacket> inbound = PlatformDependent.newSpscQueue();
+    private final AtomicInteger queuedInboundPackets = new AtomicInteger();
+    private final AtomicLong queuedInboundBytes = new AtomicLong();
     private final Queue<DataPacket> outbound = PlatformDependent.newMpscQueue();
     private final ScheduledFuture<?> tickFuture;
     private final NetworkSessionState state = new NetworkSessionState();
@@ -74,6 +105,17 @@ public class RakNetPlayerSession extends SimpleChannelInboundHandler<RakMessage>
     private final AtomicLong encryptCounter = new AtomicLong();
     private final AtomicLong decryptCounter = new AtomicLong();
 
+    private final ArrayDeque<Long> malformedBatches = new ArrayDeque<>();
+    private long lastMalformedLogNanos;
+    private long lastInboundThrottleLogNanos;
+    private long throttledInboundBatches;
+    private volatile boolean inboundThrottled;
+    private double ingressBatchTokens = MAX_INGRESS_BATCH_TOKENS;
+    private double ingressCompressedBytes = MAX_INGRESS_COMPRESSED_BYTES;
+    private double ingressDecodeBytes = MAX_INGRESS_DECODE_BYTES;
+    private double ingressFrameTokens = MAX_INGRESS_FRAME_TOKENS;
+    private long lastIngressRefillNanos;
+
     public RakNetPlayerSession(RakNetInterface server, RakChildChannel channel) {
         this.server = server;
         this.channel = channel;
@@ -89,6 +131,7 @@ public class RakNetPlayerSession extends SimpleChannelInboundHandler<RakMessage>
             this.compressionOut = this.compressionIn;
         }
         long acceptedAt = System.nanoTime();
+        this.lastIngressRefillNanos = acceptedAt;
         this.state.getConnection().setSessionCreatedNanos(acceptedAt);
         this.state.getConnection().setChildChannelAcceptedNanos(acceptedAt);
         this.state.getConnection().setRemoteAddress(String.valueOf(channel.remoteAddress()));
@@ -107,14 +150,17 @@ public class RakNetPlayerSession extends SimpleChannelInboundHandler<RakMessage>
         if (packetId == 0xfe) {
             int len = buffer.readableBytes();
             if (len > 12582912) {
-                Server.getInstance().getLogger().error("Received too big packet: " + len);
-                if (this.player != null) {
-                    this.player.close("Too big packet");
-                }
+                this.rejectWireIngress(len);
                 return;
             }
 
-            byte[] packetBuffer;
+            long ingressNowNanos = System.nanoTime();
+            boolean wireBudgetReserved = this.reserveWireIngressBudget(len, ingressNowNanos);
+            if (!wireBudgetReserved) {
+                this.rejectWireIngress(len);
+                return;
+            }
+
             boolean ci = this.shouldUsePrefixedCompression();
 
             if (this.decryptionCipher != null) {
@@ -134,7 +180,7 @@ public class RakNetPlayerSession extends SimpleChannelInboundHandler<RakMessage>
                     buffer.readerIndex(trailerIndex);
                     buffer.readBytes(checksum);
                 } catch (Exception e) {
-                    this.disconnect("Bad checksum");
+                    this.disconnect("Invalid checksum");
                     log.debug("Unable to verify checksum", e);
                     return;
                 }
@@ -153,30 +199,50 @@ public class RakNetPlayerSession extends SimpleChannelInboundHandler<RakMessage>
                     this.endLegacyInboundEncryptionGraceWindow();
                 }
                 buffer.resetReaderIndex();
-
-                packetBuffer = new byte[buffer.readableBytes() - 8];
-            } else {
-                packetBuffer = new byte[buffer.readableBytes()];
             }
 
+            if (this.inboundThrottled) {
+                this.dropInboundBatchBecauseThrottled(len);
+                return;
+            }
+            if (!this.reserveDecodeIngressBudget(ingressNowNanos)) {
+                this.dropInboundBatchBecauseThrottled(len);
+                return;
+            }
+
+            int payloadBytes = this.decryptionCipher == null ? buffer.readableBytes() : buffer.readableBytes() - 8;
+            byte[] packetBuffer = new byte[payloadBytes];
             buffer.readBytes(packetBuffer);
 
-            if (!this.processInboundBatch(packetBuffer, ci)) {
-                this.disconnect("Sent malformed packet");
-                Server.getInstance().getScheduler().scheduleDelayedTask(InternalPlugin.INSTANCE, () -> {
-                    try {
-                        InetAddress address = this.channel.remoteAddress().getAddress();
-                        this.channel.unsafe().close(this.channel.voidPromise());
-                        if (shouldBlockAddressAfterMalformed(this.state.getLogin().getPhase(), address)) {
-                            this.server.blockAddress(address, 60);
-                        }
-                    } catch (Throwable throwable) {
-                        if (Nukkit.DEBUG > 1) {
-                            log.info("Error while closing channel", throwable);
-                        }
-                    }
-                }, 10);
+            InboundBatchDecodeResult decoded = this.processInboundBatch(packetBuffer, ci);
+            this.settleIngressBudget(decoded.workBytes(), decoded.framedPackets(), ingressNowNanos);
+            if (decoded.success()) {
+                this.enqueueDecodedBatch(decoded.packets());
+                return;
             }
+            if (this.isPlayingSession()) {
+                if (!this.keepPlayingSessionAfterMalformedBatch(ingressNowNanos)) {
+                    this.exhaustIngressDecodeBudget();
+                }
+                return;
+            }
+
+            InetAddress malformedAddress = this.channel.remoteAddress().getAddress();
+            boolean blockMalformedAddress = shouldBlockAddressAfterMalformed(
+                    this.state.getLogin().getPhase(), malformedAddress);
+            this.disconnect("Sent malformed packet");
+            Server.getInstance().getScheduler().scheduleDelayedTask(InternalPlugin.INSTANCE, () -> {
+                try {
+                    this.channel.close();
+                    if (blockMalformedAddress) {
+                        this.server.blockAddress(malformedAddress, 60);
+                    }
+                } catch (Throwable throwable) {
+                    if (Nukkit.DEBUG > 1) {
+                        log.info("Error while closing channel", throwable);
+                    }
+                }
+            }, 10);
         } else if (Nukkit.DEBUG > 1) {
             log.info("Unknown EncapsulatedPacket: {}", packetId);
         }
@@ -349,8 +415,24 @@ public class RakNetPlayerSession extends SimpleChannelInboundHandler<RakMessage>
     }
 
     public void serverTick() {
+        this.serverTick(MAX_INBOUND_PACKETS_PER_SERVER_TICK, MAX_INBOUND_BYTES_PER_SERVER_TICK);
+    }
+
+    public InboundDrain serverTick(int packetBudget, long byteBudget) {
         DataPacket packet;
-        while ((packet = this.inbound.poll()) != null) {
+        int handled = 0;
+        long handledBytes = 0L;
+        int allowedPackets = Math.min(MAX_INBOUND_PACKETS_PER_SERVER_TICK, Math.max(packetBudget, 0));
+        long allowedBytes = Math.min(MAX_INBOUND_BYTES_PER_SERVER_TICK, Math.max(byteBudget, 0L));
+        while (handled < allowedPackets
+                && (packet = this.inbound.peek()) != null
+                && handledBytes + packetBytes(packet) <= allowedBytes) {
+            this.inbound.poll();
+            this.queuedInboundPackets.decrementAndGet();
+            int packetBytes = packetBytes(packet);
+            this.queuedInboundBytes.addAndGet(-packetBytes);
+            handled++;
+            handledBytes += packetBytes;
             try {
                 this.player.handleDataPacket(packet);
             } catch (Throwable e) {
@@ -358,6 +440,12 @@ public class RakNetPlayerSession extends SimpleChannelInboundHandler<RakMessage>
                         new Object[]{packet.getClass().getSimpleName(), this.player.getName()}, e));
             }
         }
+        if (this.inboundThrottled
+                && this.queuedInboundPackets.get() <= INBOUND_LOW_WATER_PACKETS
+                && this.queuedInboundBytes.get() <= INBOUND_LOW_WATER_BYTES) {
+            this.inboundThrottled = false;
+        }
+        return new InboundDrain(handled, handledBytes);
     }
 
     private void sendPackets(Collection<DataPacket> packets) {
@@ -592,15 +680,22 @@ public class RakNetPlayerSession extends SimpleChannelInboundHandler<RakMessage>
         return this.player == null ? String.valueOf(this.channel.remoteAddress()) : this.player.getName();
     }
 
-    private boolean processInboundBatch(byte[] packetBuffer, boolean ci) {
+    private InboundBatchDecodeResult processInboundBatch(byte[] packetBuffer, boolean ci) {
         try {
             if (!ci) {
-                if (!this.server.getNetwork().processBatchQuietly(packetBuffer, this.inbound, this.compressionIn, this.channel.config().getProtocolVersion(), this.player)) {
-                    log.warn("[{}] Failed to decode batch packet ({} bytes, non-prefixed, compression={})",
+                List<DataPacket> decoded = new ObjectArrayList<>();
+                Network.BatchProcessResult measured = this.server.getNetwork().processBatchMeasured(
+                        packetBuffer, decoded, this.compressionIn,
+                        this.channel.config().getProtocolVersion(), this.player, false);
+                if (!measured.success()) {
+                    this.logMalformedBatch(measured.failure(),
+                            "[{}] Failed to decode batch packet ({} bytes, non-prefixed, compression={})",
                             this.playerLabel(), packetBuffer.length, this.compressionIn);
-                    return false;
+                    return InboundBatchDecodeResult.failed(
+                            measured.decompressedBytes(), measured.framedPackets(), measured.failure());
                 }
-                return true;
+                return InboundBatchDecodeResult.legacy(
+                        this.compressionIn, decoded, measured.decompressedBytes(), measured.framedPackets());
             }
 
             InboundBatchDecodeResult result = decodeInboundPrefixedBatch(
@@ -612,10 +707,13 @@ public class RakNetPlayerSession extends SimpleChannelInboundHandler<RakMessage>
                     this.player
             );
             if (!result.success()) {
-                log.warn("[{}] Failed to decode batch packet ({} bytes, prefixed, raknetProtocol={}, legacyFallback={})",
-                        this.playerLabel(), packetBuffer.length, this.channel.config().getProtocolVersion(),
+                this.logMalformedBatch(result.failure(),
+                        "[{}] Failed to decode batch packet ({} bytes, prefixed, prefix=0x{}, compressionIn={}, raknetProtocol={}, legacyFallback={})",
+                        this.playerLabel(), packetBuffer.length,
+                        packetBuffer.length > 0 ? Integer.toHexString(packetBuffer[0] & 0xFF) : "-",
+                        this.compressionIn, this.channel.config().getProtocolVersion(),
                         this.state.getSecurity().isLegacyInboundGraceWindow());
-                return false;
+                return result;
             }
 
             this.compressionIn = result.compression();
@@ -623,11 +721,11 @@ public class RakNetPlayerSession extends SimpleChannelInboundHandler<RakMessage>
             if (result.prefixed()) {
                 this.endLegacyInboundCompressionGraceWindow();
             }
-            this.inbound.addAll(result.packets());
-            return true;
+            return result;
         } catch (Exception e) {
             log.error("[{}] Unable to process batch packet", this.playerLabel(), e);
-            return false;
+            return InboundBatchDecodeResult.failed(
+                    (int) DECODE_BYTES_RESERVATION, (int) FRAME_TOKENS_RESERVATION, e);
         }
     }
 
@@ -635,16 +733,25 @@ public class RakNetPlayerSession extends SimpleChannelInboundHandler<RakMessage>
                                                                boolean allowLegacyFallback, int raknetProtocol, Player player) {
         if (packetBuffer.length == 0) {
             log.debug("Prefixed batch decode failed: empty packet buffer");
-            return InboundBatchDecodeResult.failed();
+            return InboundBatchDecodeResult.failed(0, 0, null);
         }
 
+        int workBytes = 0;
+        int framedPackets = 0;
+        Throwable failure = null;
         CompressionProvider prefixedCompression = tryResolveCompressionByPrefix(packetBuffer[0], raknetProtocol);
         if (prefixedCompression != null && packetBuffer.length > 1) {
             List<DataPacket> prefixedPackets = new ObjectArrayList<>();
             // Skip the 1-byte compression prefix; copy cost is negligible vs decompression
             byte[] prefixedPayload = Arrays.copyOfRange(packetBuffer, 1, packetBuffer.length);
-            if (network.processBatchQuietly(prefixedPayload, prefixedPackets, prefixedCompression, raknetProtocol, player)) {
-                return InboundBatchDecodeResult.prefixed(prefixedCompression, prefixedPackets);
+            Network.BatchProcessResult measured = network.processBatchMeasured(
+                    prefixedPayload, prefixedPackets, prefixedCompression, raknetProtocol, player, false);
+            workBytes += measured.decompressedBytes();
+            framedPackets += measured.framedPackets();
+            failure = measured.failure();
+            if (measured.success()) {
+                return InboundBatchDecodeResult.prefixed(
+                        prefixedCompression, prefixedPackets, workBytes, framedPackets);
             }
             log.debug("Prefixed batch decode failed: processBatch returned false (compression={}, {} bytes, raknetProtocol={})",
                     prefixedCompression, prefixedPayload.length, raknetProtocol);
@@ -657,12 +764,20 @@ public class RakNetPlayerSession extends SimpleChannelInboundHandler<RakMessage>
 
         if (allowLegacyFallback && legacyCompression != null) {
             List<DataPacket> legacyPackets = new ObjectArrayList<>();
-            if (network.processBatchQuietly(packetBuffer, legacyPackets, legacyCompression, raknetProtocol, player)) {
-                return InboundBatchDecodeResult.legacy(legacyCompression, legacyPackets);
+            Network.BatchProcessResult measured = network.processBatchMeasured(
+                    packetBuffer, legacyPackets, legacyCompression, raknetProtocol, player, false);
+            workBytes += measured.decompressedBytes();
+            framedPackets += measured.framedPackets();
+            if (measured.failure() != null) {
+                failure = measured.failure();
+            }
+            if (measured.success()) {
+                return InboundBatchDecodeResult.legacy(
+                        legacyCompression, legacyPackets, workBytes, framedPackets);
             }
             log.debug("Prefixed batch decode: legacy fallback also failed (compression={})", legacyCompression);
         }
-        return InboundBatchDecodeResult.failed();
+        return InboundBatchDecodeResult.failed(workBytes, framedPackets, failure);
     }
 
     private static CompressionProvider tryResolveCompressionByPrefix(byte prefix, int raknetProtocol) {
@@ -691,24 +806,198 @@ public class RakNetPlayerSession extends SimpleChannelInboundHandler<RakMessage>
         return nowNanos - childChannelAcceptedNanos >= TimeUnit.MILLISECONDS.toNanos(timeoutMillis);
     }
 
+    /**
+     * Isolate malformed batches after login and apply decode backpressure to repeated failures.
+     * Successful traffic does not clear the sliding failure window. Login stays fail-closed.
+     */
+    boolean keepPlayingSessionAfterMalformedBatch(long nowNanos) {
+        if (this.player == null
+                || this.state.getLogin().getPhase().ordinal() < SessionLoginPhase.LOGGED_IN.ordinal()
+                || this.state.getLogin().getPhase() == SessionLoginPhase.DISCONNECTED) {
+            return false;
+        }
+        long cutoff = nowNanos - MALFORMED_BATCH_WINDOW_NANOS;
+        while (!this.malformedBatches.isEmpty() && this.malformedBatches.peekFirst() <= cutoff) {
+            this.malformedBatches.removeFirst();
+        }
+        this.malformedBatches.addLast(nowNanos);
+        return this.malformedBatches.size() <= MAX_MALFORMED_BATCHES_WHILE_PLAYING;
+    }
+
+    boolean enqueueDecodedBatch(List<DataPacket> packets) {
+        if (packets.isEmpty()) {
+            return true;
+        }
+        long batchBytes = 0L;
+        for (DataPacket packet : packets) {
+            batchBytes += packetBytes(packet);
+        }
+        int queuedPackets = this.queuedInboundPackets.get();
+        long queuedBytes = this.queuedInboundBytes.get();
+        if (queuedPackets + packets.size() > MAX_QUEUED_INBOUND_PACKETS
+                || queuedBytes + batchBytes > MAX_QUEUED_INBOUND_BYTES) {
+            this.inboundThrottled = true;
+            this.logInboundThrottle(queuedPackets, queuedBytes, packets.size(), batchBytes);
+            return false;
+        }
+
+        this.queuedInboundPackets.addAndGet(packets.size());
+        this.queuedInboundBytes.addAndGet(batchBytes);
+        this.inbound.addAll(packets);
+        if (queuedPackets + packets.size() >= MAX_QUEUED_INBOUND_PACKETS
+                || queuedBytes + batchBytes >= MAX_QUEUED_INBOUND_BYTES) {
+            this.inboundThrottled = true;
+        }
+        return true;
+    }
+
+    int queuedInboundPacketCount() {
+        return this.queuedInboundPackets.get();
+    }
+
+    long queuedInboundByteCount() {
+        return this.queuedInboundBytes.get();
+    }
+
+    boolean isInboundThrottled() {
+        return this.inboundThrottled;
+    }
+
+    boolean reserveWireIngressBudget(int wireBytes, long nowNanos) {
+        this.refillIngressBudget(nowNanos);
+        if (this.ingressBatchTokens < 1D
+                || this.ingressCompressedBytes < wireBytes) {
+            return false;
+        }
+        this.ingressBatchTokens -= 1D;
+        this.ingressCompressedBytes -= wireBytes;
+        return true;
+    }
+
+    boolean reserveDecodeIngressBudget(long nowNanos) {
+        this.refillIngressBudget(nowNanos);
+        if (this.ingressDecodeBytes < DECODE_BYTES_RESERVATION
+                || this.ingressFrameTokens < FRAME_TOKENS_RESERVATION) {
+            return false;
+        }
+        this.ingressDecodeBytes -= DECODE_BYTES_RESERVATION;
+        this.ingressFrameTokens -= FRAME_TOKENS_RESERVATION;
+        return true;
+    }
+
+    void settleIngressBudget(int decodedBytes, int framedPackets, long nowNanos) {
+        this.refillIngressBudget(nowNanos);
+        this.ingressDecodeBytes = Math.max(0D, Math.min(MAX_INGRESS_DECODE_BYTES,
+                this.ingressDecodeBytes + DECODE_BYTES_RESERVATION - decodedBytes));
+        this.ingressFrameTokens = Math.max(0D, Math.min(MAX_INGRESS_FRAME_TOKENS,
+                this.ingressFrameTokens + FRAME_TOKENS_RESERVATION - framedPackets));
+    }
+
+    private void refillIngressBudget(long nowNanos) {
+        if (nowNanos <= this.lastIngressRefillNanos) {
+            return;
+        }
+        double elapsedSeconds = (nowNanos - this.lastIngressRefillNanos) / 1_000_000_000D;
+        this.lastIngressRefillNanos = nowNanos;
+        this.ingressBatchTokens = Math.min(MAX_INGRESS_BATCH_TOKENS,
+                this.ingressBatchTokens + elapsedSeconds * INGRESS_BATCH_TOKENS_PER_SECOND);
+        this.ingressCompressedBytes = Math.min(MAX_INGRESS_COMPRESSED_BYTES,
+                this.ingressCompressedBytes + elapsedSeconds * INGRESS_COMPRESSED_BYTES_PER_SECOND);
+        this.ingressDecodeBytes = Math.min(MAX_INGRESS_DECODE_BYTES,
+                this.ingressDecodeBytes + elapsedSeconds * INGRESS_DECODE_BYTES_PER_SECOND);
+        this.ingressFrameTokens = Math.min(MAX_INGRESS_FRAME_TOKENS,
+                this.ingressFrameTokens + elapsedSeconds * INGRESS_FRAME_TOKENS_PER_SECOND);
+    }
+
+    private boolean isPlayingSession() {
+        return this.player != null
+                && this.state.getLogin().getPhase().ordinal() >= SessionLoginPhase.LOGGED_IN.ordinal()
+                && this.state.getLogin().getPhase() != SessionLoginPhase.DISCONNECTED;
+    }
+
+    private void exhaustIngressDecodeBudget() {
+        this.ingressDecodeBytes = 0D;
+        this.ingressFrameTokens = 0D;
+    }
+
+    private void rejectWireIngress(int wireBytes) {
+        log.warn("[{}] Wire ingress budget exhausted (wireBytes={}); closing before decrypt",
+                this.playerLabel(), wireBytes);
+        this.disconnect("Too much inbound data");
+        this.channel.close();
+    }
+
+    private static int packetBytes(DataPacket packet) {
+        return Math.max(packet.getCount(), 1);
+    }
+
+    public record InboundDrain(int packets, long bytes) {
+    }
+
+    private void dropInboundBatchBecauseThrottled(int compressedBytes) {
+        this.throttledInboundBatches++;
+        long nowNanos = System.nanoTime();
+        if (this.lastInboundThrottleLogNanos != 0L
+                && nowNanos - this.lastInboundThrottleLogNanos < DIAGNOSTIC_LOG_INTERVAL_NANOS) {
+            return;
+        }
+        this.lastInboundThrottleLogNanos = nowNanos;
+        log.warn("[{}] Inbound backpressure dropped batch (compressedBytes={}, queuedPackets={}, queuedBytes={}, droppedBatches={})",
+                this.playerLabel(), compressedBytes, this.queuedInboundPackets.get(),
+                this.queuedInboundBytes.get(), this.throttledInboundBatches);
+    }
+
+    private void logInboundThrottle(int queuedPackets, long queuedBytes, int batchPackets, long batchBytes) {
+        this.throttledInboundBatches++;
+        long nowNanos = System.nanoTime();
+        if (this.lastInboundThrottleLogNanos != 0L
+                && nowNanos - this.lastInboundThrottleLogNanos < DIAGNOSTIC_LOG_INTERVAL_NANOS) {
+            return;
+        }
+        this.lastInboundThrottleLogNanos = nowNanos;
+        log.warn("[{}] Inbound backpressure rejected decoded batch (queuedPackets={}, queuedBytes={}, batchPackets={}, batchBytes={}, droppedBatches={})",
+                this.playerLabel(), queuedPackets, queuedBytes, batchPackets, batchBytes,
+                this.throttledInboundBatches);
+    }
+
+    private void logMalformedBatch(Throwable failure, String message, Object... arguments) {
+        long nowNanos = System.nanoTime();
+        if (this.lastMalformedLogNanos != 0L
+                && nowNanos - this.lastMalformedLogNanos < DIAGNOSTIC_LOG_INTERVAL_NANOS) {
+            return;
+        }
+        this.lastMalformedLogNanos = nowNanos;
+        Object[] withCause = Arrays.copyOf(arguments, arguments.length + 1);
+        withCause[arguments.length] = failure == null ? "unknown" : failure.toString();
+        log.warn(message + ", cause={}", withCause);
+    }
+
     static boolean shouldBlockAddressAfterMalformed(SessionLoginPhase phase, InetAddress address) {
         return address != null
                 && !address.isSiteLocalAddress()
-                && phase.ordinal() >= SessionLoginPhase.LOGIN_RECEIVED.ordinal();
+                && phase.ordinal() >= SessionLoginPhase.LOGIN_RECEIVED.ordinal()
+                && phase.ordinal() < SessionLoginPhase.LOGGED_IN.ordinal();
     }
 
-    record InboundBatchDecodeResult(boolean success, CompressionProvider compression, boolean prefixed, List<DataPacket> packets) {
+    record InboundBatchDecodeResult(boolean success, CompressionProvider compression, boolean prefixed,
+                                    List<DataPacket> packets, int workBytes, int framedPackets,
+                                    Throwable failure) {
 
-        static InboundBatchDecodeResult failed() {
-            return new InboundBatchDecodeResult(false, null, false, List.of());
+        static InboundBatchDecodeResult failed(int workBytes, int framedPackets, Throwable failure) {
+            return new InboundBatchDecodeResult(
+                    false, null, false, List.of(), workBytes, framedPackets, failure);
         }
 
-        static InboundBatchDecodeResult prefixed(CompressionProvider compression, List<DataPacket> packets) {
-            return new InboundBatchDecodeResult(true, compression, true, packets);
+        static InboundBatchDecodeResult prefixed(CompressionProvider compression, List<DataPacket> packets,
+                                                 int workBytes, int framedPackets) {
+            return new InboundBatchDecodeResult(
+                    true, compression, true, packets, workBytes, framedPackets, null);
         }
 
-        static InboundBatchDecodeResult legacy(CompressionProvider compression, List<DataPacket> packets) {
-            return new InboundBatchDecodeResult(true, compression, false, packets);
+        static InboundBatchDecodeResult legacy(CompressionProvider compression, List<DataPacket> packets,
+                                               int workBytes, int framedPackets) {
+            return new InboundBatchDecodeResult(
+                    true, compression, false, packets, workBytes, framedPackets, null);
         }
     }
 

--- a/src/test/java/cn/nukkit/network/session/RakNetPlayerSessionTest.java
+++ b/src/test/java/cn/nukkit/network/session/RakNetPlayerSessionTest.java
@@ -4,6 +4,7 @@ import cn.nukkit.GameVersion;
 import cn.nukkit.MockServer;
 import cn.nukkit.Player;
 import cn.nukkit.network.CompressionProvider;
+import cn.nukkit.network.encryption.EncryptionUtils;
 import cn.nukkit.network.Network;
 import cn.nukkit.network.RakNetInterface;
 import cn.nukkit.network.proxy.ProxyProtocolHandler;
@@ -13,7 +14,10 @@ import cn.nukkit.network.protocol.RequestNetworkSettingsPacket;
 import cn.nukkit.network.protocol.ResourcePackChunkRequestPacket;
 import cn.nukkit.network.session.login.SessionLoginPhase;
 import cn.nukkit.utils.BinaryStream;
+import cn.nukkit.scheduler.ServerScheduler;
+import cn.nukkit.plugin.InternalPlugin;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
@@ -21,6 +25,15 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoop;
 import io.netty.util.concurrent.ScheduledFuture;
 import org.cloudburstmc.netty.channel.raknet.RakChildChannel;
+import org.cloudburstmc.netty.channel.raknet.packet.RakMessage;
+import org.mockito.ArgumentCaptor;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.security.MessageDigest;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -76,6 +89,9 @@ class RakNetPlayerSessionTest {
         assertSame(CompressionProvider.NONE, result.compression());
         assertEquals(1, result.packets().size());
         assertInstanceOf(ClientToServerHandshakePacket.class, result.packets().get(0));
+        assertTrue(result.workBytes() > legacyPacketBuffer.length,
+                "the failed prefixed attempt must also consume the decode budget");
+        assertTrue(result.framedPackets() > result.packets().size());
     }
 
     @Test
@@ -308,7 +324,354 @@ class RakNetPlayerSessionTest {
         assertFalse(RakNetPlayerSession.shouldBlockAddressAfterMalformed(SessionLoginPhase.CONNECTED, address));
         assertFalse(RakNetPlayerSession.shouldBlockAddressAfterMalformed(SessionLoginPhase.NETWORK_SETTINGS_NEGOTIATED, address));
         assertTrue(RakNetPlayerSession.shouldBlockAddressAfterMalformed(SessionLoginPhase.LOGIN_RECEIVED, address));
-        assertTrue(RakNetPlayerSession.shouldBlockAddressAfterMalformed(SessionLoginPhase.LOGGED_IN, address));
+        assertTrue(RakNetPlayerSession.shouldBlockAddressAfterMalformed(SessionLoginPhase.RESOURCE_PACK, address));
+        assertFalse(RakNetPlayerSession.shouldBlockAddressAfterMalformed(SessionLoginPhase.LOGGED_IN, address));
+        assertFalse(RakNetPlayerSession.shouldBlockAddressAfterMalformed(SessionLoginPhase.DISCONNECTED, address));
+    }
+
+    @Test
+    void serverTickDefersInboundTailWithoutDroppingPackets() {
+        SessionFixture fixture = createSession(false);
+        int burst = RakNetPlayerSession.MAX_INBOUND_PACKETS_PER_SERVER_TICK + 44;
+        assertTrue(fixture.session.enqueueDecodedBatch(testPackets(burst)));
+
+        fixture.session.serverTick();
+
+        verify(fixture.player, times(RakNetPlayerSession.MAX_INBOUND_PACKETS_PER_SERVER_TICK))
+                .handleDataPacket(any(DataPacket.class));
+        assertEquals(44, fixture.session.queuedInboundPacketCount());
+
+        fixture.session.serverTick();
+
+        verify(fixture.player, times(burst)).handleDataPacket(any(DataPacket.class));
+        assertEquals(0, fixture.session.queuedInboundPacketCount());
+    }
+
+    @Test
+    void inboundQueueHasAHardPerSessionBound() {
+        SessionFixture fixture = createSession(false);
+
+        assertTrue(fixture.session.enqueueDecodedBatch(
+                testPackets(RakNetPlayerSession.MAX_QUEUED_INBOUND_PACKETS)));
+        assertFalse(fixture.session.enqueueDecodedBatch(List.of(new TestPacket())));
+
+        assertEquals(RakNetPlayerSession.MAX_QUEUED_INBOUND_PACKETS,
+                fixture.session.queuedInboundPacketCount());
+        assertTrue(fixture.session.isInboundThrottled());
+        assertNull(fixture.session.getDisconnectReason());
+    }
+
+    @Test
+    void inboundBackpressureClearsAtLowWater() {
+        SessionFixture fixture = createSession(false);
+        assertTrue(fixture.session.enqueueDecodedBatch(
+                testPackets(RakNetPlayerSession.MAX_QUEUED_INBOUND_PACKETS)));
+
+        while (fixture.session.queuedInboundPacketCount() > RakNetPlayerSession.MAX_QUEUED_INBOUND_PACKETS / 2) {
+            fixture.session.serverTick();
+        }
+
+        assertFalse(fixture.session.isInboundThrottled());
+        assertTrue(fixture.session.enqueueDecodedBatch(List.of(new TestPacket())));
+        assertNull(fixture.session.getDisconnectReason());
+    }
+
+    @Test
+    void inboundQueueAlsoHasAByteBound() {
+        SessionFixture fixture = createSession(false);
+        TestPacket fullBatch = new TestPacket();
+        fullBatch.setBuffer(new byte[(int) RakNetPlayerSession.MAX_QUEUED_INBOUND_BYTES]);
+
+        assertTrue(fixture.session.enqueueDecodedBatch(List.of(fullBatch)));
+        assertFalse(fixture.session.enqueueDecodedBatch(List.of(new TestPacket())));
+
+        assertEquals(RakNetPlayerSession.MAX_QUEUED_INBOUND_BYTES,
+                fixture.session.queuedInboundByteCount());
+        assertTrue(fixture.session.isInboundThrottled());
+        assertNull(fixture.session.getDisconnectReason());
+    }
+
+    @Test
+    void ingressBudgetChargesDecodeWorkEvenWhenNothingCanBeQueued() {
+        SessionFixture fixture = createSession(false);
+        long now = System.nanoTime();
+        int worstDecode = 6 * 1024 * 1024;
+
+        for (int i = 0; i < 3; i++) {
+            assertTrue(fixture.session.reserveWireIngressBudget(64, now));
+            assertTrue(fixture.session.reserveDecodeIngressBudget(now));
+            fixture.session.settleIngressBudget(worstDecode, 1300, now);
+        }
+
+        assertTrue(fixture.session.reserveWireIngressBudget(64, now));
+        assertFalse(fixture.session.reserveDecodeIngressBudget(now));
+        assertNull(fixture.session.getDisconnectReason());
+    }
+
+    @Test
+    void ingressBudgetAllowsNormalSmallBatchesButBoundsSameInstantBurst() {
+        SessionFixture fixture = createSession(false);
+        long now = System.nanoTime();
+
+        for (int i = 0; i < 1200; i++) {
+            assertTrue(fixture.session.reserveWireIngressBudget(1, now));
+            assertTrue(fixture.session.reserveDecodeIngressBudget(now));
+            fixture.session.settleIngressBudget(1, 1, now);
+        }
+
+        assertFalse(fixture.session.reserveWireIngressBudget(1, now));
+    }
+
+    @Test
+    void measuredDecodeCountsUnknownFrames() {
+        BinaryStream batch = new BinaryStream();
+        BinaryStream unknownPacket = new BinaryStream();
+        unknownPacket.putUnsignedVarInt(0x3ff);
+        for (int i = 0; i < 1300; i++) {
+            batch.putByteArray(unknownPacket.getBuffer());
+        }
+        List<DataPacket> decoded = new ArrayList<>();
+
+        Network.BatchProcessResult result = network.processBatchMeasured(
+                batch.getBuffer(), decoded, CompressionProvider.NONE, RAKNET_PROTOCOL, null, false);
+
+        assertTrue(result.success());
+        assertEquals(1300, result.framedPackets());
+        assertTrue(decoded.isEmpty());
+    }
+
+    @Test
+    void interfaceBudgetRotatesPastSessionsThatUsedThePreviousTick() throws Exception {
+        Queue<RakNetPlayerSession> creationQueue = new ArrayDeque<>();
+        Set<RakNetPlayerSession> pending = Collections.newSetFromMap(new ConcurrentHashMap<>());
+        Map<InetSocketAddress, RakNetPlayerSession> sessions = new LinkedHashMap<>();
+        RakNetInterface interfaceUnderTest = createRakNetInterface(
+                MockServer.get(), creationQueue, pending, sessions);
+        List<SessionFixture> fixtures = new ArrayList<>();
+        for (int i = 0; i < 20; i++) {
+            SessionFixture fixture = createSession(interfaceUnderTest, false, true, true);
+            fixture.session.enqueueDecodedBatch(testPackets(1300));
+            fixtures.add(fixture);
+            sessions.put(new InetSocketAddress("127.0.0.1", 20000 + i), fixture.session);
+        }
+
+        interfaceUnderTest.process();
+
+        int queuedAfterFirstTick = fixtures.stream()
+                .mapToInt(fixture -> fixture.session.queuedInboundPacketCount())
+                .sum();
+        assertEquals(20 * 1300 - 2048, queuedAfterFirstTick);
+        assertEquals(1300, fixtures.get(19).session.queuedInboundPacketCount());
+
+        interfaceUnderTest.process();
+
+        assertTrue(fixtures.get(19).session.queuedInboundPacketCount() < 1300,
+                "the round-robin cursor must serve a session skipped by the previous global budget");
+    }
+
+    @Test
+    void loggedInMalformedBudgetIsSlidingAndSuccessfulTrafficDoesNotClearIt() {
+        SessionFixture fixture = createSession(false);
+        fixture.session.getState().getLogin().setPhase(SessionLoginPhase.LOGGED_IN);
+        long now = TimeUnit.SECONDS.toNanos(100);
+
+        for (int i = 0; i < 32; i++) {
+            assertTrue(fixture.session.keepPlayingSessionAfterMalformedBatch(now));
+        }
+        assertTrue(fixture.session.enqueueDecodedBatch(List.of(new TestPacket())));
+
+        assertFalse(fixture.session.keepPlayingSessionAfterMalformedBatch(now));
+    }
+
+    @Test
+    void expiredMalformedBatchesFreeTheBudget() {
+        SessionFixture fixture = createSession(false);
+        fixture.session.getState().getLogin().setPhase(SessionLoginPhase.LOGGED_IN);
+        long now = TimeUnit.SECONDS.toNanos(100);
+        for (int i = 0; i < 32; i++) {
+            assertTrue(fixture.session.keepPlayingSessionAfterMalformedBatch(now));
+        }
+
+        assertTrue(fixture.session.keepPlayingSessionAfterMalformedBatch(
+                now + RakNetPlayerSession.MALFORMED_BATCH_WINDOW_NANOS + 1));
+    }
+
+    @Test
+    void malformedBatchBeforeLoginStillFailsClosed() {
+        SessionFixture fixture = createSession(false);
+        fixture.session.getState().getLogin().setPhase(SessionLoginPhase.RESOURCE_PACK);
+
+        assertFalse(fixture.session.keepPlayingSessionAfterMalformedBatch(1));
+    }
+
+    @Test
+    void delayedMalformedLoginCloseUsesOriginalPhaseAndAddress() throws Exception {
+        assertMalformedLoginPolicy(SessionLoginPhase.RESOURCE_PACK, true);
+    }
+
+    @Test
+    void delayedMalformedNegotiationCloseDoesNotBlockAnAddress() throws Exception {
+        assertMalformedLoginPolicy(SessionLoginPhase.NETWORK_SETTINGS_NEGOTIATED, false);
+    }
+
+    private static void assertMalformedLoginPolicy(SessionLoginPhase phase, boolean expectedBlock) throws Exception {
+        RakNetInterface networkInterface = mock(RakNetInterface.class, RETURNS_DEEP_STUBS);
+        when(networkInterface.getNetwork()).thenReturn(network);
+        SessionFixture fixture = createSession(networkInterface, false, true, true);
+        fixture.session.getState().getLogin().setPhase(phase);
+        InetAddress originalAddress = InetAddress.getByName("192.0.2.23");
+        when(fixture.channel.remoteAddress()).thenReturn(new InetSocketAddress(originalAddress, 20000));
+        ServerScheduler scheduler = mock(ServerScheduler.class);
+        when(MockServer.get().getScheduler()).thenReturn(scheduler);
+
+        receiveBatch(fixture.session, new byte[]{(byte) 0x80});
+
+        assertEquals(SessionLoginPhase.DISCONNECTED, fixture.session.getState().getLogin().getPhase());
+        assertEquals("Sent malformed packet", fixture.session.getDisconnectReason());
+        ArgumentCaptor<Runnable> callback = ArgumentCaptor.forClass(Runnable.class);
+        verify(scheduler).scheduleDelayedTask(eq(InternalPlugin.INSTANCE), callback.capture(), eq(10));
+        when(fixture.channel.remoteAddress()).thenThrow(new IllegalStateException("channel already closed"));
+
+        callback.getValue().run();
+
+        verify(fixture.channel).close();
+        verify(networkInterface, times(expectedBlock ? 1 : 0)).blockAddress(originalAddress, 60);
+        verify(fixture.channel, never()).unsafe();
+    }
+
+    @Test
+    void encryptedSoftThrottleKeepsTheNextPacketDecryptable() throws Exception {
+        for (boolean queueThrottle : new boolean[]{true, false}) {
+            RakNetInterface networkInterface = mock(RakNetInterface.class, RETURNS_DEEP_STUBS);
+            when(networkInterface.getNetwork()).thenReturn(network);
+            SessionFixture fixture = createSession(networkInterface, false, true, true);
+            fixture.session.getState().getLogin().setPhase(SessionLoginPhase.LOGGED_IN);
+            fixture.session.setCompression(CompressionProvider.NONE);
+            SecretKey key = new SecretKeySpec(new byte[32], "AES");
+            Cipher clientCipher = EncryptionUtils.createCipher(true, true, key);
+            fixture.session.setEncryption(key, EncryptionUtils.createCipher(true, true, key),
+                    EncryptionUtils.createCipher(true, false, key));
+            if (queueThrottle) {
+                setField(fixture.session, "inboundThrottled", true);
+            } else {
+                setField(fixture.session, "ingressDecodeBytes", 0D);
+                setField(fixture.session, "lastIngressRefillNanos", Long.MAX_VALUE);
+            }
+            byte[] payload = {(byte) 0xff, 0x01, ClientToServerHandshakePacket.NETWORK_ID};
+
+            receiveBatch(fixture.session, encryptBatch(clientCipher, key, 0, payload));
+
+            assertEquals(0, fixture.session.queuedInboundPacketCount());
+            assertNull(fixture.session.getDisconnectReason());
+            setField(fixture.session, "inboundThrottled", false);
+            setField(fixture.session, "ingressDecodeBytes", 24D * 1024 * 1024);
+
+            receiveBatch(fixture.session, encryptBatch(clientCipher, key, 1, payload));
+
+            assertEquals(1, fixture.session.queuedInboundPacketCount(),
+                    "soft backpressure must advance both the cipher stream and checksum counter");
+            assertNull(fixture.session.getDisconnectReason());
+            verify(fixture.channel, never()).close();
+        }
+    }
+
+    @Test
+    void wireThrottleClosesBeforeDecrypting() throws Exception {
+        SessionFixture fixture = createSession(false);
+        Cipher cipher = mock(Cipher.class);
+        SecretKey key = new SecretKeySpec(new byte[32], "AES");
+        fixture.session.setEncryption(key, cipher, cipher);
+        setField(fixture.session, "ingressBatchTokens", 0D);
+        setField(fixture.session, "lastIngressRefillNanos", Long.MAX_VALUE);
+
+        receiveBatch(fixture.session, new byte[]{1, 2, 3});
+
+        assertEquals("Too much inbound data", fixture.session.getDisconnectReason());
+        verify(fixture.channel).close();
+        verifyNoInteractions(cipher);
+    }
+
+    @Test
+    void malformedSecondFrameDoesNotEnqueueTheValidFirstFrame() throws Exception {
+        RakNetInterface networkInterface = mock(RakNetInterface.class, RETURNS_DEEP_STUBS);
+        when(networkInterface.getNetwork()).thenReturn(network);
+        SessionFixture fixture = createSession(networkInterface, false, true, true);
+        fixture.session.getState().getLogin().setPhase(SessionLoginPhase.LOGGED_IN);
+        BinaryStream batch = new BinaryStream();
+        batch.putByteArray(new byte[]{ClientToServerHandshakePacket.NETWORK_ID});
+        batch.putByteArray(new byte[]{(byte) 0x80});
+        List<DataPacket> prefix = new ArrayList<>();
+        Network.BatchProcessResult result = network.processBatchMeasured(
+                batch.getBuffer(), prefix, CompressionProvider.NONE, RAKNET_PROTOCOL, fixture.player, false);
+        assertFalse(result.success());
+        assertEquals(2, result.framedPackets());
+        assertEquals(batch.getCount(), result.decompressedBytes());
+        assertEquals(1, prefix.size(), "the first frame really did decode before the failure");
+
+        receiveBatch(fixture.session, batch.getBuffer());
+
+        assertEquals(0, fixture.session.queuedInboundPacketCount());
+        assertEquals(0, fixture.session.queuedInboundByteCount());
+        assertNull(fixture.session.getDisconnectReason());
+    }
+
+    @Test
+    void uncompressedBatchesCannotBypassTheDecodedByteLimit() {
+        byte[] oversized = new byte[3 * 1024 * 1024 + 1];
+        List<DataPacket> decoded = new ArrayList<>();
+
+        Network.BatchProcessResult result = network.processBatchMeasured(
+                oversized, decoded, CompressionProvider.NONE, RAKNET_PROTOCOL, null, false);
+
+        assertFalse(result.success());
+        assertEquals(oversized.length, result.decompressedBytes());
+        assertEquals(0, result.framedPackets());
+        assertTrue(decoded.isEmpty());
+    }
+
+    @Test
+    void globalByteBudgetEventuallyServesALargeHeadPacket() throws Exception {
+        Map<InetSocketAddress, RakNetPlayerSession> sessions = new LinkedHashMap<>();
+        RakNetInterface networkInterface = createRakNetInterface(MockServer.get(), new ArrayDeque<>(),
+                Collections.newSetFromMap(new ConcurrentHashMap<>()), sessions);
+        List<SessionFixture> fixtures = new ArrayList<>();
+        int[] sizes = {3 * 1024 * 1024, 4 * 1024 * 1024, 1024 * 1024};
+        for (int i = 0; i < sizes.length; i++) {
+            SessionFixture fixture = createSession(networkInterface, false, true, true);
+            TestPacket packet = new TestPacket();
+            packet.setBuffer(new byte[sizes[i]]);
+            assertTrue(fixture.session.enqueueDecodedBatch(List.of(packet)));
+            fixtures.add(fixture);
+            sessions.put(new InetSocketAddress("127.0.0.1", 20000 + i), fixture.session);
+        }
+
+        networkInterface.process();
+
+        assertEquals(0, fixtures.get(0).session.queuedInboundPacketCount());
+        assertEquals(1, fixtures.get(1).session.queuedInboundPacketCount());
+        assertEquals(0, fixtures.get(2).session.queuedInboundPacketCount());
+        networkInterface.process();
+        assertEquals(0, fixtures.get(1).session.queuedInboundPacketCount(),
+                "the next round must give a large head packet the full global byte budget");
+    }
+
+    private static void receiveBatch(RakNetPlayerSession session, byte[] payload) throws Exception {
+        RakMessage message = new RakMessage(Unpooled.buffer(payload.length + 1).writeByte(0xfe).writeBytes(payload));
+        try {
+            session.channelRead0(mock(ChannelHandlerContext.class), message);
+        } finally {
+            message.release();
+        }
+    }
+
+    private static byte[] encryptBatch(Cipher cipher, SecretKey key, long counter, byte[] payload) throws Exception {
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        digest.update(ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN).putLong(counter).array());
+        digest.update(payload);
+        digest.update(key.getEncoded());
+        byte[] plaintext = Arrays.copyOf(payload, payload.length + 8);
+        System.arraycopy(digest.digest(), 0, plaintext, payload.length, 8);
+        return cipher.update(plaintext);
     }
 
     @Test
@@ -386,7 +749,7 @@ class RakNetPlayerSessionTest {
             when(player.shouldLogin()).thenReturn(false);
             session.setPlayer(player);
         }
-        return new SessionFixture(session, channel, eventLoop, scheduledFuture);
+        return new SessionFixture(session, channel, eventLoop, scheduledFuture, session.getPlayer());
     }
 
     private static void invokeNetworkTick(RakNetPlayerSession session) throws Exception {
@@ -418,7 +781,8 @@ class RakNetPlayerSessionTest {
     }
 
     private static void setField(Object target, String fieldName, Object value) throws Exception {
-        Field field = RakNetInterface.class.getDeclaredField(fieldName);
+        Class<?> owner = target instanceof RakNetPlayerSession ? RakNetPlayerSession.class : RakNetInterface.class;
+        Field field = owner.getDeclaredField(fieldName);
         field.setAccessible(true);
         field.set(target, value);
     }
@@ -460,8 +824,16 @@ class RakNetPlayerSessionTest {
         return prefixed;
     }
 
+    private static List<DataPacket> testPackets(int count) {
+        List<DataPacket> packets = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            packets.add(new TestPacket());
+        }
+        return packets;
+    }
+
     private record SessionFixture(RakNetPlayerSession session, RakChildChannel channel, EventLoop eventLoop,
-                                  ScheduledFuture<?> tickFuture) {
+                                  ScheduledFuture<?> tickFuture, Player player) {
     }
 
     private static final class TestPacket extends DataPacket {

--- a/src/test/java/cn/nukkit/network/session/RakNetPlayerSessionTest.java
+++ b/src/test/java/cn/nukkit/network/session/RakNetPlayerSessionTest.java
@@ -4,44 +4,39 @@ import cn.nukkit.GameVersion;
 import cn.nukkit.MockServer;
 import cn.nukkit.Player;
 import cn.nukkit.network.CompressionProvider;
-import cn.nukkit.network.encryption.EncryptionUtils;
 import cn.nukkit.network.Network;
 import cn.nukkit.network.RakNetInterface;
-import cn.nukkit.network.proxy.ProxyProtocolHandler;
+import cn.nukkit.network.encryption.EncryptionUtils;
 import cn.nukkit.network.protocol.ClientToServerHandshakePacket;
 import cn.nukkit.network.protocol.DataPacket;
 import cn.nukkit.network.protocol.RequestNetworkSettingsPacket;
 import cn.nukkit.network.protocol.ResourcePackChunkRequestPacket;
+import cn.nukkit.network.proxy.ProxyProtocolHandler;
 import cn.nukkit.network.session.login.SessionLoginPhase;
-import cn.nukkit.utils.BinaryStream;
-import cn.nukkit.scheduler.ServerScheduler;
 import cn.nukkit.plugin.InternalPlugin;
+import cn.nukkit.scheduler.ServerScheduler;
+import cn.nukkit.utils.BinaryStream;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelPipeline;
-import io.netty.channel.EventLoop;
+import io.netty.channel.*;
 import io.netty.util.concurrent.ScheduledFuture;
 import org.cloudburstmc.netty.channel.raknet.RakChildChannel;
 import org.cloudburstmc.netty.channel.raknet.packet.RakMessage;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.security.MessageDigest;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.security.MessageDigest;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -335,13 +330,13 @@ class RakNetPlayerSessionTest {
         int burst = RakNetPlayerSession.MAX_INBOUND_PACKETS_PER_SERVER_TICK + 44;
         assertTrue(fixture.session.enqueueDecodedBatch(testPackets(burst)));
 
-        fixture.session.serverTick();
+        drainServerTick(fixture.session);
 
         verify(fixture.player, times(RakNetPlayerSession.MAX_INBOUND_PACKETS_PER_SERVER_TICK))
                 .handleDataPacket(any(DataPacket.class));
         assertEquals(44, fixture.session.queuedInboundPacketCount());
 
-        fixture.session.serverTick();
+        drainServerTick(fixture.session);
 
         verify(fixture.player, times(burst)).handleDataPacket(any(DataPacket.class));
         assertEquals(0, fixture.session.queuedInboundPacketCount());
@@ -368,7 +363,7 @@ class RakNetPlayerSessionTest {
                 testPackets(RakNetPlayerSession.MAX_QUEUED_INBOUND_PACKETS)));
 
         while (fixture.session.queuedInboundPacketCount() > RakNetPlayerSession.MAX_QUEUED_INBOUND_PACKETS / 2) {
-            fixture.session.serverTick();
+            drainServerTick(fixture.session);
         }
 
         assertFalse(fixture.session.isInboundThrottled());
@@ -592,6 +587,33 @@ class RakNetPlayerSessionTest {
     }
 
     @Test
+    void oversizedWirePacketClosesWithSizeCapReason() throws Exception {
+        SessionFixture fixture = createSession(false);
+
+        receiveBatch(fixture.session, new byte[RakNetPlayerSession.MAX_INBOUND_WIRE_BYTES + 1]);
+
+        assertEquals("Too big packet", fixture.session.getDisconnectReason());
+        verify(fixture.channel).close();
+    }
+
+    @Test
+    void malformedBatchesAboveWindowDisconnectPlayingSession() throws Exception {
+        RakNetInterface networkInterface = mock(RakNetInterface.class, RETURNS_DEEP_STUBS);
+        when(networkInterface.getNetwork()).thenReturn(network);
+        SessionFixture fixture = createSession(networkInterface, false, true, true);
+        fixture.session.getState().getLogin().setPhase(SessionLoginPhase.LOGGED_IN);
+
+        for (int i = 0; i < RakNetPlayerSession.MAX_MALFORMED_BATCHES_WHILE_PLAYING; i++) {
+            receiveBatch(fixture.session, new byte[]{(byte) 0x80});
+            assertNull(fixture.session.getDisconnectReason());
+        }
+
+        receiveBatch(fixture.session, new byte[]{(byte) 0x80});
+
+        assertEquals("Sent malformed packet", fixture.session.getDisconnectReason());
+    }
+
+    @Test
     void malformedSecondFrameDoesNotEnqueueTheValidFirstFrame() throws Exception {
         RakNetInterface networkInterface = mock(RakNetInterface.class, RETURNS_DEEP_STUBS);
         when(networkInterface.getNetwork()).thenReturn(network);
@@ -653,6 +675,11 @@ class RakNetPlayerSessionTest {
         networkInterface.process();
         assertEquals(0, fixtures.get(1).session.queuedInboundPacketCount(),
                 "the next round must give a large head packet the full global byte budget");
+    }
+
+    private static void drainServerTick(RakNetPlayerSession session) {
+        session.serverTick(RakNetPlayerSession.MAX_INBOUND_PACKETS_PER_SERVER_TICK,
+                RakNetPlayerSession.MAX_INBOUND_BYTES_PER_SERVER_TICK);
     }
 
     private static void receiveBatch(RakNetPlayerSession session, byte[] payload) throws Exception {


### PR DESCRIPTION
Incoming batches can accumulate an unbounded session queue and let one busy connection consume an entire server tick. Decoding also needs a separate budget: dropped batches, unknown packet IDs, malformed frames, and legacy compression fallback still perform work even when no packet reaches the queue.

Add measured batch decoding and independent per-session budgets for wire traffic, decoded bytes, and framed packets. Admit only complete successful batches into a queue capped at 1,300 packets and 6 MiB. Drain at most 120 packets per session per tick, with a shared interface budget of 2,048 packets / 6 MiB and a rotating starting session. Enforce the decoded byte limit centrally for compression providers such as NONE that do not enforce it themselves.

Wire-budget exhaustion closes the channel before decryption. Queue or decode backpressure consumes the encrypted packet and validates its checksum before discarding it, preserving the cipher stream and packet counter for subsequent traffic. Malformed batches after login are isolated and repeated failures exhaust decode tokens; pre-login failures retain fail-closed behavior. Capture the login phase and remote address before disconnecting so delayed address-block decisions use the original state, and close through the channel's public API.

This overlaps #892 and supersedes its malformed-batch handling policy with bounded decode work, a sliding failure window, and rate-limited diagnostics. This PR applies directly to current master and does not require that branch.

Validation includes session queue/count/byte bounds, fair draining under global packet and byte budgets, accounting for failed fallback attempts and unknown frames, all-or-nothing session admission when a later frame is malformed, post-decompression size enforcement, actual delayed pre-login close callbacks, and real AES encrypted packets across both forms of soft backpressure. Focused session and proxy tests were run with Java 17.
