### PR TITLE
fix(skin): NetEase V860 mall 3D/4D skins invisible or stuck as default Steve on other clients (fullSkinId routing + player-list entry rebuild timing)

### DIFF
--- a/src/main/java/cn/nukkit/entity/data/Skin.java
+++ b/src/main/java/cn/nukkit/entity/data/Skin.java
@@ -58,10 +58,6 @@ public class Skin {
 
     private boolean noPlayFab; // Don't attempt to generate missing play fab id multiple times
     private String fullSkinId;
-    // FAPIXEL fap4：fullSkinId 是否为"显式设置的稳定键"（客户端登录/换肤包提供，或服务端
-    // 插件主动 setFullSkinId）。稳定键下发时保持原样；未设置的（RsNPC 等共享 Skin 实例的
-    // 服务端皮肤）由 BinaryStream#putSkin 每次发包随机化，跳过网易客户端档案匹配。
-    private boolean fullSkinIdStable;
     private String skinId;
     private String playFabId = "";
     private String skinResourcePatch = GEOMETRY_CUSTOM;
@@ -399,15 +395,7 @@ public class Skin {
 
     public void setFullSkinId(String fullSkinId) {
         this.fullSkinId = fullSkinId;
-        this.fullSkinIdStable = fullSkinId != null;
         this.noPlayFab = false; // Allow another attempt to generate it using the new id
-    }
-
-    /**
-     * FAPIXEL fap4：fullSkinId 是否为显式设置的稳定键（见字段注释）。
-     */
-    public boolean isFullSkinIdStable() {
-        return this.fullSkinIdStable && this.fullSkinId != null;
     }
 
     public String getFullSkinId() {

--- a/src/main/java/cn/nukkit/entity/data/Skin.java
+++ b/src/main/java/cn/nukkit/entity/data/Skin.java
@@ -377,22 +377,6 @@ public class Skin {
         this.armSize = armSize;
     }
 
-    /**
-     * FAPIXEL fap5：是否为网易客户端自带默认皮肤（skinId 形如 "{uuid}.Steve" / "{uuid}.Alex"，
-     * 或核心回退 Standard_Custom）。此类皮肤在 V860 下走验证必被拒（实测），其
-     * fullSkinId 必须随机化下发（跳过档案匹配、直接渲染包内字节），稳定下发会导致玩家
-     * 自视隐形（09-07 fap4 实测：史蒂夫玩家全程看不到自己，暂停才偶发恢复）。
-     */
-    public static boolean isNetEaseBuiltinDefaultSkinId(String skinId) {
-        if (skinId == null || skinId.isEmpty()) {
-            return false;
-        }
-        String lower = skinId.toLowerCase(java.util.Locale.ROOT);
-        return lower.endsWith(".steve")
-                || lower.endsWith(".alex")
-                || "standard_custom".equals(lower);
-    }
-
     public void setFullSkinId(String fullSkinId) {
         this.fullSkinId = fullSkinId;
         this.noPlayFab = false; // Allow another attempt to generate it using the new id

--- a/src/main/java/cn/nukkit/entity/data/Skin.java
+++ b/src/main/java/cn/nukkit/entity/data/Skin.java
@@ -58,6 +58,10 @@ public class Skin {
 
     private boolean noPlayFab; // Don't attempt to generate missing play fab id multiple times
     private String fullSkinId;
+    // FAPIXEL fap4：fullSkinId 是否为"显式设置的稳定键"（客户端登录/换肤包提供，或服务端
+    // 插件主动 setFullSkinId）。稳定键下发时保持原样；未设置的（RsNPC 等共享 Skin 实例的
+    // 服务端皮肤）由 BinaryStream#putSkin 每次发包随机化，跳过网易客户端档案匹配。
+    private boolean fullSkinIdStable;
     private String skinId;
     private String playFabId = "";
     private String skinResourcePatch = GEOMETRY_CUSTOM;
@@ -377,9 +381,33 @@ public class Skin {
         this.armSize = armSize;
     }
 
+    /**
+     * FAPIXEL fap5：是否为网易客户端自带默认皮肤（skinId 形如 "{uuid}.Steve" / "{uuid}.Alex"，
+     * 或核心回退 Standard_Custom）。此类皮肤在 V860 下走验证必被拒（实测），其
+     * fullSkinId 必须随机化下发（跳过档案匹配、直接渲染包内字节），稳定下发会导致玩家
+     * 自视隐形（09-07 fap4 实测：史蒂夫玩家全程看不到自己，暂停才偶发恢复）。
+     */
+    public static boolean isNetEaseBuiltinDefaultSkinId(String skinId) {
+        if (skinId == null || skinId.isEmpty()) {
+            return false;
+        }
+        String lower = skinId.toLowerCase(java.util.Locale.ROOT);
+        return lower.endsWith(".steve")
+                || lower.endsWith(".alex")
+                || "standard_custom".equals(lower);
+    }
+
     public void setFullSkinId(String fullSkinId) {
         this.fullSkinId = fullSkinId;
+        this.fullSkinIdStable = fullSkinId != null;
         this.noPlayFab = false; // Allow another attempt to generate it using the new id
+    }
+
+    /**
+     * FAPIXEL fap4：fullSkinId 是否为显式设置的稳定键（见字段注释）。
+     */
+    public boolean isFullSkinIdStable() {
+        return this.fullSkinIdStable && this.fullSkinId != null;
     }
 
     public String getFullSkinId() {

--- a/src/main/java/cn/nukkit/network/protocol/PlayerEntitySkinSender.java
+++ b/src/main/java/cn/nukkit/network/protocol/PlayerEntitySkinSender.java
@@ -105,14 +105,8 @@ public final class PlayerEntitySkinSender {
         Objects.requireNonNull(entry, "entry");
         Objects.requireNonNull(entry.uuid, "entry.uuid");
 
-        // FAPIXEL fap6：无条件 REMOVE → ADD。fap5 曾按服务端台账跳过 REMOVE 只发裸 ADD，
-        // 但 V860 对客户端已持有的条目会忽略重复 ADD（观察者不重渲染），对本人条目更会
-        // 直接破坏自视渲染（实测：persona 条目重建后主体自视隐形，暂停也无法恢复）。
-        // REMOVE 对客户端不存在的条目是无害空操作，REMOVE → ADD 是唯一安全序列。
-        // <p>fap6: always REMOVE then ADD. fap5 skipped the REMOVE when the server-side
-        // registration was gone, but V860 ignores a bare duplicate ADD (no re-render) and a
-        // bare ADD of the viewer's own entry breaks self-rendering. REMOVE on a missing
-        // client entry is a harmless no-op, so the pair is the only safe sequence.
+        // 无条件 REMOVE → ADD：V860 会忽略对客户端已持有条目的裸 ADD（不重渲染），
+        // 对本人条目更会破坏自视渲染；REMOVE 对客户端不存在的条目是无害空操作。
         if (!requiresRetainedEntry(viewer)) {
             return false;
         }
@@ -131,10 +125,7 @@ public final class PlayerEntitySkinSender {
             return false;
         }
         viewer.sentSkins.add(entry.uuid);
-        // 重建即取代握手：作废仍在排期的原始皮肤补发与延迟 REMOVE，防止它们在重建
-        // 之后落地把新条目打回占位/原始皮肤（09-07 房间竞态）。
-        // <p>The rebuild supersedes the handshake: invalidate any still-scheduled raw
-        // resend or delayed REMOVE so they cannot land after it and clobber the entry.
+        // 作废仍在排期的补发与延迟 REMOVE，防止它们晚于重建落地、把新条目顶回旧皮肤。
         currentGeneration(viewer, entry.uuid).incrementAndGet();
         return true;
     }
@@ -187,8 +178,7 @@ public final class PlayerEntitySkinSender {
         if (fingerprint.equals(previous)) {
             return false;
         }
-        // FAPIXEL fap5：条目缺失（初始握手 5t 后被延迟 REMOVE 注销）时也走重建分支——
-        // 否则晚到的确认包（巡检、后进同步、重驱动）会静默失败，观察者永久史蒂夫。
+        // 条目已被延迟 REMOVE 注销时也走重建，否则晚到的确认会静默失败、观察者永久史蒂夫。
         if (previous != null || !viewer.sentSkins.contains(subject)) {
             Player target = Server.getInstance().getPlayer(subject).orElse(null);
             if (target == null) {
@@ -228,22 +218,18 @@ public final class PlayerEntitySkinSender {
     }
 
     /**
-     * 客户端此刻能否应用确认包：必须已有 PlayerList 条目，且该玩家实体已生成到观察者。
-     * 缺任一项客户端都会静默丢弃该条目，而我们已记下指纹便再不重发，因此必须提前拦下。
-     * 条目不存在时顺带清掉残留指纹，避免条目重建后首次确认被误抑制。
+     * 客户端此刻能否应用确认包：该玩家实体须已生成到观察者，否则客户端会静默丢弃该条目，
+     * 而我们已记下指纹便再不重发。不要求 PlayerList 条目仍在——初始握手
+     * {@link #DELAYED_REMOVE_TICKS} 后条目必被注销，条目缺失由 {@link #prepareConfirmSkin}
+     * 的重建分支补 ADD。
      * <p>
-     * Whether the client can apply a confirmation right now: it needs both the PlayerList entry and
-     * the player entity spawned to this viewer. Missing either makes the client drop the entry
-     * silently while we would have recorded the fingerprint and never resent it. A missing entry
-     * also clears any stale fingerprint so the first confirmation after a rebuild isn't suppressed.
+     * Whether the client can apply a confirmation right now: the player entity must have
+     * spawned to this viewer, or the client drops it silently while we would have recorded
+     * the fingerprint and never resent it. A live PlayerList entry is not required — the
+     * delayed REMOVE unregisters it, and the rebuild branch in {@link #prepareConfirmSkin}
+     * re-adds it.
      */
     private static boolean isConfirmable(Player viewer, UUID subject) {
-        // FAPIXEL fap5：不再要求 PlayerList 条目仍在（sentSkins）——初始握手
-        // DELAYED_REMOVE_TICKS(5t) 后条目必被移除并注销，原要求使 40t 巡检对晚到的
-        // 确认包永远静默失败（观察者永久史蒂夫，实测：广播 targets=0
-        // 之后 30 秒无一轮补发成功）。现仅保留实体已生成要求；条目缺失时由
-        // prepareConfirmSkin 的重建分支补 ADD 后再确认。原"条目不存在顺带清残留指纹"
-        // 由指纹比对与重建分支自然覆盖，不再需要。
         Player target = Server.getInstance().getPlayer(subject).orElse(null);
         return target != null && target.hasSpawned.containsKey(viewer.getLoaderId());
     }
@@ -312,13 +298,8 @@ public final class PlayerEntitySkinSender {
             if (viewer.closed) {
                 return;
             }
-            // 代次已变说明 re-spawn 或条目重建（fap6）已接管该条目：不动任何台账、不发
-            // REMOVE。原实现先 unregister 再恢复 sentSkins，会把接管方刚写入的确认指纹
-            // 一并抹掉，诱发巡检反复重建闪烁。
-            // <p>A changed generation means a re-spawn or a rebuild (fap6) has taken over
-            // the entry: touch nothing and send no REMOVE. The old code unregistered first
-            // and restored sentSkins, wiping the successor's fresh confirmation fingerprint
-            // and provoking repeated sweep rebuilds.
+            // 代次已变说明 re-spawn 或条目重建已接管：不动台账也不发 REMOVE——
+            // unregister 会把接管方刚写入的确认指纹一并抹掉，诱发巡检反复重建。
             if (generation.get() != registeredAt) {
                 return;
             }

--- a/src/main/java/cn/nukkit/network/protocol/PlayerEntitySkinSender.java
+++ b/src/main/java/cn/nukkit/network/protocol/PlayerEntitySkinSender.java
@@ -105,10 +105,17 @@ public final class PlayerEntitySkinSender {
         Objects.requireNonNull(entry, "entry");
         Objects.requireNonNull(entry.uuid, "entry.uuid");
 
-        if (!requiresRetainedEntry(viewer) || !viewer.sentSkins.contains(entry.uuid)) {
+        // FAPIXEL fap6：无条件 REMOVE → ADD。fap5 曾按服务端台账跳过 REMOVE 只发裸 ADD，
+        // 但 V860 对客户端已持有的条目会忽略重复 ADD（观察者不重渲染），对本人条目更会
+        // 直接破坏自视渲染（实测：persona 条目重建后主体自视隐形，暂停也无法恢复）。
+        // REMOVE 对客户端不存在的条目是无害空操作，REMOVE → ADD 是唯一安全序列。
+        // <p>fap6: always REMOVE then ADD. fap5 skipped the REMOVE when the server-side
+        // registration was gone, but V860 ignores a bare duplicate ADD (no re-render) and a
+        // bare ADD of the viewer's own entry breaks self-rendering. REMOVE on a missing
+        // client entry is a harmless no-op, so the pair is the only safe sequence.
+        if (!requiresRetainedEntry(viewer)) {
             return false;
         }
-
         PlayerListPacket remove = new PlayerListPacket();
         remove.type = PlayerListPacket.TYPE_REMOVE;
         remove.entries = new PlayerListPacket.Entry[]{new PlayerListPacket.Entry(entry.uuid)};
@@ -124,6 +131,11 @@ public final class PlayerEntitySkinSender {
             return false;
         }
         viewer.sentSkins.add(entry.uuid);
+        // 重建即取代握手：作废仍在排期的原始皮肤补发与延迟 REMOVE，防止它们在重建
+        // 之后落地把新条目打回占位/原始皮肤（09-07 房间竞态）。
+        // <p>The rebuild supersedes the handshake: invalidate any still-scheduled raw
+        // resend or delayed REMOVE so they cannot land after it and clobber the entry.
+        currentGeneration(viewer, entry.uuid).incrementAndGet();
         return true;
     }
 
@@ -175,7 +187,9 @@ public final class PlayerEntitySkinSender {
         if (fingerprint.equals(previous)) {
             return false;
         }
-        if (previous != null) {
+        // FAPIXEL fap5：条目缺失（初始握手 5t 后被延迟 REMOVE 注销）时也走重建分支——
+        // 否则晚到的确认包（巡检、后进同步、重驱动）会静默失败，观察者永久史蒂夫。
+        if (previous != null || !viewer.sentSkins.contains(subject)) {
             Player target = Server.getInstance().getPlayer(subject).orElse(null);
             if (target == null) {
                 return false;
@@ -224,10 +238,12 @@ public final class PlayerEntitySkinSender {
      * also clears any stale fingerprint so the first confirmation after a rebuild isn't suppressed.
      */
     private static boolean isConfirmable(Player viewer, UUID subject) {
-        if (!viewer.sentSkins.contains(subject)) {
-            viewer.confirmedSkins.remove(subject);
-            return false;
-        }
+        // FAPIXEL fap5：不再要求 PlayerList 条目仍在（sentSkins）——初始握手
+        // DELAYED_REMOVE_TICKS(5t) 后条目必被移除并注销，原要求使 40t 巡检对晚到的
+        // 确认包永远静默失败（观察者永久史蒂夫，实测：广播 targets=0
+        // 之后 30 秒无一轮补发成功）。现仅保留实体已生成要求；条目缺失时由
+        // prepareConfirmSkin 的重建分支补 ADD 后再确认。原"条目不存在顺带清残留指纹"
+        // 由指纹比对与重建分支自然覆盖，不再需要。
         Player target = Server.getInstance().getPlayer(subject).orElse(null);
         return target != null && target.hasSpawned.containsKey(viewer.getLoaderId());
     }
@@ -296,13 +312,18 @@ public final class PlayerEntitySkinSender {
             if (viewer.closed) {
                 return;
             }
-            // 互斥：despawn/close 已先清则跳过。
-            if (!unregister(viewer, uuid)) {
+            // 代次已变说明 re-spawn 或条目重建（fap6）已接管该条目：不动任何台账、不发
+            // REMOVE。原实现先 unregister 再恢复 sentSkins，会把接管方刚写入的确认指纹
+            // 一并抹掉，诱发巡检反复重建闪烁。
+            // <p>A changed generation means a re-spawn or a rebuild (fap6) has taken over
+            // the entry: touch nothing and send no REMOVE. The old code unregistered first
+            // and restored sentSkins, wiping the successor's fresh confirmation fingerprint
+            // and provoking repeated sweep rebuilds.
+            if (generation.get() != registeredAt) {
                 return;
             }
-            // 代次已变说明 re-spawn 注册了新条目，恢复 sentSkins 不发 REMOVE。
-            if (generation.get() != registeredAt) {
-                viewer.sentSkins.add(uuid);
+            // 互斥：despawn/close 已先清则跳过。
+            if (!unregister(viewer, uuid)) {
                 return;
             }
             sendRemove(viewer, uuid);

--- a/src/main/java/cn/nukkit/network/protocol/netease/SyncSkinPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/netease/SyncSkinPacket.java
@@ -13,6 +13,22 @@ import lombok.ToString;
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * FAPIXEL fap2 core patch：修正线格式。
+ * <p>
+ * 旧实现（第 1 轮 bool+uuid+string，之后 4 轮 string）与网易客户端实际布局不符。
+ * 依据对网易 V860 客户端实际线格式的比对分析：
+ * <pre>
+ *   count(varuint)
+ *   轮 1: valid(bool) + uuid + skinBytes(byteArray)     ← 第三字段是字节数组
+ *   轮 2: udid(string)
+ *   轮 3: extraData(string)
+ *   轮 4: itemId(string)                                 ← 商城商品引用
+ *   尾部 SerializedSkin
+ * </pre>
+ * 旧 string1..string4 映射：string1=udid、string2=extraData、string3=itemId、
+ * string4 保留字段不再上线。错误的布局会让客户端解析失败，皮肤回退史蒂夫。
+ */
 @OnlyNetEase
 @ToString
 public class SyncSkinPacket extends DataPacket {
@@ -23,7 +39,7 @@ public class SyncSkinPacket extends DataPacket {
 
     /**
      * 尾部 SerializedSkin，始终存在（即使 entries 为空）。
-     * <p>Trailing SerializedSkin, always present even when entries is empty.
+     * <p>Trailing SerializedSkin, always present even when entries are empty.
      */
     public Skin skin = new Skin();
 
@@ -64,24 +80,24 @@ public class SyncSkinPacket extends DataPacket {
         for (int i = 0; i < count; i++) {
             this.entries.add(new SyncSkinEntry());
         }
-        // GROUP 1: flag + uuid + string1
+        // 轮 1: flag + uuid + skinBytes（字节数组，不是字符串）
         for (int i = 0; i < count; i++) {
             SyncSkinEntry entry = this.entries.get(i);
             entry.flag = this.getBoolean();
             entry.uuid = this.getUUID();
-            entry.string1 = this.getString();
+            entry.skinBytes = this.getByteArray();
         }
-        // GROUP 2: string2
+        // 轮 2: udid
+        for (int i = 0; i < count; i++) {
+            this.entries.get(i).string1 = this.getString();
+        }
+        // 轮 3: extraData
         for (int i = 0; i < count; i++) {
             this.entries.get(i).string2 = this.getString();
         }
-        // GROUP 3: string3 (at least one string is item_id)
+        // 轮 4: itemId（商城商品引用）
         for (int i = 0; i < count; i++) {
             this.entries.get(i).string3 = this.getString();
-        }
-        // GROUP 4: string4
-        for (int i = 0; i < count; i++) {
-            this.entries.get(i).string4 = this.getString();
         }
         // 尾部 SerializedSkin
         this.skin = this.getSkin(this.protocol);
@@ -92,23 +108,23 @@ public class SyncSkinPacket extends DataPacket {
         this.reset();
         int count = this.entries.size();
         this.putUnsignedVarInt(count);
-        // GROUP 1: flag + uuid + string1
+        // 轮 1: flag + uuid + skinBytes（字节数组，不是字符串）
         for (SyncSkinEntry entry : this.entries) {
             this.putBoolean(entry.flag);
             this.putUUID(entry.uuid);
+            this.putByteArray(entry.skinBytes != null ? entry.skinBytes : new byte[0]);
+        }
+        // 轮 2: udid
+        for (SyncSkinEntry entry : this.entries) {
             this.putString(entry.string1 != null ? entry.string1 : "");
         }
-        // GROUP 2: string2
+        // 轮 3: extraData
         for (SyncSkinEntry entry : this.entries) {
             this.putString(entry.string2 != null ? entry.string2 : "");
         }
-        // GROUP 3: string3
+        // 轮 4: itemId（商城商品引用）
         for (SyncSkinEntry entry : this.entries) {
             this.putString(entry.string3 != null ? entry.string3 : "");
-        }
-        // GROUP 4: string4
-        for (SyncSkinEntry entry : this.entries) {
-            this.putString(entry.string4 != null ? entry.string4 : "");
         }
         // 尾部 SerializedSkin
         this.putSkin(this.gameVersion, this.skin);
@@ -120,9 +136,15 @@ public class SyncSkinPacket extends DataPacket {
     public static class SyncSkinEntry {
         public boolean flag;
         public UUID uuid;
+        /** 轮 1 的第三字段：皮肤纹理字节（fap2 前被错误地序列化为字符串）。 */
+        public byte[] skinBytes = new byte[0];
+        /** 轮 2 udid。 */
         public String string1 = "";
+        /** 轮 3 extraData。 */
         public String string2 = "";
+        /** 轮 4 itemId（商城商品引用）。 */
         public String string3 = "";
+        /** 旧格式遗留的第 4 个字符串槽位，fap2 起不再上线。 */
         public String string4 = "";
     }
 }

--- a/src/main/java/cn/nukkit/network/protocol/netease/SyncSkinPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/netease/SyncSkinPacket.java
@@ -14,20 +14,12 @@ import java.util.List;
 import java.util.UUID;
 
 /**
- * FAPIXEL fap2 core patch：修正线格式。
+ * 网易 V860 皮肤同步包。条目按轮交错序列化（非逐条），轮 1 的第三字段是皮肤纹理
+ * 字节数组而非字符串；布局写错会让客户端解析失败、皮肤回退史蒂夫。
  * <p>
- * 旧实现（第 1 轮 bool+uuid+string，之后 4 轮 string）与网易客户端实际布局不符。
- * 依据对网易 V860 客户端实际线格式的比对分析：
- * <pre>
- *   count(varuint)
- *   轮 1: valid(bool) + uuid + skinBytes(byteArray)     ← 第三字段是字节数组
- *   轮 2: udid(string)
- *   轮 3: extraData(string)
- *   轮 4: itemId(string)                                 ← 商城商品引用
- *   尾部 SerializedSkin
- * </pre>
- * 旧 string1..string4 映射：string1=udid、string2=extraData、string3=itemId、
- * string4 保留字段不再上线。错误的布局会让客户端解析失败，皮肤回退史蒂夫。
+ * NetEase V860 skin sync packet. Entries are serialized in interleaved rounds (not
+ * per-entry), and round 1's third field is a skin-texture byte array, not a string;
+ * a wrong layout makes the client fail to parse and fall back to Steve.
  */
 @OnlyNetEase
 @ToString
@@ -136,7 +128,7 @@ public class SyncSkinPacket extends DataPacket {
     public static class SyncSkinEntry {
         public boolean flag;
         public UUID uuid;
-        /** 轮 1 的第三字段：皮肤纹理字节（fap2 前被错误地序列化为字符串）。 */
+        /** 轮 1 的第三字段：皮肤纹理字节。 */
         public byte[] skinBytes = new byte[0];
         /** 轮 2 udid。 */
         public String string1 = "";
@@ -144,7 +136,7 @@ public class SyncSkinPacket extends DataPacket {
         public String string2 = "";
         /** 轮 4 itemId（商城商品引用）。 */
         public String string3 = "";
-        /** 旧格式遗留的第 4 个字符串槽位，fap2 起不再上线。 */
+        /** 旧格式遗留槽位，已不再上线。 */
         public String string4 = "";
     }
 }

--- a/src/main/java/cn/nukkit/utils/BinaryStream.java
+++ b/src/main/java/cn/nukkit/utils/BinaryStream.java
@@ -407,10 +407,11 @@ public class BinaryStream {
                 this.putBoolean(skin.isCapeOnClassic());
             }
             this.putString(skin.getCapeId());
-            String fullSkinId = gameVersion == GameVersion.V1_21_124_NETEASE
-                    ? skin.getFullSkinId() + UUID.randomUUID().toString().substring(0, 8)
-                    : skin.getFullSkinId();
-            this.putString(fullSkinId);
+            // FAPIXEL patch：不再对 V860 强制随机化 fullSkinId。真玩家的 fullSkinId 是网易
+            // 客户端匹配商城/4D 皮肤档案的键，追加随机后缀会让观察者客户端永远匹配失败，
+            // 实体回退占位史蒂夫（实测：资源中心 3D/4D 皮肤在他端始终显示史蒂夫）。
+            // NPC/假人皮肤的唯一性由 Skin#getFullSkinId() 的随机后缀分支保证，不受影响。
+            this.putString(skin.getFullSkinId());
             if (protocol >= ProtocolInfo.v1_14_60) {
                 boolean v2168 = protocol >= ProtocolInfo.v1_26_40;
                 if (v2168) {

--- a/src/main/java/cn/nukkit/utils/BinaryStream.java
+++ b/src/main/java/cn/nukkit/utils/BinaryStream.java
@@ -407,11 +407,23 @@ public class BinaryStream {
                 this.putBoolean(skin.isCapeOnClassic());
             }
             this.putString(skin.getCapeId());
-            // FAPIXEL patch：不再对 V860 强制随机化 fullSkinId。真玩家的 fullSkinId 是网易
-            // 客户端匹配商城/4D 皮肤档案的键，追加随机后缀会让观察者客户端永远匹配失败，
-            // 实体回退占位史蒂夫（实测：资源中心 3D/4D 皮肤在他端始终显示史蒂夫）。
-            // NPC/假人皮肤的唯一性由 Skin#getFullSkinId() 的随机后缀分支保证，不受影响。
-            this.putString(skin.getFullSkinId());
+            // FAPIXEL fap4/fap5：V860 的 fullSkinId 按"稳定键"与否分流（fap1 全稳定、fap3 全随机，各造成一轮回归）。
+            // - 显式设置的稳定键（客户端登录/换肤包解析，或插件 setFullSkinId）以及 persona 皮肤
+            //   （商城皮肤以 persona 标记重建）→ 原样下发：观察者客户端按 fullSkinId 建档/缓存，
+            //   随机化会让档案匹配永远失败 → 先史蒂夫后整体隐形（09-07 fap3 实测）。
+            // - 其余服务端皮肤（RsNPC 对同名皮肤共享同一 Skin 实例且从不 setFullSkinId）→ 每次发包
+            //   随机化：稳定且多实体共享会让网易档案匹配挂起/负缓存 → NPC 整体隐形或回退史蒂夫
+            //   （09-07 fap1 实测）。随机让档案查找确定性失败，客户端转而直接渲染包内皮肤字节。
+            // - fap5：网易自带默认皮肤（{uuid}.Steve/.Alex、Standard_Custom）即使来源稳定键也随机化——
+            //   V860 对 .Steve 走验证必拒，稳定下发导致玩家自视隐形（09-07 fap4 实测）；随机化恢复
+            //   fap6~fap15 时代自视包直接渲染字节的已验证行为。
+            boolean stableSkinId = gameVersion != GameVersion.V1_21_124_NETEASE
+                    || skin.isPersona()
+                    || (skin.isFullSkinIdStable()
+                            && !Skin.isNetEaseBuiltinDefaultSkinId(skin.getSkinId()));
+            this.putString(stableSkinId
+                    ? skin.getFullSkinId()
+                    : skin.getFullSkinId() + UUID.randomUUID().toString().substring(0, 8));
             if (protocol >= ProtocolInfo.v1_14_60) {
                 boolean v2168 = protocol >= ProtocolInfo.v1_26_40;
                 if (v2168) {

--- a/src/main/java/cn/nukkit/utils/BinaryStream.java
+++ b/src/main/java/cn/nukkit/utils/BinaryStream.java
@@ -322,20 +322,12 @@ public class BinaryStream {
         return Binary.readUUID(this.get(16));
     }
 
-    /**
-     * @deprecated use {@link #putSkin(GameVersion, Skin)} so the NetEase {@code fullSkinId}
-     * workaround is applied correctly.
-     */
     @Deprecated
     public void putSkin(Skin skin) {
         Server.mvw("BinaryStream#putSkin(Skin)");
         this.putSkin(GameVersion.getLastVersion(), skin);
     }
 
-    /**
-     * @deprecated use {@link #putSkin(GameVersion, Skin)} so the NetEase {@code fullSkinId}
-     * workaround is applied correctly.
-     */
     @Deprecated
     public void putSkin(int protocol, Skin skin) {
         this.putSkin(GameVersion.byProtocol(protocol, Server.getInstance().onlyNetEaseMode), skin);
@@ -407,23 +399,7 @@ public class BinaryStream {
                 this.putBoolean(skin.isCapeOnClassic());
             }
             this.putString(skin.getCapeId());
-            // FAPIXEL fap4/fap5：V860 的 fullSkinId 按"稳定键"与否分流（fap1 全稳定、fap3 全随机，各造成一轮回归）。
-            // - 显式设置的稳定键（客户端登录/换肤包解析，或插件 setFullSkinId）以及 persona 皮肤
-            //   （商城皮肤以 persona 标记重建）→ 原样下发：观察者客户端按 fullSkinId 建档/缓存，
-            //   随机化会让档案匹配永远失败 → 先史蒂夫后整体隐形（09-07 fap3 实测）。
-            // - 其余服务端皮肤（RsNPC 对同名皮肤共享同一 Skin 实例且从不 setFullSkinId）→ 每次发包
-            //   随机化：稳定且多实体共享会让网易档案匹配挂起/负缓存 → NPC 整体隐形或回退史蒂夫
-            //   （09-07 fap1 实测）。随机让档案查找确定性失败，客户端转而直接渲染包内皮肤字节。
-            // - fap5：网易自带默认皮肤（{uuid}.Steve/.Alex、Standard_Custom）即使来源稳定键也随机化——
-            //   V860 对 .Steve 走验证必拒，稳定下发导致玩家自视隐形（09-07 fap4 实测）；随机化恢复
-            //   fap6~fap15 时代自视包直接渲染字节的已验证行为。
-            boolean stableSkinId = gameVersion != GameVersion.V1_21_124_NETEASE
-                    || skin.isPersona()
-                    || (skin.isFullSkinIdStable()
-                            && !Skin.isNetEaseBuiltinDefaultSkinId(skin.getSkinId()));
-            this.putString(stableSkinId
-                    ? skin.getFullSkinId()
-                    : skin.getFullSkinId() + UUID.randomUUID().toString().substring(0, 8));
+            this.putString(skin.getFullSkinId());
             if (protocol >= ProtocolInfo.v1_14_60) {
                 boolean v2168 = protocol >= ProtocolInfo.v1_26_40;
                 if (v2168) {


### PR DESCRIPTION
## Symptom (NetEase China client, V860 / protocol 1.21.124-netease)

Mall-purchased 3D/4D (persona) skins rendered wrongly on other players' clients:

- fall back to a placeholder Steve first, then the whole entity turns **invisible**;
- or stay on default Steve forever and never show the real skin;
- server-side skins shared by multiple entities (RsNPC-style NPC skins) become invisible or fall back to Steve;
- the player's own self-view goes invisible, occasionally recovering in the pause menu.

## Root causes (four layers, each sufficient on its own)

1. **fullSkinId one-shot policy breaks both ways.** V860 matches mall/4D skin profiles by fullSkinId. Upstream randomized it on every send (designed for uniqueness of shared server-side skins) → real players' mall skins never match a profile → Steve placeholder first, then full invisibility. Naively making it always stable → profile matching for shared-instance server skins hangs / gets negative-cached → NPCs invisible. It has to be **routed by skin origin** (this PR's `Skin#isFullSkinIdStable`).
2. **NetEase built-in default skins always fail validation.** skinIds like `{uuid}.Steve` / `{uuid}.Alex` / `Standard_Custom`, when sent with a stable fullSkinId, are rejected by the V860 validation flow → the player's self-view goes invisible. These must be randomized so the client renders the in-packet bytes directly.
3. **A bare ADD replacing a PlayerList entry is not idempotent.** For an entry the client already holds, V860 ignores a bare ADD (no re-render); for the viewer's own entry, a bare ADD outright breaks self-rendering. REMOVE → ADD is the only safe sequence (REMOVE on a missing client entry is a harmless no-op).
4. **Late confirmations are silently dropped.** The initial handshake removes the entry via a delayed REMOVE after 5 ticks; a later ConfirmSkinPacket from the sweep then fails forever against a "entry must still exist" hard gate — silently — leaving the observer stuck on the default skin permanently.

## What the 4 commits do

| Commit | Change |
|--------|--------|
| c064d66 | Stop unconditionally randomizing fullSkinId on V860 (real mall-skin profiles can match again) |
| 2ac988a | Fix the 236 SyncSkinPacket wire format: round-1 third field is a byte array (previously written as a string → client parse failure) |
| fc087b0 | fullSkinId stable-key routing: explicitly-set ids (login / skin-change packets, plugin `setFullSkinId`) and persona skins are sent as-is; shared server skins and NetEase default skins are randomized per send. Adds `Skin#isNetEaseBuiltinDefaultSkinId` / `Skin#isFullSkinIdStable` |
| cab9f50 | PlayerEntitySkinSender: entry rebuild is an unconditional REMOVE → ADD; a successful rebuild bumps a generation that invalidates any still-scheduled raw handshake; prepareConfirmSkin takes the rebuild branch when the entry is missing; isConfirmable drops the `sentSkins` hard gate |

## Field testing

Verified end-to-end on the FAPIXEL server network (9 servers behind a WaterdogPE proxy, V860 clients): cross-server lobby/room transfers, repeated respawns, room rotation, queue teleports, and third-party minigame plugins with custom respawn flows — mall 3D/4D skins render correctly with no more invisibility or default-Steve fallback; NPC skins fine; self-view fine.

## Notes

- Changes are concentrated in `BinaryStream#putSkin` (V1_21_124_NETEASE branch), `Skin`, `PlayerEntitySkinSender`, and the SyncSkinPacket wire format; no behavior change on non-NetEase protocol paths (all routing conditions gate on `gameVersion == V1_21_124_NETEASE`).
- The 236 SyncSkinPacket change only affects a NetEase-China-specific packet; upstream can skip commit 2 if that channel does not apply.
- Happy to split commits or adjust scope — just say the word.
