### PR TITLE
feat: expose complete server tick timing through paired events

### DIFF
--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -24,6 +24,8 @@ import cn.nukkit.event.server.BatchPacketsEvent;
 import cn.nukkit.event.server.PlayerDataSerializeEvent;
 import cn.nukkit.event.server.QueryRegenerateEvent;
 import cn.nukkit.event.server.ServerStopEvent;
+import cn.nukkit.event.server.ServerTickStartEvent;
+import cn.nukkit.event.server.ServerTickEndEvent;
 import cn.nukkit.inventory.CraftingManager;
 import cn.nukkit.inventory.Recipe;
 import cn.nukkit.item.Item;
@@ -129,6 +131,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Pattern;
+import java.util.function.LongSupplier;
 
 /**
  * The main server class
@@ -1781,7 +1784,11 @@ public class Server {
     }
 
     private void tick() {
-        long tickTime = System.currentTimeMillis();
+        tick(System.currentTimeMillis(), System::nanoTime);
+    }
+
+    // The actual tick body also accepts a monotonic clock for deterministic boundary tests.
+    void tick(long tickTime, LongSupplier nanoTime) {
 
         long time = tickTime - this.nextTick;
         if (time < -25) {
@@ -1792,84 +1799,104 @@ public class Server {
             }
         }
 
-        long tickTimeNano = System.nanoTime();
         if ((tickTime - this.nextTick) < -25) {
             return;
         }
 
-        ++this.tickCounter;
+        long tickTimeNano = nanoTime.getAsLong();
+        long tickId = ++this.tickCounter;
+        Throwable tickFailure = null;
+        try {
+            this.pluginManager.callEvent(new ServerTickStartEvent(tickId));
+            this.network.processInterfaces();
 
-        this.network.processInterfaces();
+            if (this.rcon != null) {
+                this.rcon.check();
+            }
 
-        if (this.rcon != null) {
-            this.rcon.check();
-        }
+            this.scheduler.mainThreadHeartbeat(this.tickCounter);
 
-        this.scheduler.mainThreadHeartbeat(this.tickCounter);
+            this.checkTickUpdates(this.tickCounter);
 
-        this.checkTickUpdates(this.tickCounter);
+            for (Player player : new ArrayList<>(this.players.values())) {
+                player.checkNetwork();
+            }
 
-        for (Player player : new ArrayList<>(this.players.values())) {
-            player.checkNetwork();
-        }
+            if ((this.tickCounter & 0b1111) == 0) {
+                this.titleTick();
 
-        if ((this.tickCounter & 0b1111) == 0) {
-            this.titleTick();
+                this.network.resetStatistics();
+                this.maxTick = 20;
+                this.maxUse = 0;
 
-            this.network.resetStatistics();
-            this.maxTick = 20;
-            this.maxUse = 0;
-
-            if ((this.tickCounter & 0b111111111) == 0) {
-                try {
-                    this.pluginManager.callEvent(this.queryRegenerateEvent = new QueryRegenerateEvent(this, 5));
-                    if (this.queryHandler != null) {
-                        this.queryHandler.regenerateInfo();
+                if ((this.tickCounter & 0b111111111) == 0) {
+                    try {
+                        this.pluginManager.callEvent(this.queryRegenerateEvent = new QueryRegenerateEvent(this, 5));
+                        if (this.queryHandler != null) {
+                            this.queryHandler.regenerateInfo();
+                        }
+                    } catch (Exception e) {
+                        log.error(e);
                     }
-                } catch (Exception e) {
-                    log.error(e);
+                }
+
+                this.network.updateName();
+            }
+
+            if (++this.autoSaveTicker >= this.autoSaveTicks) {
+                this.autoSaveTicker = 0;
+                this.doAutoSave();
+            }
+
+            if (this.tickCounter % 100 == 0) {
+                for (Level level : this.levelArray) {
+                    if (!level.isBeingConverted) {
+                        level.doChunkGarbageCollection();
+                    }
                 }
             }
 
-            this.network.updateName();
-        }
+            long nowNano = nanoTime.getAsLong();
 
-        if (++this.autoSaveTicker >= this.autoSaveTicks) {
-            this.autoSaveTicker = 0;
-            this.doAutoSave();
-        }
+            float tick = (float) Math.min(20, 1000000000 / Math.max(1000000, ((double) nowNano - tickTimeNano)));
+            float use = (float) Math.min(1, ((double) (nowNano - tickTimeNano)) / 50000000);
 
-        if (this.tickCounter % 100 == 0) {
-            for (Level level : this.levelArray) {
-                if (!level.isBeingConverted) {
-                    level.doChunkGarbageCollection();
+            if (this.maxTick > tick) {
+                this.maxTick = tick;
+            }
+
+            if (this.maxUse < use) {
+                this.maxUse = use;
+            }
+
+            System.arraycopy(this.tickAverage, 1, this.tickAverage, 0, this.tickAverage.length - 1);
+            this.tickAverage[this.tickAverage.length - 1] = tick;
+
+            System.arraycopy(this.useAverage, 1, this.useAverage, 0, this.useAverage.length - 1);
+            this.useAverage[this.useAverage.length - 1] = use;
+
+            if ((this.nextTick - tickTime) < -1000) {
+                this.nextTick = tickTime;
+            } else {
+                this.nextTick += 50;
+            }
+        } catch (RuntimeException | Error failure) {
+            tickFailure = failure;
+            throw failure;
+        } finally {
+            // Capture before dispatch: observers must not inflate the value they receive.
+            long durationNanos = nanoTime.getAsLong() - tickTimeNano;
+            try {
+                this.pluginManager.callEvent(new ServerTickEndEvent(tickId, durationNanos));
+            } catch (RuntimeException | Error eventFailure) {
+                if (tickFailure != null) {
+                    if (eventFailure != tickFailure) {
+                        tickFailure.addSuppressed(eventFailure);
+                    }
+                } else {
+                    throw eventFailure;
                 }
             }
-        }
-
-        long nowNano = System.nanoTime();
-
-        float tick = (float) Math.min(20, 1000000000 / Math.max(1000000, ((double) nowNano - tickTimeNano)));
-        float use = (float) Math.min(1, ((double) (nowNano - tickTimeNano)) / 50000000);
-
-        if (this.maxTick > tick) {
-            this.maxTick = tick;
-        }
-
-        if (this.maxUse < use) {
-            this.maxUse = use;
-        }
-
-        System.arraycopy(this.tickAverage, 1, this.tickAverage, 0, this.tickAverage.length - 1);
-        this.tickAverage[this.tickAverage.length - 1] = tick;
-
-        System.arraycopy(this.useAverage, 1, this.useAverage, 0, this.useAverage.length - 1);
-        this.useAverage[this.useAverage.length - 1] = use;
-
-        if ((this.nextTick - tickTime) < -1000) {
-            this.nextTick = tickTime;
-        } else {
-            this.nextTick += 50;
         }
     }
 

--- a/src/main/java/cn/nukkit/event/server/ServerTickEndEvent.java
+++ b/src/main/java/cn/nukkit/event/server/ServerTickEndEvent.java
@@ -1,0 +1,32 @@
+package cn.nukkit.event.server;
+
+import cn.nukkit.event.HandlerList;
+
+/**
+ * Completion of one real server tick, even when its body throws.
+ * Duration covers network, scheduler, worlds, players, autosave and tick bookkeeping.
+ * Waiting and opportunistic GC in tickProcessor are outside this interval, as are end listeners.
+ * The duration is uncapped monotonic nanoseconds, not TPS or the capped tick-usage estimate.
+ */
+public final class ServerTickEndEvent extends ServerEvent {
+    private static final HandlerList handlers = new HandlerList();
+    private final long tickId;
+    private final long durationNanos;
+
+    public ServerTickEndEvent(long tickId, long durationNanos) {
+        this.tickId = tickId;
+        this.durationNanos = durationNanos;
+    }
+
+    public long getTickId() {
+        return tickId;
+    }
+
+    public long getDurationNanos() {
+        return durationNanos;
+    }
+
+    public static HandlerList getHandlers() {
+        return handlers;
+    }
+}

--- a/src/main/java/cn/nukkit/event/server/ServerTickStartEvent.java
+++ b/src/main/java/cn/nukkit/event/server/ServerTickStartEvent.java
@@ -1,0 +1,24 @@
+package cn.nukkit.event.server;
+
+import cn.nukkit.event.HandlerList;
+
+/**
+ * Start of one real server tick, after the early-wakeup guard and before network processing.
+ * Not cancellable. Paired with exactly one {@link ServerTickEndEvent}, including failed ticks.
+ */
+public final class ServerTickStartEvent extends ServerEvent {
+    private static final HandlerList handlers = new HandlerList();
+    private final long tickId;
+
+    public ServerTickStartEvent(long tickId) {
+        this.tickId = tickId;
+    }
+
+    public long getTickId() {
+        return tickId;
+    }
+
+    public static HandlerList getHandlers() {
+        return handlers;
+    }
+}

--- a/src/test/java/cn/nukkit/ServerTickMeasurementTest.java
+++ b/src/test/java/cn/nukkit/ServerTickMeasurementTest.java
@@ -1,0 +1,224 @@
+package cn.nukkit;
+
+import cn.nukkit.command.SimpleCommandMap;
+import cn.nukkit.event.Event;
+import cn.nukkit.event.EventPriority;
+import cn.nukkit.event.HandlerList;
+import cn.nukkit.event.Listener;
+import cn.nukkit.event.server.ServerTickEndEvent;
+import cn.nukkit.event.server.ServerTickStartEvent;
+import cn.nukkit.level.Level;
+import cn.nukkit.network.Network;
+import cn.nukkit.plugin.Plugin;
+import cn.nukkit.plugin.PluginDescription;
+import cn.nukkit.plugin.PluginLoader;
+import cn.nukkit.plugin.PluginManager;
+import cn.nukkit.plugin.RegisteredListener;
+import cn.nukkit.scheduler.ServerScheduler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class ServerTickMeasurementTest {
+    private final Server server = mock(Server.class);
+    private final Network network = mock(Network.class);
+    private final ServerScheduler scheduler = mock(ServerScheduler.class);
+    private final PluginManager manager = mock(PluginManager.class);
+    private final AtomicLong nanos = new AtomicLong(1);
+    private final List<Event> events = new ArrayList<>();
+
+    @BeforeEach
+    void prepareActualTickBody() throws Exception {
+        set("network", network);
+        set("scheduler", scheduler);
+        set("pluginManager", manager);
+        set("players", new HashMap<InetSocketAddress, Player>());
+        set("levelArray", new Level[0]);
+        set("tickAverage", new float[20]);
+        set("useAverage", new float[20]);
+        set("autoSaveTicks", Integer.MAX_VALUE);
+        doCallRealMethod().when(server).tick(anyLong(), any());
+        doAnswer(invocation -> {
+            events.add(invocation.getArgument(0));
+            return null;
+        }).when(manager).callEvent(any());
+    }
+
+    @Test
+    void twoMillisWorkAndFortyEightMillisWaitingRemainTwoMillisWork() {
+        doAnswer(invocation -> {
+            nanos.addAndGet(2_000_000);
+            return null;
+        }).when(network).processInterfaces();
+
+        server.tick(0, nanos::get);
+        nanos.addAndGet(48_000_000); // Waiting in tickProcessor, outside Server.tick.
+        server.tick(50, nanos::get);
+
+        assertEquals(4, events.size());
+        assertEquals(2_000_000, end(1).getDurationNanos());
+        assertEquals(2_000_000, end(3).getDurationNanos());
+        assertEquals(1, ((ServerTickStartEvent) events.get(0)).getTickId());
+        assertEquals(1, end(1).getTickId());
+        assertEquals(2, end(3).getTickId());
+    }
+
+    @Test
+    void includesWorkAfterSchedulerAndDoesNotClipAtFiftyMillis() throws Exception {
+        Player player = mock(Player.class);
+        set("players", new HashMap<>(java.util.Map.of(new InetSocketAddress(0), player)));
+        set("autoSaveTicks", 1);
+        doAnswer(invocation -> { nanos.addAndGet(2_000_000); return null; })
+                .when(scheduler).mainThreadHeartbeat(1);
+        doAnswer(invocation -> { nanos.addAndGet(30_000_000); return null; })
+                .when(player).checkNetwork();
+        doAnswer(invocation -> { nanos.addAndGet(43_000_000); return null; })
+                .when(server).doAutoSave();
+
+        server.tick(0, nanos::get);
+
+        assertEquals(75_000_000, end(1).getDurationNanos());
+        verify(scheduler).mainThreadHeartbeat(1);
+        verify(player).checkNetwork();
+        verify(server).doAutoSave();
+    }
+
+    @Test
+    void earlyWakeupEmitsNeitherStartNorEnd() throws Exception {
+        set("nextTick", 26L);
+
+        server.tick(0, nanos::get);
+
+        assertTrue(events.isEmpty());
+        verifyNoInteractions(network, scheduler, manager);
+        Field counter = Server.class.getDeclaredField("tickCounter");
+        counter.setAccessible(true);
+        assertEquals(0, counter.getInt(server));
+    }
+
+    @Test
+    void bodyExceptionStillEmitsExactlyOneEndAndSurvivesEndObserverFailure() {
+        RuntimeException bodyFailure = new IllegalStateException("tick body");
+        Error observerFailure = new AssertionError("end observer");
+        doAnswer(invocation -> {
+            nanos.addAndGet(75_000_000);
+            throw bodyFailure;
+        }).when(scheduler).mainThreadHeartbeat(1);
+        doAnswer(invocation -> {
+            Event event = invocation.getArgument(0);
+            events.add(event);
+            if (event instanceof ServerTickEndEvent) throw observerFailure;
+            return null;
+        }).when(manager).callEvent(any());
+
+        assertSame(bodyFailure, assertThrows(RuntimeException.class, () -> server.tick(0, nanos::get)));
+        assertEquals(2, events.size());
+        assertEquals(((ServerTickStartEvent) events.get(0)).getTickId(), end(1).getTickId());
+        assertEquals(75_000_000, end(1).getDurationNanos());
+        assertArrayEquals(new Throwable[]{observerFailure}, bodyFailure.getSuppressed());
+    }
+
+    @Test
+    void startObserverFailureStillEmitsOneEnd() {
+        Error failure = new AssertionError("start observer");
+        doAnswer(invocation -> {
+            Event event = invocation.getArgument(0);
+            events.add(event);
+            if (event instanceof ServerTickStartEvent) throw failure;
+            return null;
+        }).when(manager).callEvent(any());
+
+        assertSame(failure, assertThrows(Error.class, () -> server.tick(0, nanos::get)));
+        assertEquals(2, events.size());
+        assertEquals(((ServerTickStartEvent) events.get(0)).getTickId(), end(1).getTickId());
+        verifyNoInteractions(network, scheduler);
+    }
+
+    @Test
+    void endObserverWorkDoesNotChangeReportedDuration() {
+        doAnswer(invocation -> {
+            nanos.addAndGet(2_000_000);
+            return null;
+        }).when(network).processInterfaces();
+        doAnswer(invocation -> {
+            Event event = invocation.getArgument(0);
+            events.add(event);
+            if (event instanceof ServerTickEndEvent) nanos.addAndGet(90_000_000);
+            return null;
+        }).when(manager).callEvent(any());
+
+        server.tick(0, nanos::get);
+
+        assertEquals(2_000_000, end(1).getDurationNanos());
+    }
+
+    @Test
+    void noListenersStillRunsTheSameTickBody() throws Exception {
+        set("pluginManager", new PluginManager(server, mock(SimpleCommandMap.class)));
+
+        server.tick(0, nanos::get);
+
+        verify(network).processInterfaces();
+        verify(scheduler).mainThreadHeartbeat(1);
+        Field nextTick = Server.class.getDeclaredField("nextTick");
+        nextTick.setAccessible(true);
+        assertEquals(50L, nextTick.getLong(server));
+    }
+
+    @Test
+    void pluginDisableUnregistersTickObserversBeforeReload() {
+        PluginManager realManager = new PluginManager(server, mock(SimpleCommandMap.class));
+        when(server.getScheduler()).thenReturn(scheduler);
+        Plugin oldPlugin = enabledPlugin();
+        Plugin reloadedPlugin = enabledPlugin();
+        AtomicInteger oldCalls = new AtomicInteger();
+        AtomicInteger newCalls = new AtomicInteger();
+        try {
+            register(oldPlugin, oldCalls);
+            realManager.callEvent(new ServerTickEndEvent(1, 2));
+            realManager.disablePlugin(oldPlugin);
+            register(reloadedPlugin, newCalls);
+            realManager.callEvent(new ServerTickEndEvent(2, 2));
+            assertEquals(1, oldCalls.get());
+            assertEquals(1, newCalls.get());
+        } finally {
+            HandlerList.unregisterAll(oldPlugin);
+            HandlerList.unregisterAll(reloadedPlugin);
+        }
+    }
+
+    private static Plugin enabledPlugin() {
+        Plugin plugin = mock(Plugin.class);
+        when(plugin.isEnabled()).thenReturn(true);
+        when(plugin.getPluginLoader()).thenReturn(mock(PluginLoader.class));
+        when(plugin.getDescription()).thenReturn(mock(PluginDescription.class));
+        return plugin;
+    }
+
+    private static void register(Plugin plugin, AtomicInteger calls) {
+        ServerTickEndEvent.getHandlers().register(new RegisteredListener(
+                new Listener() {}, (listener, event) -> calls.incrementAndGet(),
+                EventPriority.MONITOR, plugin, false));
+    }
+
+    private ServerTickEndEvent end(int index) {
+        return assertInstanceOf(ServerTickEndEvent.class, events.get(index));
+    }
+
+    private void set(String name, Object value) throws Exception {
+        Field field = Server.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(server, value);
+    }
+}


### PR DESCRIPTION
Plugins can observe scheduler work, but that does not measure the complete server tick, including network processing, world/player updates, autosave and bookkeeping. The existing tick-usage estimate is capped at 50 ms, so it cannot express the duration of a slow tick.

Add non-cancellable `ServerTickStartEvent` and `ServerTickEndEvent` events with matching tick IDs. The end event exposes the uncapped duration in monotonic nanoseconds and runs from `finally`, including when the tick body or start dispatch throws. If both the body and end dispatch fail, the original failure is preserved and the observer failure is suppressed. Waiting between ticks and end-event listeners are excluded from the reported interval.

The normal tick entry point still supplies the real clocks; a package-private clock seam makes boundary and failure tests deterministic.

Validation: all 8 `ServerTickMeasurementTest` tests pass on Java 17. They cover idle time exclusion, work after the scheduler and durations over 50 ms, early-wakeup suppression, paired events during failures, end-listener timing, operation without listeners, and listener removal on plugin disable/reload.

```text
mvn -q -Dtest=ServerTickMeasurementTest test
```
