### PR TITLE
feat: apply netherite armour resistance to incoming knockback impulses

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -2774,7 +2774,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
      * Builds the knockback resistance attribute entry and refreshes the last-sent cache.
      */
     private Attribute knockBackResistanceAttributeEntry() {
-        float value = Math.max(0f, Math.min(1f, (float) this.getKnockBackResistance()));
+        float value = Math.max(0, Math.min(1, (float) this.getKnockBackResistance()));
         this.lastSentKnockBackResistance = value;
         return Attribute.getAttribute(Attribute.KNOCKBACK_RESISTANCE).setValue(value);
     }

--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -2754,10 +2754,42 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                 Attribute.getAttribute(Attribute.MAX_HEALTH).setMaxValue(this.getMaxHealth()).setValue(health > 0 ? (health < getMaxHealth() ? health : getMaxHealth()) : 0),
                 Attribute.getAttribute(Attribute.MAX_HUNGER).setValue(this.foodData.getLevel()).setDefaultValue(this.foodData.getMaxLevel()),
                 Attribute.getAttribute(Attribute.MOVEMENT_SPEED).setValue(this.speedToSend).setDefaultValue(this.getMovementSpeed()),
+                this.knockBackResistanceAttributeEntry(),
                 Attribute.getAttribute(Attribute.EXPERIENCE_LEVEL).setValue(this.expLevel),
                 Attribute.getAttribute(Attribute.EXPERIENCE).setValue(((float) this.exp) / calculateRequireExperience(this.expLevel))
         };
         this.dataPacket(pk);
+    }
+
+    /**
+     * 上次同步给客户端的击退抗性值，[-1, 0) 表示尚未同步过。
+     * <p>
+     * Last knockback resistance value sent to the client; values in [-1, 0) mean never sent.
+     */
+    private float lastSentKnockBackResistance = -1f;
+
+    /**
+     * 构造击退抗性属性条目并更新已同步值缓存。
+     * <p>
+     * Builds the knockback resistance attribute entry and refreshes the last-sent cache.
+     */
+    private Attribute knockBackResistanceAttributeEntry() {
+        float value = Math.max(0f, Math.min(1f, (float) this.getKnockBackResistance()));
+        this.lastSentKnockBackResistance = value;
+        return Attribute.getAttribute(Attribute.KNOCKBACK_RESISTANCE).setValue(value);
+    }
+
+    /**
+     * 将当前击退抗性通过属性包同步给客户端，盔甲变化后调用；值未变化时跳过发包。
+     * <p>
+     * Syncs the current knockback resistance to the client via the attribute packet, called after armour changes; skips the packet when the value is unchanged.
+     */
+    public void sendKnockBackResistanceAttribute() {
+        float value = Math.max(0f, Math.min(1f, (float) this.getKnockBackResistance()));
+        if (value == this.lastSentKnockBackResistance) {
+            return;
+        }
+        this.setAttribute(this.knockBackResistanceAttributeEntry());
     }
 
     public void sendFogStack() {

--- a/src/main/java/cn/nukkit/entity/EntityHumanType.java
+++ b/src/main/java/cn/nukkit/entity/EntityHumanType.java
@@ -10,7 +10,6 @@ import cn.nukkit.inventory.PlayerEnderChestInventory;
 import cn.nukkit.inventory.PlayerInventory;
 import cn.nukkit.inventory.PlayerOffhandInventory;
 import cn.nukkit.item.Item;
-import cn.nukkit.item.ItemArmor;
 import cn.nukkit.item.ItemSkull;
 import cn.nukkit.item.enchantment.Enchantment;
 import cn.nukkit.level.format.FullChunk;
@@ -149,9 +148,7 @@ public abstract class EntityHumanType extends EntityCreature implements Inventor
         double resistance = super.getKnockBackResistance();
         if (this.inventory != null) {
             for (Item armor : this.inventory.getArmorContents()) {
-                if (armor instanceof ItemArmor piece && piece.getTier() == ItemArmor.TIER_NETHERITE) {
-                    resistance += KNOCKBACK_RESISTANCE_PER_NETHERITE_PIECE;
-                }
+                resistance += armor.getKnockBackResistance();
             }
         }
         return resistance;

--- a/src/main/java/cn/nukkit/entity/EntityHumanType.java
+++ b/src/main/java/cn/nukkit/entity/EntityHumanType.java
@@ -10,6 +10,7 @@ import cn.nukkit.inventory.PlayerEnderChestInventory;
 import cn.nukkit.inventory.PlayerInventory;
 import cn.nukkit.inventory.PlayerOffhandInventory;
 import cn.nukkit.item.Item;
+import cn.nukkit.item.ItemArmor;
 import cn.nukkit.item.ItemSkull;
 import cn.nukkit.item.enchantment.Enchantment;
 import cn.nukkit.level.format.FullChunk;
@@ -141,6 +142,19 @@ public abstract class EntityHumanType extends EntityCreature implements Inventor
             return drops.toArray(Item.EMPTY_ARRAY);
         }
         return Item.EMPTY_ARRAY;
+    }
+
+    @Override
+    public double getKnockBackResistance() {
+        double resistance = super.getKnockBackResistance();
+        if (this.inventory != null) {
+            for (Item armor : this.inventory.getArmorContents()) {
+                if (armor instanceof ItemArmor piece && piece.getTier() == ItemArmor.TIER_NETHERITE) {
+                    resistance += KNOCKBACK_RESISTANCE_PER_NETHERITE_PIECE;
+                }
+            }
+        }
+        return resistance;
     }
 
     @Override

--- a/src/main/java/cn/nukkit/entity/EntityLiving.java
+++ b/src/main/java/cn/nukkit/entity/EntityLiving.java
@@ -55,9 +55,6 @@ public abstract class EntityLiving extends Entity implements EntityDamageable {
     protected int attackTime = 0;
     protected int knockBackTime = 0;
 
-    /** Resistance contributed by each worn piece of netherite armour. */
-    public static final double KNOCKBACK_RESISTANCE_PER_NETHERITE_PIECE = 0.1;
-
     protected float movementSpeed = 0.1f;
 
     protected int turtleTicks = 0;
@@ -210,7 +207,7 @@ public abstract class EntityLiving extends Entity implements EntityDamageable {
 
     /** Fraction of an incoming knockback impulse resisted, from zero to one. */
     public double getKnockBackResistance() {
-        return 0d;
+        return 0;
     }
 
     public void knockBack(Entity attacker, double damage, double x, double z, double base) {
@@ -219,8 +216,8 @@ public abstract class EntityLiving extends Entity implements EntityDamageable {
             return;
         }
 
-        double kept = 1d - Math.max(0d, Math.min(1d, this.getKnockBackResistance()));
-        if (kept <= 0d) {
+        double kept = 1 - Math.max(0, Math.min(1, this.getKnockBackResistance()));
+        if (kept <= 0) {
             return;
         }
 
@@ -534,7 +531,7 @@ public abstract class EntityLiving extends Entity implements EntityDamageable {
     public float getMovementSpeed() {
         return this.movementSpeed;
     }
-    
+
     public int getAirTicks() {
         return this.airTicks;
     }

--- a/src/main/java/cn/nukkit/entity/EntityLiving.java
+++ b/src/main/java/cn/nukkit/entity/EntityLiving.java
@@ -55,6 +55,9 @@ public abstract class EntityLiving extends Entity implements EntityDamageable {
     protected int attackTime = 0;
     protected int knockBackTime = 0;
 
+    /** Resistance contributed by each worn piece of netherite armour. */
+    public static final double KNOCKBACK_RESISTANCE_PER_NETHERITE_PIECE = 0.1;
+
     protected float movementSpeed = 0.1f;
 
     protected int turtleTicks = 0;
@@ -205,9 +208,19 @@ public abstract class EntityLiving extends Entity implements EntityDamageable {
         this.knockBack(attacker, damage, x, z, 0.3);
     }
 
+    /** Fraction of an incoming knockback impulse resisted, from zero to one. */
+    public double getKnockBackResistance() {
+        return 0d;
+    }
+
     public void knockBack(Entity attacker, double damage, double x, double z, double base) {
         double f = Math.sqrt(x * x + z * z);
         if (f <= 0) {
+            return;
+        }
+
+        double kept = 1d - Math.max(0d, Math.min(1d, this.getKnockBackResistance()));
+        if (kept <= 0d) {
             return;
         }
 
@@ -218,9 +231,9 @@ public abstract class EntityLiving extends Entity implements EntityDamageable {
         motion.x /= 2d;
         motion.y /= 2d;
         motion.z /= 2d;
-        motion.x += x * f * base;
-        motion.y += base;
-        motion.z += z * f * base;
+        motion.x += x * f * base * kept;
+        motion.y += base * kept;
+        motion.z += z * f * base * kept;
 
         if (motion.y > base) {
             motion.y = base;

--- a/src/main/java/cn/nukkit/inventory/PlayerInventory.java
+++ b/src/main/java/cn/nukkit/inventory/PlayerInventory.java
@@ -201,6 +201,9 @@ public class PlayerInventory extends BaseInventory {
         if (index >= this.getSize()) {
             this.sendArmorSlot(index, this.getViewers());
             this.sendArmorSlot(index, this.getHolder().getViewers().values());
+            if (holder instanceof Player player) {
+                player.sendKnockBackResistanceAttribute();
+            }
         } else {
             super.onSlotChange(index, before, send);
         }

--- a/src/main/java/cn/nukkit/item/Item.java
+++ b/src/main/java/cn/nukkit/item/Item.java
@@ -1908,6 +1908,10 @@ public class Item implements Cloneable, BlockID, ItemID, ItemNamespaceId, Protoc
         return 0;
     }
 
+    public double getKnockBackResistance() {
+        return 0;
+    }
+
     public boolean isUnbreakable() {
         if (!(this instanceof ItemDurable)) {
             return false;

--- a/src/main/java/cn/nukkit/item/ItemArmor.java
+++ b/src/main/java/cn/nukkit/item/ItemArmor.java
@@ -25,6 +25,9 @@ abstract public class ItemArmor extends Item implements ItemDurable {
     public static final int TIER_NETHERITE = 7;
     public static final int TIER_OTHER = 8;
 
+    /** Resistance contributed by each worn piece of netherite armour. */
+    public static final double KNOCKBACK_RESISTANCE_PER_NETHERITE_PIECE = 0.1;
+
     public ItemArmor(int id) {
         super(id);
     }
@@ -154,6 +157,11 @@ abstract public class ItemArmor extends Item implements ItemDurable {
         }
 
         return 0;
+    }
+
+    @Override
+    public double getKnockBackResistance() {
+        return this.getTier() == TIER_NETHERITE ? KNOCKBACK_RESISTANCE_PER_NETHERITE_PIECE : 0;
     }
 
     @Override

--- a/src/test/java/cn/nukkit/entity/NetheriteKnockBackResistanceTest.java
+++ b/src/test/java/cn/nukkit/entity/NetheriteKnockBackResistanceTest.java
@@ -1,0 +1,99 @@
+package cn.nukkit.entity;
+
+import cn.nukkit.Player;
+import cn.nukkit.inventory.PlayerInventory;
+import cn.nukkit.item.*;
+import cn.nukkit.math.Vector3;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class NetheriteKnockBackResistanceTest {
+    @Test
+    void everyWornPieceContributesOneTenth() {
+        Item[] pieces = {new ItemHelmetNetherite(), new ItemChestplateNetherite(),
+                new ItemLeggingsNetherite(), new ItemBootsNetherite()};
+        for (int count = 0; count <= 4; count++) {
+            Player player = wearer(java.util.Arrays.copyOf(pieces, count));
+            assertEquals(count * 0.1, player.getKnockBackResistance(), 1e-9);
+            Vector3 motion = push(player, 3, 4);
+            assertEquals(0.18 * (1 - count * 0.1), motion.x, 1e-9);
+            assertEquals(0.3 * (1 - count * 0.1), motion.y, 1e-9);
+            assertEquals(0.24 * (1 - count * 0.1), motion.z, 1e-9);
+        }
+    }
+
+    @Test
+    void diamondArmourDoesNotAddResistance() {
+        Player player = wearer(new ItemHelmetDiamond(), new ItemChestplateDiamond(),
+                new ItemLeggingsDiamond(), new ItemBootsDiamond());
+        assertEquals(0, player.getKnockBackResistance());
+        assertEquals(0.3, push(player, 1, 0).x, 1e-9);
+    }
+
+    @Test
+    void mixedArmourOnlyCountsNetherite() {
+        Player player = wearer(new ItemHelmetNetherite(), new ItemChestplateDiamond(),
+                new ItemLeggingsDiamond(), new ItemBootsNetherite());
+        assertEquals(0.2, player.getKnockBackResistance(), 1e-9);
+    }
+
+    @Test
+    void currentMotionAndVerticalCeilingKeepTheirExistingMeaning() {
+        Player player = wearer(new ItemHelmetNetherite());
+        player.motionX = 0.2;
+        player.motionY = 2;
+        player.motionZ = -0.2;
+        Vector3 motion = push(player, 1, 0);
+        assertEquals(0.37, motion.x, 1e-9);
+        assertEquals(0.3, motion.y, 1e-9);
+        assertEquals(-0.1, motion.z, 1e-9);
+        verify(player).resetFallDistance();
+        assertEquals(10, player.knockBackTime);
+    }
+
+    @Test
+    void fullOrGreaterResistanceSkipsTheImpulse() {
+        for (double resistance : new double[]{1, 2}) {
+            Player player = wearer();
+            when(player.getKnockBackResistance()).thenReturn(resistance);
+            player.knockBack(null, 1, 1, 0, 0.3);
+            verify(player, never()).setMotion(any(Vector3.class));
+            verify(player, never()).resetFallDistance();
+        }
+    }
+
+    @Test
+    void negativeResistanceDoesNotAmplifyKnockback() {
+        Player player = wearer();
+        when(player.getKnockBackResistance()).thenReturn(-1d);
+        assertEquals(0.3, push(player, 1, 0).x, 1e-9);
+    }
+
+    @Test
+    void zeroDirectionStillDoesNothing() {
+        Player player = wearer(new ItemHelmetNetherite());
+        player.knockBack(null, 1, 0, 0, 0.3);
+        verify(player, never()).setMotion(any(Vector3.class));
+    }
+
+    private static Player wearer(Item... armour) {
+        Player player = mock(Player.class);
+        PlayerInventory inventory = mock(PlayerInventory.class);
+        player.inventory = inventory;
+        when(inventory.getArmorContents()).thenReturn(armour);
+        doCallRealMethod().when(player).getKnockBackResistance();
+        doCallRealMethod().when(player).knockBack(nullable(Entity.class), anyDouble(), anyDouble(), anyDouble(), anyDouble());
+        return player;
+    }
+
+    private static Vector3 push(Player player, double x, double z) {
+        player.knockBack(null, 1, x, z, 0.3);
+        ArgumentCaptor<Vector3> motion = ArgumentCaptor.forClass(Vector3.class);
+        verify(player).setMotion(motion.capture());
+        return motion.getValue();
+    }
+}

--- a/src/test/java/cn/nukkit/entity/NetheriteKnockBackResistanceTest.java
+++ b/src/test/java/cn/nukkit/entity/NetheriteKnockBackResistanceTest.java
@@ -7,7 +7,7 @@ import cn.nukkit.math.Vector3;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -78,6 +78,55 @@ class NetheriteKnockBackResistanceTest {
         Player player = wearer(new ItemHelmetNetherite());
         player.knockBack(null, 1, 0, 0, 0.3);
         verify(player, never()).setMotion(any(Vector3.class));
+    }
+
+    @Test
+    void attributePacketReflectsWornNetherite() {
+        Player player = wearer(new ItemHelmetNetherite(), new ItemBootsNetherite());
+        doCallRealMethod().when(player).sendKnockBackResistanceAttribute();
+        player.sendKnockBackResistanceAttribute();
+        ArgumentCaptor<Attribute> attribute = ArgumentCaptor.forClass(Attribute.class);
+        verify(player).setAttribute(attribute.capture());
+        assertEquals(Attribute.KNOCKBACK_RESISTANCE, attribute.getValue().getId());
+        assertEquals("minecraft:knockback_resistance", attribute.getValue().getName());
+        assertEquals(0.2f, attribute.getValue().getValue(), 1e-9f);
+    }
+
+    @Test
+    void attributeValueIsClampedToAttributeRange() {
+        Player player = wearer();
+        when(player.getKnockBackResistance()).thenReturn(2d);
+        doCallRealMethod().when(player).sendKnockBackResistanceAttribute();
+        player.sendKnockBackResistanceAttribute();
+        ArgumentCaptor<Attribute> attribute = ArgumentCaptor.forClass(Attribute.class);
+        verify(player).setAttribute(attribute.capture());
+        assertEquals(1f, attribute.getValue().getValue());
+    }
+
+    @Test
+    void unchangedResistanceSkipsThePacket() {
+        Player player = wearer(new ItemHelmetNetherite());
+        doCallRealMethod().when(player).sendKnockBackResistanceAttribute();
+        player.sendKnockBackResistanceAttribute();
+        player.sendKnockBackResistanceAttribute();
+        verify(player, times(1)).setAttribute(any(Attribute.class));
+    }
+
+    @Test
+    void armourSlotChangeSyncsTheAttribute() {
+        Player player = mock(Player.class);
+        PlayerInventory inventory = mock(PlayerInventory.class);
+        player.inventory = inventory;
+        player.spawned = true;
+        when(inventory.getHolder()).thenReturn(player);
+        when(inventory.getSize()).thenReturn(36);
+        when(inventory.getViewers()).thenReturn(java.util.Collections.emptySet());
+        when(player.getViewers()).thenReturn(new java.util.HashMap<>());
+        doCallRealMethod().when(inventory).onSlotChange(anyInt(), any(), anyBoolean());
+
+        inventory.onSlotChange(36, Item.get(Item.AIR), true);
+
+        verify(player).sendKnockBackResistanceAttribute();
     }
 
     private static Player wearer(Item... armour) {


### PR DESCRIPTION
Netherite armour currently has no effect on EntityLiving.knockBack: a fully equipped player receives the same impulse as a player wearing no armour.

Add a knockback-resistance hook with a zero default and let armour-wearing entities contribute 0.1 for each worn netherite piece. Scale only the incoming impulse by the remaining fraction, clamped to zero through one. Preserve the existing half-motion damping, base strength, vertical ceiling, and knockback timer for ordinary hits. Full resistance skips the impulse.

This applies directly to master; it does not include the knockback strength/enchantment changes from #908 or any server-specific balance settings. The Bedrock [Nether Update notes](https://feedback.minecraft.net/hc/en-us/articles/360044928311-Minecraft-Nether-Update-1-16-0-Bedrock) document knockback resistance as a scale rather than a probability.

Validation: all 7 NetheriteKnockBackResistanceTest cases pass, covering zero through four pieces, mixed/diamond armour, horizontal direction and vertical impulse, existing motion and ceiling, full/excess/negative resistance, and a zero-length direction.
