### PR TITLE
perf: reduce collision, palette, and chunk-loader lookup allocations

### DIFF
--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -315,7 +315,12 @@ public class Level implements ChunkManager, Metadatable {
 
     private final Int2IntMap loaderCounter = new Int2IntOpenHashMap();
 
-    private final Map<Long, Map<Integer, ChunkLoader>> chunkLoaders = new ConcurrentHashMap<>();
+    /**
+     * Primitive keys avoid boxing and mix both coordinates of {@link #chunkHash(int, int)}.
+     * Long.hashCode folds them into x ^ z, causing colliding bins for diagonal chunks.
+     * Keep concurrent outer-map reads available to the chunk-loading pipeline.
+     */
+    private final Long2ObjectNonBlockingMap<Map<Integer, ChunkLoader>> chunkLoaders = new Long2ObjectNonBlockingMap<>();
 
     private final Map<Long, Map<Integer, Player>> playerLoaders = new ConcurrentHashMap<>();
 

--- a/src/main/java/cn/nukkit/level/format/leveldb/structure/StateBlockStorage.java
+++ b/src/main/java/cn/nukkit/level/format/leveldb/structure/StateBlockStorage.java
@@ -5,6 +5,7 @@ import cn.nukkit.Nukkit;
 import cn.nukkit.Server;
 import cn.nukkit.block.Block;
 import cn.nukkit.block.BlockID;
+import cn.nukkit.level.BlockPalette;
 import cn.nukkit.level.GlobalBlockPalette;
 import cn.nukkit.level.Level;
 import cn.nukkit.level.format.anvil.util.BlockStorage;
@@ -14,6 +15,7 @@ import cn.nukkit.level.util.BitArray;
 import cn.nukkit.level.util.BitArrayVersion;
 import cn.nukkit.level.util.PalettedBlockStorage;
 import cn.nukkit.math.BlockVector3;
+import cn.nukkit.network.protocol.ProtocolInfo;
 import cn.nukkit.utils.BinaryStream;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
@@ -242,16 +244,33 @@ public class StateBlockStorage {
     public void writeTo(GameVersion protocol, BinaryStream stream, boolean antiXray) {
         PalettedBlockStorage palettedBlockStorage = PalettedBlockStorage.createFromBlockPalette(protocol);
 
-        for (int i = 0; i < SECTION_SIZE; i++) {
-            int fullId = get(i);
-            int id = fullId >> Block.DATA_BITS;
-            int meta = fullId & Block.DATA_MASK;
-            if (antiXray && id < Block.MAX_BLOCK_ID && Level.xrayableBlocks[id]) {
-                id = Block.STONE;
-                meta = 0;
+        // Resolve the palette and network-ID format once per section, as in anvil BlockStorage.
+        // Older protocols still need GlobalBlockPalette's legacy runtime-ID tables.
+        if (protocol.getProtocol() >= ProtocolInfo.v1_16_100) {
+            BlockPalette blockPalette = GlobalBlockPalette.getPaletteByProtocol(protocol);
+            boolean useHash = GlobalBlockPalette.shouldUseHashedBlockNetworkIds(protocol);
+            for (int i = 0; i < SECTION_SIZE; i++) {
+                int fullId = get(i);
+                int id = fullId >> Block.DATA_BITS;
+                int meta = fullId & Block.DATA_MASK;
+                if (antiXray && id < Block.MAX_BLOCK_ID && Level.xrayableBlocks[id]) {
+                    id = Block.STONE;
+                    meta = 0;
+                }
+                palettedBlockStorage.setBlock(i, useHash ? blockPalette.getHashId(id, meta)
+                                                        : blockPalette.getRuntimeId(id, meta));
             }
-            int runtimeId = GlobalBlockPalette.getOrCreateRuntimeId(protocol, id, meta);
-            palettedBlockStorage.setBlock(i, runtimeId);
+        } else {
+            for (int i = 0; i < SECTION_SIZE; i++) {
+                int fullId = get(i);
+                int id = fullId >> Block.DATA_BITS;
+                int meta = fullId & Block.DATA_MASK;
+                if (antiXray && id < Block.MAX_BLOCK_ID && Level.xrayableBlocks[id]) {
+                    id = Block.STONE;
+                    meta = 0;
+                }
+                palettedBlockStorage.setBlock(i, GlobalBlockPalette.getOrCreateRuntimeId(protocol, id, meta));
+            }
         }
 
         palettedBlockStorage.writeTo(stream);

--- a/src/main/java/cn/nukkit/utils/CollisionHelper.java
+++ b/src/main/java/cn/nukkit/utils/CollisionHelper.java
@@ -5,6 +5,7 @@ import cn.nukkit.block.Block;
 import cn.nukkit.block.BlockBarrier;
 import cn.nukkit.entity.Entity;
 import cn.nukkit.level.Level;
+import cn.nukkit.level.format.FullChunk;
 import cn.nukkit.math.AxisAlignedBB;
 import cn.nukkit.math.NukkitMath;
 import org.jetbrains.annotations.NotNull;
@@ -34,6 +35,34 @@ public record CollisionHelper(Entity entity) {
     /** Test-only hook to reset the throttle map between tests. Not part of the public API. */
     static void resetThrottleStateForTests() {
         RUNAWAY_LOG_TIMES.clear();
+    }
+
+    /** Default filter of the {@code getCollisionBlocks} overloads: everything except air. Kept as a
+     * constant so the loop can recognise it and take the allocation-free air fast path below. */
+    private static final Predicate<Block> NOT_AIR = block -> block.getId() != Block.AIR;
+
+    /**
+     * Resolves the chunk owning a block column, reusing {@code hint} when it already covers it.
+     * Returns {@code null} for an unloaded chunk, which every caller here treats as air - exactly what
+     * {@link Level#getBlock} produces for a missing chunk.
+     */
+    private static FullChunk chunkAt(Level level, FullChunk hint, int x, int z) {
+        int cx = x >> 4;
+        int cz = z >> 4;
+        if (hint != null && hint.getX() == cx && hint.getZ() == cz) {
+            return hint;
+        }
+        return level.getChunkIfLoaded(cx, cz);
+    }
+
+    /**
+     * Allocation-free air probe: reads the raw block id out of the section instead of materialising a
+     * Block. Empty cells dominate every entity bounding box, and each one used to allocate a BlockAir
+     * (plus its Position/Vector3 clone) that the very next line threw away. Air has no bounding box and
+     * no collision box, so skipping it is behaviour-preserving for all callers below.
+     */
+    private static boolean isAirAt(FullChunk chunk, int x, int y, int z) {
+        return chunk == null || chunk.getBlockId(x & 0xF, y, z & 0xF, 0) == Block.AIR;
     }
 
     /** Rejects non-finite AABBs: NaN/Infinity make floor/ceil overflow and throw NegativeArraySizeException. */
@@ -209,8 +238,11 @@ public record CollisionHelper(Entity entity) {
 
         for (int x = minX; x <= maxX; x++) {
             for (int z = minZ; z <= maxZ; z++) {
+                FullChunk chunk = chunkAt(level, entity.chunk, x, z);
                 for (int y = clampedMinY; y <= clampedMaxY; y++) {
-                    Block block = level.getBlock(entity.chunk, x, y, z, 0, false);
+                    if (isAirAt(chunk, x, y, z)) continue;
+
+                    Block block = level.getBlock(chunk, x, y, z, 0, false);
                     if (block == null || block.isAir()) continue;
 
                     if (count == result.length) {
@@ -256,10 +288,14 @@ public record CollisionHelper(Entity entity) {
             return false;
         }
 
+        boolean skipAir = targetBlockId != Block.AIR;
         for (int x = minX; x <= maxX; x++) {
             for (int z = minZ; z <= maxZ; z++) {
+                FullChunk chunk = chunkAt(level, entity.chunk, x, z);
                 for (int y = clampedMinY; y <= clampedMaxY; y++) {
-                    Block block = level.getBlock(entity.chunk, x, y, z, 0, false);
+                    if (skipAir && isAirAt(chunk, x, y, z)) continue;
+
+                    Block block = level.getBlock(chunk, x, y, z, 0, false);
                     if (block == null || block.getId() != targetBlockId) continue;
 
                     if (block.collidesWithBB(boundingBox, true)) {
@@ -371,7 +407,7 @@ public record CollisionHelper(Entity entity) {
                 entity,
                 targetFirst,
                 false,
-                block -> block.getId() != Block.AIR
+                NOT_AIR
         );
     }
 
@@ -398,7 +434,7 @@ public record CollisionHelper(Entity entity) {
                 entity,
                 targetFirst,
                 ignoreCollidesCheck,
-                block -> block.getId() != Block.AIR
+                NOT_AIR
         );
     }
 
@@ -444,11 +480,19 @@ public record CollisionHelper(Entity entity) {
             return Collections.emptyList();
         }
 
+        // Only the built-in filter is known to reject air; a caller-supplied predicate may well be
+        // looking for it, so the fast path stays off for anything else.
+        boolean skipAir = condition == NOT_AIR;
+        FullChunk hint = entity != null && entity.getLevel() == level ? entity.chunk : null;
+
         if (targetFirst) {
             for (int z = minZ; z <= maxZ; ++z) {
                 for (int x = minX; x <= maxX; ++x) {
+                    FullChunk chunk = chunkAt(level, hint, x, z);
                     for (int y = clampedMinY; y <= clampedMaxY; ++y) {
-                        Block block = level.getBlock(x, y, z, false);
+                        if (skipAir && isAirAt(chunk, x, y, z)) continue;
+
+                        Block block = level.getBlock(chunk, x, y, z, 0, false);
                         if (block != null && condition.test(block) &&
                                 (ignoreCollidesCheck || block.collidesWithBB(boundingBox))) {
                             return Collections.singletonList(block);
@@ -460,9 +504,11 @@ public record CollisionHelper(Entity entity) {
             List<Block> collides = new ArrayList<>();
             for (int z = minZ; z <= maxZ; ++z) {
                 for (int x = minX; x <= maxX; ++x) {
+                    FullChunk chunk = chunkAt(level, hint, x, z);
                     for (int y = clampedMinY; y <= clampedMaxY; ++y) {
-                        Block block = level.getBlock(entity != null ? entity.chunk : null,
-                                x, y, z, 0, false);
+                        if (skipAir && isAirAt(chunk, x, y, z)) continue;
+
+                        Block block = level.getBlock(chunk, x, y, z, 0, false);
                         if (block != null && condition.test(block) &&
                                 (ignoreCollidesCheck || block.collidesWithBB(boundingBox))) {
                             collides.add(block);
@@ -514,10 +560,15 @@ public record CollisionHelper(Entity entity) {
             return false;
         }
 
+        FullChunk hint = entity != null && entity.getLevel() == level ? entity.chunk : null;
         for (int z = minZ; z <= maxZ; ++z) {
             for (int x = minX; x <= maxX; ++x) {
+                FullChunk chunk = chunkAt(level, hint, x, z);
                 for (int y = clampedMinY; y <= clampedMaxY; ++y) {
-                    Block block = level.getBlock(entity != null ? entity.chunk : null, x, y, z, 0, false);
+                    // Air passes through and owns no bounding box, so it never reached `return true`.
+                    if (isAirAt(chunk, x, y, z)) continue;
+
+                    Block block = level.getBlock(chunk, x, y, z, 0, false);
                     if (block != null &&
                             (!checkCanPassThrough || !block.canPassThrough()) &&
                             block.collidesWithBB(boundingBox)) {
@@ -597,10 +648,15 @@ public record CollisionHelper(Entity entity) {
             return collides;
         }
 
+        FullChunk hint = entity != null && entity.getLevel() == level ? entity.chunk : null;
         for (int z = minZ; z <= maxZ; ++z) {
             for (int x = minX; x <= maxX; ++x) {
+                FullChunk chunk = chunkAt(level, hint, x, z);
                 for (int y = clampedMinY; y <= clampedMaxY; ++y) {
-                    Block block = level.getBlock(x, y, z, false);
+                    // Air is neither a barrier nor solid: it contributed no cube here.
+                    if (isAirAt(chunk, x, y, z)) continue;
+
+                    Block block = level.getBlock(chunk, x, y, z, 0, false);
                     if (block instanceof BlockBarrier && entity.canPassThroughBarrier()) {
                         continue;
                     }

--- a/src/test/java/cn/nukkit/entity/ArmorDamageReductionTest.java
+++ b/src/test/java/cn/nukkit/entity/ArmorDamageReductionTest.java
@@ -100,7 +100,9 @@ public class ArmorDamageReductionTest {
     public void testEntityBaseTickAppliesLavaDamageWhileStandingInLava() {
         Level level = newMockLevel();
         stubLevelAsLava(level);
-        TestLiving target = new TestLiving(newMockChunk(level), baseNbt());
+        FullChunk chunk = newMockChunk(level);
+        stubChunkAsLava(chunk);
+        TestLiving target = new TestLiving(chunk, baseNbt());
 
         assertTrue(target.isInsideOfLava());
         for (int i = 0; i < 10; i++) {
@@ -758,6 +760,13 @@ public class ArmorDamageReductionTest {
                         invocation.getArgument(1, Integer.class),
                         invocation.getArgument(2, Integer.class),
                         invocation.getArgument(3, Integer.class)));
+    }
+
+    /** Keep the raw block IDs consistent with the Level#getBlock lava fixture. */
+    private static void stubChunkAsLava(FullChunk chunk) {
+        lenient().when(chunk.getBlockId(anyInt(), anyInt(), anyInt())).thenReturn(Block.LAVA);
+        lenient().when(chunk.getBlockId(anyInt(), anyInt(), anyInt(), anyInt())).thenAnswer(
+                invocation -> invocation.getArgument(3, Integer.class) == 0 ? Block.LAVA : Block.AIR);
     }
 
     private static Block blockAt(Level level, int id, int x, int y, int z) {

--- a/src/test/java/cn/nukkit/level/AsyncChunkLoadTest.java
+++ b/src/test/java/cn/nukkit/level/AsyncChunkLoadTest.java
@@ -59,7 +59,7 @@ public class AsyncChunkLoadTest {
         setField(level, "pendingChunkLoads", new ConcurrentHashMap<>());
         setField(level, "completedChunkLoads", new ConcurrentLinkedQueue<>());
         setField(level, "unloadQueue", new Long2ObjectNonBlockingMap<>());
-        setField(level, "chunkLoaders", new ConcurrentHashMap<>());
+        setField(level, "chunkLoaders", new Long2ObjectNonBlockingMap<>());
         setField(level, "playerLoaders", new ConcurrentHashMap<>());
         setField(level, "loaders", new Int2ObjectOpenHashMap<>());
         setField(level, "loaderCounter", new Int2IntOpenHashMap());

--- a/src/test/java/cn/nukkit/level/LevelChunkLoaderIndexTest.java
+++ b/src/test/java/cn/nukkit/level/LevelChunkLoaderIndexTest.java
@@ -1,0 +1,99 @@
+package cn.nukkit.level;
+
+import cn.nukkit.utils.collection.nb.Long2ObjectNonBlockingMap;
+import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class LevelChunkLoaderIndexTest {
+    private final Level level = mock(Level.class);
+
+    @BeforeEach
+    void prepareIndex() throws Exception {
+        set("chunkLoaders", new Long2ObjectNonBlockingMap<>());
+        set("playerLoaders", new ConcurrentHashMap<>());
+        set("loaders", new Int2ObjectOpenHashMap<>());
+        set("loaderCounter", new Int2IntOpenHashMap());
+        doCallRealMethod().when(level).registerChunkLoader(any(), anyInt(), anyInt(), anyBoolean());
+        doCallRealMethod().when(level).unregisterChunkLoader(any(), anyInt(), anyInt());
+        doCallRealMethod().when(level).getChunkLoaders(anyInt(), anyInt());
+        doCallRealMethod().when(level).isChunkInUse(anyLong());
+    }
+
+    @Test
+    void diagonalAndZeroChunkKeysKeepIndependentLoadersAndRemoveOnlyTheLastRegistration() {
+        ChunkLoader first = loader(1);
+        ChunkLoader second = loader(2);
+        for (int coordinate : new int[]{-128, -1, 0, 1, 128}) {
+            level.registerChunkLoader(first, coordinate, coordinate, false);
+            level.registerChunkLoader(first, coordinate, coordinate, false);
+            level.registerChunkLoader(second, coordinate, coordinate, false);
+            assertEquals(2, level.getChunkLoaders(coordinate, coordinate).length);
+            assertTrue(level.isChunkInUse(Level.chunkHash(coordinate, coordinate)));
+        }
+
+        level.unregisterChunkLoader(first, 0, 0);
+        assertTrue(level.isChunkInUse(Level.chunkHash(0, 0)));
+        assertArrayEquals(new ChunkLoader[]{second}, level.getChunkLoaders(0, 0));
+        level.unregisterChunkLoader(second, 0, 0);
+        assertFalse(level.isChunkInUse(Level.chunkHash(0, 0)));
+        assertEquals(0, level.getChunkLoaders(0, 0).length);
+        assertTrue(level.isChunkInUse(Level.chunkHash(-1, -1)));
+        assertTrue(level.isChunkInUse(Level.chunkHash(1, 1)));
+    }
+
+    @Test
+    void concurrentReadsKeepFindingStableChunkWhileOtherChunkKeysAreInsertedAndRemoved() throws Exception {
+        ChunkLoader stable = loader(1);
+        ChunkLoader moving = loader(2);
+        long stableHash = Level.chunkHash(-1, -1);
+        level.registerChunkLoader(stable, -1, -1, false);
+        ExecutorService reader = Executors.newSingleThreadExecutor();
+        CountDownLatch started = new CountDownLatch(1);
+        try {
+            Future<?> reads = reader.submit(() -> {
+                started.countDown();
+                for (int i = 0; i < 4096; i++) {
+                    assertTrue(level.isChunkInUse(stableHash));
+                }
+            });
+            assertTrue(started.await(10, TimeUnit.SECONDS));
+            for (int i = 0; i < 256; i++) {
+                level.registerChunkLoader(moving, i, i, false);
+            }
+            for (int i = 0; i < 256; i++) {
+                level.unregisterChunkLoader(moving, i, i);
+                assertFalse(level.isChunkInUse(Level.chunkHash(i, i)));
+            }
+            reads.get(10, TimeUnit.SECONDS);
+            assertTrue(level.isChunkInUse(stableHash));
+        } finally {
+            reader.shutdownNow();
+        }
+    }
+
+    private ChunkLoader loader(int id) {
+        ChunkLoader loader = mock(ChunkLoader.class);
+        when(loader.getLoaderId()).thenReturn(id);
+        return loader;
+    }
+
+    private void set(String name, Object value) throws Exception {
+        Field field = Level.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(level, value);
+    }
+}

--- a/src/test/java/cn/nukkit/level/LevelChunkSaveBackpressureTest.java
+++ b/src/test/java/cn/nukkit/level/LevelChunkSaveBackpressureTest.java
@@ -50,7 +50,7 @@ public class LevelChunkSaveBackpressureTest {
         setField(level, "pendingChunkLoads", new ConcurrentHashMap<>());
         setField(level, "completedChunkLoads", new ConcurrentLinkedQueue<>());
         setField(level, "unloadQueue", new Long2ObjectNonBlockingMap<>());
-        setField(level, "chunkLoaders", new ConcurrentHashMap<>());
+        setField(level, "chunkLoaders", new Long2ObjectNonBlockingMap<>());
         setField(level, "playerLoaders", new ConcurrentHashMap<>());
         setField(level, "loaders", new Int2ObjectOpenHashMap<>());
         setField(level, "loaderCounter", new Int2IntOpenHashMap());

--- a/src/test/java/cn/nukkit/level/format/leveldb/structure/StateBlockStorageNetworkTest.java
+++ b/src/test/java/cn/nukkit/level/format/leveldb/structure/StateBlockStorageNetworkTest.java
@@ -1,0 +1,76 @@
+package cn.nukkit.level.format.leveldb.structure;
+
+import cn.nukkit.GameVersion;
+import cn.nukkit.block.Block;
+import cn.nukkit.level.GlobalBlockPalette;
+import cn.nukkit.level.Level;
+import cn.nukkit.level.format.leveldb.BlockStateMapping;
+import cn.nukkit.level.util.PalettedBlockStorage;
+import cn.nukkit.utils.BinaryStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+class StateBlockStorageNetworkTest {
+    private boolean originalHashedIds;
+
+    @BeforeEach
+    void saveNetworkIdSetting() {
+        originalHashedIds = GlobalBlockPalette.useHashedBlockNetworkIds();
+    }
+
+    @AfterEach
+    void restoreNetworkIdSetting() {
+        GlobalBlockPalette.setUseHashedBlockNetworkIds(originalHashedIds);
+    }
+
+    static Stream<GameVersion> protocols() {
+        return Stream.of(GameVersion.V1_12_0, GameVersion.V1_16_0, GameVersion.V1_16_100,
+                GameVersion.V1_19_80, GameVersion.V1_21_50_NETEASE, GameVersion.getLastVersion());
+    }
+
+    @ParameterizedTest
+    @MethodSource("protocols")
+    void bytesMatchPerBlockLookupWithAndWithoutAntiXrayAndHashedIds(GameVersion protocol) {
+        StateBlockStorage storage = new StateBlockStorage();
+        int[][] blocks = {{Block.AIR, 0}, {Block.STONE, 0}, {Block.PLANKS, 2},
+                {Block.WOOL, 14}, {Block.DIAMOND_ORE, 0}, {Block.LOG, 8}};
+        for (int i = 0; i < 4096; i++) {
+            int[] block = blocks[i % blocks.length];
+            storage.set(i, BlockStateMapping.get().getState(block[0], block[1]));
+        }
+
+        for (boolean hashed : new boolean[]{false, true}) {
+            GlobalBlockPalette.setUseHashedBlockNetworkIds(hashed);
+            for (boolean antiXray : new boolean[]{false, true}) {
+                BinaryStream actual = new BinaryStream();
+                storage.writeTo(protocol, actual, antiXray);
+                assertArrayEquals(serializeUsingPerBlockLookup(storage, protocol, antiXray), actual.getBuffer(),
+                        protocol + ", hashed=" + hashed + ", antiXray=" + antiXray);
+            }
+        }
+    }
+
+    /** The previous wire-format algorithm is an independent reference for both palette paths. */
+    private byte[] serializeUsingPerBlockLookup(StateBlockStorage storage, GameVersion protocol, boolean antiXray) {
+        PalettedBlockStorage output = PalettedBlockStorage.createFromBlockPalette(protocol);
+        for (int i = 0; i < 4096; i++) {
+            int fullId = storage.get(i);
+            int id = fullId >> Block.DATA_BITS;
+            int meta = fullId & Block.DATA_MASK;
+            if (antiXray && id < Block.MAX_BLOCK_ID && Level.xrayableBlocks[id]) {
+                id = Block.STONE;
+                meta = 0;
+            }
+            output.setBlock(i, GlobalBlockPalette.getOrCreateRuntimeId(protocol, id, meta));
+        }
+        BinaryStream expected = new BinaryStream();
+        output.writeTo(expected);
+        return expected.getBuffer();
+    }
+}

--- a/src/test/java/cn/nukkit/utils/CollisionHelperAirTest.java
+++ b/src/test/java/cn/nukkit/utils/CollisionHelperAirTest.java
@@ -1,0 +1,148 @@
+package cn.nukkit.utils;
+
+import cn.nukkit.block.Block;
+import cn.nukkit.entity.Entity;
+import cn.nukkit.level.Level;
+import cn.nukkit.level.format.FullChunk;
+import cn.nukkit.level.format.generic.BaseFullChunk;
+import cn.nukkit.math.AxisAlignedBB;
+import cn.nukkit.math.SimpleAxisAlignedBB;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class CollisionHelperAirTest {
+    private final Level level = mock(Level.class);
+    private final Entity entity = mock(Entity.class);
+    private final Map<Long, FullChunk> chunks = new HashMap<>();
+    private final AxisAlignedBB bounds = new SimpleAxisAlignedBB(-0.5, 64, 0.1, 0.5, 65, 0.9);
+
+    @BeforeEach
+    void prepareWorld() {
+        when(level.getMinBlockY()).thenReturn(-64);
+        when(level.getMaxBlockY()).thenReturn(319);
+        when(level.isYInRange(anyInt())).thenAnswer(invocation -> {
+            int y = invocation.getArgument(0);
+            return y >= -64 && y <= 319;
+        });
+        when(level.getChunkIfLoaded(anyInt(), anyInt())).thenAnswer(invocation ->
+                chunks.get(Level.chunkHash(invocation.getArgument(0), invocation.getArgument(1))));
+        doCallRealMethod().when(level).getBlock(nullable(FullChunk.class), anyInt(), anyInt(), anyInt(), anyInt(), anyBoolean());
+        doCallRealMethod().when(level).getBlock(anyInt(), anyInt(), anyInt(), anyBoolean());
+        when(entity.getLevel()).thenReturn(level);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void customPredicateCanFindAirInLoadedAndUnloadedChunks(boolean targetFirst) {
+        addChunk(0, 0, Block.AIR);
+
+        List<Block> result = CollisionHelper.getCollisionBlocks(level, bounds, entity, targetFirst, true,
+                block -> block.getId() == Block.AIR);
+
+        assertEquals(targetFirst ? 1 : 4, result.size());
+        assertTrue(result.stream().allMatch(Block::isAir));
+        // Traversal starts in the unloaded negative-X chunk, which also represents air.
+        assertEquals(-1, result.get(0).getFloorX());
+        verify(level, never()).getChunk(anyInt(), anyInt());
+    }
+
+    @Test
+    void defaultQueriesSkipAirWithoutMaterializingBlocksOrLoadingMissingChunks() {
+        addChunk(0, 0, Block.AIR);
+
+        assertTrue(CollisionHelper.getCollisionBlocks(level, bounds, entity, false, true).isEmpty());
+        assertFalse(CollisionHelper.hasCollisionBlocks(level, entity, bounds, true));
+        assertTrue(CollisionHelper.getCollisionCubes(level, entity, bounds, false, false).isEmpty());
+        CollisionHelper helper = new CollisionHelper(entity);
+        assertEquals(0, helper.getBlocksInBoundingBox(bounds).length);
+        assertFalse(helper.isInsideBlock(bounds, Block.LAVA));
+
+        verify(level, never()).getBlock(nullable(FullChunk.class), anyInt(), anyInt(), anyInt(), anyInt(), anyBoolean());
+        verify(level, never()).getChunk(anyInt(), anyInt());
+    }
+
+    @Test
+    void explicitAirInsideQueryStillMaterializesAirAndChecksItsCollisionBox() {
+        addChunk(0, 0, Block.AIR);
+
+        assertFalse(new CollisionHelper(entity).isInsideBlock(bounds, Block.AIR));
+
+        verify(level, atLeastOnce()).getBlock(nullable(FullChunk.class), anyInt(), anyInt(), anyInt(), eq(0), eq(false));
+    }
+
+    @Test
+    void solidBlocksAcrossChunkBoundaryKeepCoordinatesAndCollisionsWithWrongChunkHint() {
+        addChunk(-1, 0, Block.STONE);
+        addChunk(0, 0, Block.STONE);
+        entity.chunk = addChunk(5, 5, Block.AIR);
+
+        List<Block> result = CollisionHelper.getCollisionBlocks(level, bounds, entity, false, false);
+
+        assertEquals(2, result.size());
+        assertEquals(List.of(-1, 0), result.stream().map(Block::getFloorX).toList());
+        assertTrue(result.stream().allMatch(block -> block.getId() == Block.STONE && block.getFloorY() == 64));
+        assertTrue(CollisionHelper.hasCollisionBlocks(level, entity, bounds, true));
+        assertEquals(2, CollisionHelper.getCollisionCubes(level, entity, bounds, false, false).size());
+        assertTrue(new CollisionHelper(entity).isInsideBlock(bounds, Block.STONE));
+        assertEquals(4, new CollisionHelper(entity).getBlocksInBoundingBox(bounds).length);
+    }
+
+    @Test
+    void matchingEntityChunkHintWorksWithoutAnotherLoadedChunkLookup() {
+        entity.chunk = addChunk(0, 0, Block.STONE);
+        chunks.clear(); // The hint is still a valid chunk, even without a lookup entry.
+        AxisAlignedBB localBounds = new SimpleAxisAlignedBB(0.1, -63.9, 0.1, 0.9, -63.1, 0.9);
+
+        assertEquals(1, CollisionHelper.getCollisionBlocks(level, localBounds, entity, true, false).size());
+
+        verify(level, never()).getChunkIfLoaded(anyInt(), anyInt());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void destinationQueriesIgnoreAnEntityChunkFromAnotherWorldAtTheSameCoordinates(boolean destinationIsSolid) {
+        int destinationId = destinationIsSolid ? Block.STONE : Block.AIR;
+        int sourceId = destinationIsSolid ? Block.AIR : Block.STONE;
+        addChunk(0, 0, destinationId);
+        Level sourceLevel = mock(Level.class);
+        FullChunk sourceChunk = mock(BaseFullChunk.class);
+        when(sourceChunk.getBlockId(anyInt(), anyInt(), anyInt(), eq(0))).thenReturn(sourceId);
+        when(sourceChunk.getBlockState(anyInt(), anyInt(), anyInt(), eq(0))).thenReturn(new int[]{sourceId, 0});
+        when(entity.getLevel()).thenReturn(sourceLevel);
+        entity.chunk = sourceChunk;
+        AxisAlignedBB destinationBounds = new SimpleAxisAlignedBB(0.1, 64.1, 0.1, 0.9, 64.9, 0.9);
+        int expectedCollisions = destinationIsSolid ? 1 : 0;
+
+        assertAll(
+                () -> assertEquals(expectedCollisions,
+                        CollisionHelper.getCollisionBlocks(level, destinationBounds, entity, true, false).size()),
+                () -> assertEquals(expectedCollisions,
+                        CollisionHelper.getCollisionBlocks(level, destinationBounds, entity, false, false).size()),
+                () -> assertEquals(expectedCollisions,
+                        CollisionHelper.getCollisionCubes(level, entity, destinationBounds, false, false).size()),
+                () -> assertEquals(destinationIsSolid,
+                        CollisionHelper.hasCollisionBlocks(level, entity, destinationBounds, true)));
+        verify(sourceChunk, never()).getBlockId(anyInt(), anyInt(), anyInt(), anyInt());
+        verify(sourceChunk, never()).getBlockState(anyInt(), anyInt(), anyInt(), anyInt());
+    }
+
+    private FullChunk addChunk(int chunkX, int chunkZ, int id) {
+        FullChunk chunk = mock(BaseFullChunk.class);
+        when(chunk.getX()).thenReturn(chunkX);
+        when(chunk.getZ()).thenReturn(chunkZ);
+        when(chunk.getBlockId(anyInt(), anyInt(), anyInt(), eq(0))).thenReturn(id);
+        when(chunk.getBlockState(anyInt(), anyInt(), anyInt(), eq(0))).thenReturn(new int[]{id, 0});
+        chunks.put(Level.chunkHash(chunkX, chunkZ), chunk);
+        return chunk;
+    }
+}

--- a/src/test/java/cn/nukkit/utils/CollisionHelperRunawayTest.java
+++ b/src/test/java/cn/nukkit/utils/CollisionHelperRunawayTest.java
@@ -5,6 +5,7 @@ import cn.nukkit.Server;
 import cn.nukkit.block.Block;
 import cn.nukkit.entity.Entity;
 import cn.nukkit.level.Level;
+import cn.nukkit.level.format.FullChunk;
 import cn.nukkit.math.AxisAlignedBB;
 import cn.nukkit.math.SimpleAxisAlignedBB;
 import org.junit.jupiter.api.BeforeEach;
@@ -183,6 +184,10 @@ public class CollisionHelperRunawayTest {
         AxisAlignedBB bb = new SimpleAxisAlignedBB(0.3, 0, 0.3, 0.7, 1.8, 0.7);
         Level level = Mockito.mock(Level.class);
         Entity entity = Mockito.mock(Entity.class);
+        FullChunk chunk = Mockito.mock(FullChunk.class);
+        entity.chunk = chunk;
+        Mockito.when(chunk.getBlockId(Mockito.anyInt(), Mockito.anyInt(), Mockito.anyInt(), Mockito.eq(0)))
+                .thenReturn(Block.LAVA);
         Block lava = Block.get(Block.LAVA);
         lava.setLevel(level);
         lava.setComponents(0, 0, 0);


### PR DESCRIPTION
Collision scans currently materialize `BlockAir` objects for empty cells, LevelDB section serialization resolves the same protocol palette for each of 4,096 blocks, and the chunk-loader index boxes coordinate hashes as `Long` keys. This changes those three paths to avoid repeated work:

- Read the raw chunk block ID before constructing blocks for collision checks. Custom predicates still receive air, explicit air searches still check their collision boxes, and missing chunks retain their existing air behavior without loading them.
- Resolve the LevelDB section palette and hashed-ID choice once per section. Protocols before 1.16.100 retain the legacy lookup path, including anti-xray handling.
- Use the existing `Long2ObjectNonBlockingMap` for the outer chunk-loader index, avoiding boxed keys and the `x ^ z` collision pattern of `Long.hashCode()` on diagonal chunk coordinates.

Validation: 108 focused tests pass on Java 17, covering custom air predicates, unloaded chunks, chunk hints and boundaries (including destination queries with an entity still in another world), existing lava/collision checks, loader registration/removal and concurrent reads, async loading and save backpressure. Byte-for-byte serialization comparisons use the previous per-block algorithm across six legacy/modern/NetEase protocol selections with anti-xray and hashed IDs each on and off. This PR makes no throughput or latency benchmark claim.

```text
mvn -q -Dtest=CollisionHelperAirTest,CollisionHelperRunawayTest,StateBlockStorageNetworkTest,BlockStorageTest,ArmorDamageReductionTest,AsyncChunkLoadTest,LevelChunkSaveBackpressureTest,LevelChunkLoaderIndexTest test
```
