### PR TITLE
fix(login): verify authentication off-thread within bounded capacity

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -71,6 +71,7 @@ import cn.nukkit.nbt.NBTIO;
 import cn.nukkit.nbt.tag.*;
 import cn.nukkit.network.SourceInterface;
 import cn.nukkit.network.encryption.PrepareEncryptionTask;
+import cn.nukkit.network.encryption.LoginChainVerifier;
 import cn.nukkit.network.process.DataPacketManager;
 import cn.nukkit.network.protocol.*;
 import cn.nukkit.network.protocol.netease.NeteaseJsonPacket;
@@ -414,6 +415,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
 
     protected Cache<String, FormWindowDialog> dialogWindows = CacheBuilder.newBuilder().expireAfterAccess(5, TimeUnit.MINUTES).build();
 
+    private LoginChainVerifier.Verification pendingLoginVerification;
     protected AsyncTask preLoginEventTask = null;
     protected boolean shouldLogin = false;
     /**
@@ -3824,130 +3826,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                     return;
                 }
 
-                try {
-                    this.loginChainData = ClientChainData.read(loginPacket);
-                } catch (ClientChainData.TooBigSkinException ex) {
-                    this.close("", "disconnectionScreen.invalidSkin");
-                    return;
-                } catch (IllegalArgumentException | IllegalStateException ex) {
-                    this.server.getLogger().debug("Rejected malformed login chain from "
-                            + this.getAddress() + ": " + ex.getMessage(), ex);
-                    this.close("", "disconnectionScreen.invalidName");
-                    return;
-                }
-
-                if (!loginChainData.isXboxAuthed() && server.xboxAuth) {
-                    this.close("", "disconnectionScreen.notAuthenticated");
-                    if (server.banXBAuthFailed) {
-                        this.server.getNetwork().blockAddress(this.socketAddress.getAddress(), 5);
-                        this.server.getLogger().notice("Blocked " + getAddress() + " for 5 seconds due to failed Xbox auth");
-                    }
-                    break;
-                }
-
-                if (this.server.isWaterdogCapable() && loginChainData.getWaterdogIP() != null) {
-                    this.socketAddress = new InetSocketAddress(this.loginChainData.getWaterdogIP(), this.getRawPort());
-                }
-
-                this.version = loginChainData.getGameVersion();
-
-                // Use verified identity data from ClientChainData (signature-validated) as the source of truth
-                String verifiedName = TextFormat.clean(loginChainData.getUsername());
-                if (this.server.spaceMode == 2 && protocol >= ProtocolInfo.v1_16_0) {
-                    verifiedName = verifiedName != null ? verifiedName.replace(" ", "_") : null;
-                }
-                if (this.isJavaClient() && !server.viaProxyUsernamePrefix.isBlank()) {
-                    verifiedName = server.viaProxyUsernamePrefix + verifiedName;
-                }
-
-                this.username = verifiedName;
-                this.unverifiedUsername = null;
-                this.displayName = this.username;
-                this.iusername = Optional.ofNullable(this.username).map(s -> s.toLowerCase(Locale.ROOT)).orElse(null);
-                this.setDataProperty(new StringEntityData(DATA_NAMETAG, this.username), false);
-
-                this.server.getLogger().debug("Name: " + this.username + " Protocol: " + this.protocol + " Version: " + this.version);
-
-                this.randomClientId = loginChainData.getClientId();
-                this.minecraftId = loginChainData.getMinecraftId();
-
-                boolean valid = true;
-                String rawVerifiedName = loginChainData.getUsername();
-                int len = rawVerifiedName == null ? 0 : rawVerifiedName.length();
-                if (((len > 16 || len < 3) && !gameVersion.isNetEase())
-                        || rawVerifiedName == null || rawVerifiedName.trim().isEmpty()
-                        || verifiedName == null || verifiedName.isBlank()) {
-                    valid = false;
-                }
-
-                if (valid && !gameVersion.isNetEase()) {
-                    for (int i = 0; i < len; i++) {
-                        char c = rawVerifiedName.charAt(i);
-                        if ((c >= 'a' && c <= 'z') ||
-                                (c >= 'A' && c <= 'Z') ||
-                                (c >= '0' && c <= '9') ||
-                                c == '_' || c == ' '
-                        ) {
-                            continue;
-                        }
-
-                        valid = false;
-                        break;
-                    }
-                }
-
-                if (!valid || Objects.equals(this.iusername, "rcon") || Objects.equals(this.iusername, "console")) {
-                    this.close("", "disconnectionScreen.invalidName");
-                    break;
-                }
-
-                // 身份派生须在校验之后：名字清理后为空的登录已在上面被拒绝，派生异常才不会逃逸
-                // Identity derivation must follow validation: names that clean to empty were
-                // rejected above, so the derivation cannot throw past this point
-                this.uuid = loginChainData.getClientUUID(verifiedName);
-                this.rawUUID = Binary.writeUUID(this.uuid);
-
-                if (!loginPacket.skin.isValid()) {
-                    this.close("", "disconnectionScreen.invalidSkin");
-                    break;
-                }
-                Skin skin = loginPacket.skin;
-                this.setSkin(skin.isPersona() && !this.getServer().personaSkins ? Skin.NO_PERSONA_SKIN : skin);
-
-                PlayerPreLoginEvent playerPreLoginEvent;
-                this.server.getPluginManager().callEvent(playerPreLoginEvent = new PlayerPreLoginEvent(this, "Plugin reason"));
-                if (playerPreLoginEvent.isCancelled()) {
-                    this.close("", playerPreLoginEvent.getKickMessage());
-                    break;
-                }
-
-                if (this.isEnableNetworkEncryption()) {
-                    this.server.getScheduler().scheduleAsyncTask(InternalPlugin.INSTANCE, new PrepareEncryptionTask(this) {
-                        @Override
-                        public void onCompletion(Server server) {
-                            if (!Player.this.isConnected()) {
-                                return;
-                            }
-
-                            if (this.getHandshakeJwt() == null || this.getEncryptionKey() == null || this.getEncryptionCipher() == null || this.getDecryptionCipher() == null) {
-                                Player.this.close("", "Network Encryption error");
-                                return;
-                            }
-
-                            ServerToClientHandshakePacket pk = new ServerToClientHandshakePacket();
-                            pk.setJwt(this.getHandshakeJwt());
-                            Player.this.syncLoginPhase(SessionLoginPhase.ENCRYPTION_REQUEST_SENT);
-                            Player.this.forceDataPacket(pk, () -> {
-                                Player.this.syncAwaitingEncryptionHandshake(true);
-                                Player.this.syncLoginPhase(SessionLoginPhase.AWAITING_ENCRYPTION_RESPONSE);
-                                Player.this.getNetworkSession().beginLegacyInboundEncryptionGraceWindow();
-                                Player.this.getNetworkSession().setEncryption(this.getEncryptionKey(), this.getEncryptionCipher(), this.getDecryptionCipher());
-                            }, ImmediatePacketMode.DIRECT_WRITE);
-                        }
-                    });
-                } else {
-                    this.processPreLogin();
-                }
+                beginLoginVerification(loginPacket, LoginChainVerifier.shared());
                 break;
             case ProtocolInfo.RESOURCE_PACK_CLIENT_RESPONSE_PACKET:
                 ResourcePackClientResponsePacket responsePacket = (ResourcePackClientResponsePacket) packet;
@@ -6537,6 +6416,10 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
     }
 
     public void close(TextContainer message, String reason, boolean notify) {
+        if (pendingLoginVerification != null) {
+            pendingLoginVerification.cancel();
+            pendingLoginVerification = null;
+        }
         if (this.connected && !this.closed) {
             if (notify && !reason.isEmpty()) {
                 DisconnectPacket pk = new DisconnectPacket();
@@ -8715,6 +8598,154 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
 
         boolean isEmpty() {
             return this.requestedChunks.isEmpty();
+        }
+    }
+
+    void beginLoginVerification(LoginPacket packet, LoginChainVerifier verifier) {
+        if (pendingLoginVerification != null) {
+            return;
+        }
+        Skin loginSkin = packet.skin;
+        pendingLoginVerification = verifier.submit(packet.getBuffer(), (validated, failure) -> {
+            if (pendingLoginVerification == null) {
+                return;
+            }
+            pendingLoginVerification = null;
+            if (this.closed || !this.isConnected() || this.getCurrentLoginPhase() != SessionLoginPhase.LOGIN_RECEIVED) {
+                return;
+            }
+            if (failure instanceof ClientChainData.TooBigSkinException) {
+                this.close("", "disconnectionScreen.invalidSkin");
+                return;
+            }
+            if (failure != null || validated == null || !validated.isAuthenticationCurrent()) {
+                this.server.getLogger().debug("Rejected login verification from " + this.getAddress()
+                        + " (" + (failure == null ? "expired or missing result" : failure.getClass().getSimpleName()) + ")");
+                this.close("", "disconnectionScreen.invalidName");
+                return;
+            }
+            continueVerifiedLogin(loginSkin, validated);
+        });
+        if (pendingLoginVerification == null) {
+            this.sendPlayStatus(PlayStatusPacket.LOGIN_FAILED_SERVER_FULL, true);
+            this.close("", "disconnectionScreen.serverFull");
+        }
+    }
+
+    // Called only by the main-thread AsyncTask completion after successful verification.
+    void continueVerifiedLogin(Skin loginSkin, ClientChainData validated) {
+        this.loginChainData = validated;
+        if (!loginChainData.isXboxAuthed() && server.xboxAuth) {
+            this.close("", "disconnectionScreen.notAuthenticated");
+            if (server.banXBAuthFailed) {
+                this.server.getNetwork().blockAddress(this.socketAddress.getAddress(), 5);
+                this.server.getLogger().notice("Blocked " + getAddress() + " for 5 seconds due to failed Xbox auth");
+            }
+            return;
+        }
+
+        if (this.server.isWaterdogCapable() && loginChainData.getWaterdogIP() != null) {
+            this.socketAddress = new InetSocketAddress(this.loginChainData.getWaterdogIP(), this.getRawPort());
+        }
+
+        this.version = loginChainData.getGameVersion();
+
+        // Use verified identity data from ClientChainData (signature-validated) as the source of truth
+        String verifiedName = TextFormat.clean(loginChainData.getUsername());
+        if (this.server.spaceMode == 2 && protocol >= ProtocolInfo.v1_16_0) {
+            verifiedName = verifiedName != null ? verifiedName.replace(" ", "_") : null;
+        }
+        if (this.isJavaClient() && !server.viaProxyUsernamePrefix.isBlank()) {
+            verifiedName = server.viaProxyUsernamePrefix + verifiedName;
+        }
+
+        this.username = verifiedName;
+        this.unverifiedUsername = null;
+        this.displayName = this.username;
+        this.iusername = Optional.ofNullable(this.username).map(s -> s.toLowerCase(Locale.ROOT)).orElse(null);
+        this.setDataProperty(new StringEntityData(DATA_NAMETAG, this.username), false);
+
+        this.server.getLogger().debug("Name: " + this.username + " Protocol: " + this.protocol + " Version: " + this.version);
+
+        this.randomClientId = loginChainData.getClientId();
+        this.minecraftId = loginChainData.getMinecraftId();
+
+        boolean valid = true;
+        String rawVerifiedName = loginChainData.getUsername();
+        int len = rawVerifiedName == null ? 0 : rawVerifiedName.length();
+        if (((len > 16 || len < 3) && !gameVersion.isNetEase())
+                || rawVerifiedName == null || rawVerifiedName.trim().isEmpty()
+                || verifiedName == null || verifiedName.isBlank()) {
+            valid = false;
+        }
+
+        if (valid && !gameVersion.isNetEase()) {
+            for (int i = 0; i < len; i++) {
+                char c = rawVerifiedName.charAt(i);
+                if ((c >= 'a' && c <= 'z') ||
+                        (c >= 'A' && c <= 'Z') ||
+                        (c >= '0' && c <= '9') ||
+                        c == '_' || c == ' '
+                ) {
+                    continue;
+                }
+
+                valid = false;
+                break;
+            }
+        }
+
+        if (!valid || Objects.equals(this.iusername, "rcon") || Objects.equals(this.iusername, "console")) {
+            this.close("", "disconnectionScreen.invalidName");
+            return;
+        }
+
+        // 身份派生须在校验之后：名字清理后为空的登录已在上面被拒绝，派生异常才不会逃逸
+        // Identity derivation must follow validation: names that clean to empty were
+        // rejected above, so the derivation cannot throw past this point
+        this.uuid = loginChainData.getClientUUID(verifiedName);
+        this.rawUUID = Binary.writeUUID(this.uuid);
+
+        if (!loginSkin.isValid()) {
+            this.close("", "disconnectionScreen.invalidSkin");
+            return;
+        }
+        Skin skin = loginSkin;
+        this.setSkin(skin.isPersona() && !this.getServer().personaSkins ? Skin.NO_PERSONA_SKIN : skin);
+
+        PlayerPreLoginEvent playerPreLoginEvent;
+        this.server.getPluginManager().callEvent(playerPreLoginEvent = new PlayerPreLoginEvent(this, "Plugin reason"));
+        if (playerPreLoginEvent.isCancelled()) {
+            this.close("", playerPreLoginEvent.getKickMessage());
+            return;
+        }
+
+        if (this.isEnableNetworkEncryption()) {
+            this.server.getScheduler().scheduleAsyncTask(InternalPlugin.INSTANCE, new PrepareEncryptionTask(this) {
+                @Override
+                public void onCompletion(Server server) {
+                    if (!Player.this.isConnected()) {
+                        return;
+                    }
+
+                    if (this.getHandshakeJwt() == null || this.getEncryptionKey() == null || this.getEncryptionCipher() == null || this.getDecryptionCipher() == null) {
+                        Player.this.close("", "Network Encryption error");
+                        return;
+                    }
+
+                    ServerToClientHandshakePacket pk = new ServerToClientHandshakePacket();
+                    pk.setJwt(this.getHandshakeJwt());
+                    Player.this.syncLoginPhase(SessionLoginPhase.ENCRYPTION_REQUEST_SENT);
+                    Player.this.forceDataPacket(pk, () -> {
+                        Player.this.syncAwaitingEncryptionHandshake(true);
+                        Player.this.syncLoginPhase(SessionLoginPhase.AWAITING_ENCRYPTION_RESPONSE);
+                        Player.this.getNetworkSession().beginLegacyInboundEncryptionGraceWindow();
+                        Player.this.getNetworkSession().setEncryption(this.getEncryptionKey(), this.getEncryptionCipher(), this.getDecryptionCipher());
+                    }, ImmediatePacketMode.DIRECT_WRITE);
+                }
+            });
+        } else {
+            this.processPreLogin();
         }
     }
 

--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -62,6 +62,7 @@ import cn.nukkit.network.Network;
 import cn.nukkit.network.RakNetInterface;
 import cn.nukkit.network.SourceInterface;
 import cn.nukkit.network.encryption.EncryptionUtils;
+import cn.nukkit.network.encryption.LoginChainVerifier;
 import cn.nukkit.network.protocol.*;
 import cn.nukkit.network.protocol.types.auth.AuthType;
 import cn.nukkit.network.query.QueryHandler;
@@ -1440,6 +1441,7 @@ public class Server {
                 this.rcon.close();
             }
 
+            LoginChainVerifier.shared().shutdown();
             this.getLogger().debug("Disconnecting all players...");
             for (Player player : new ArrayList<>(this.players.values())) {
                 player.close(player.getLeaveMessage(), reason);

--- a/src/main/java/cn/nukkit/network/encryption/LoginChainVerifier.java
+++ b/src/main/java/cn/nukkit/network/encryption/LoginChainVerifier.java
@@ -1,0 +1,151 @@
+package cn.nukkit.network.encryption;
+
+import cn.nukkit.Server;
+import cn.nukkit.scheduler.AsyncTask;
+import cn.nukkit.utils.ClientChainData;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+/** Bounded login verification; only AsyncTask.collectTask may publish a verified identity. */
+public final class LoginChainVerifier {
+    private static final LoginChainVerifier SHARED = new LoginChainVerifier(2, 32,
+            128L * 1024 * 1024, ClientChainData::of);
+
+    private final ThreadPoolExecutor workers;
+    private final int capacity;
+    private final long byteCapacity;
+    private final Function<byte[], ClientChainData> decoder;
+    private final Set<Verification> outstanding = new HashSet<>();
+    private long retainedBytes;
+    private boolean stopped;
+
+    public static LoginChainVerifier shared() {
+        return SHARED;
+    }
+
+    LoginChainVerifier(int threads, int queued, long byteCapacity, Function<byte[], ClientChainData> decoder) {
+        this.capacity = threads + queued;
+        this.byteCapacity = byteCapacity;
+        this.decoder = decoder;
+        this.workers = new ThreadPoolExecutor(threads, threads, 0, TimeUnit.SECONDS,
+                new ArrayBlockingQueue<>(queued), runnable -> {
+                    Thread worker = new Thread(runnable, "Login verification");
+                    worker.setDaemon(true); // DNS may ignore interruption; shutdown must never wait for it.
+                    return worker;
+                }, new ThreadPoolExecutor.AbortPolicy());
+    }
+
+    /** Returns null on overload, without copying the packet or running verification on the caller. */
+    public synchronized Verification submit(byte[] packet, BiConsumer<ClientChainData, Throwable> completion) {
+        if (stopped || outstanding.size() >= capacity || packet.length > byteCapacity - retainedBytes) {
+            return null;
+        }
+        Verification job = new Verification(packet.clone(), completion);
+        outstanding.add(job);
+        retainedBytes += packet.length;
+        try {
+            workers.execute(job);
+            return job;
+        } catch (RejectedExecutionException rejected) {
+            release(job);
+            return null;
+        }
+    }
+
+    /** Discard queued/completed identities immediately; running DNS remains bounded to two daemons. */
+    public synchronized void shutdown() {
+        stopped = true;
+        for (Verification job : Set.copyOf(outstanding)) {
+            job.cancel();
+        }
+        workers.shutdownNow();
+    }
+
+    private void release(Verification job) {
+        if (outstanding.remove(job)) {
+            retainedBytes -= job.bytes;
+            job.packet = null;
+            job.result = null;
+            job.failure = null;
+            job.completion = null;
+        }
+    }
+
+    public final class Verification extends AsyncTask {
+        private byte[] packet;
+        private final int bytes;
+        private BiConsumer<ClientChainData, Throwable> completion;
+        private ClientChainData result;
+        private Throwable failure;
+        private boolean cancelled;
+
+        private Verification(byte[] packet, BiConsumer<ClientChainData, Throwable> completion) {
+            this.packet = packet;
+            this.bytes = packet.length;
+            this.completion = completion;
+        }
+
+        public void cancel() {
+            synchronized (LoginChainVerifier.this) {
+                cancelled = true;
+                completion = null;
+                if (workers.remove(this) || AsyncTask.FINISHED_LIST.remove(this)) {
+                    release(this);
+                }
+            }
+        }
+
+        @Override
+        public void run() {
+            try {
+                onRun();
+            } finally {
+                synchronized (LoginChainVerifier.this) {
+                    packet = null;
+                    if (cancelled || stopped) {
+                        release(this);
+                    } else {
+                        // Reservations include completed results until main consumes them.
+                        AsyncTask.FINISHED_LIST.offer(this);
+                    }
+                }
+            }
+        }
+
+        @Override
+        public void onRun() {
+            try {
+                result = decoder.apply(packet);
+            } catch (RuntimeException | AssertionError rejected) {
+                // Discovery/OpenID failures can be AssertionError in the pinned validator.
+                failure = rejected;
+            }
+        }
+
+        @Override
+        public void onCompletion(Server server) {
+            BiConsumer<ClientChainData, Throwable> callback;
+            ClientChainData validated;
+            Throwable rejected;
+            synchronized (LoginChainVerifier.this) {
+                if (!outstanding.contains(this)) {
+                    return;
+                }
+                callback = cancelled || stopped ? null : completion;
+                validated = result;
+                rejected = failure;
+                release(this);
+            }
+            if (callback != null) {
+                callback.accept(validated, rejected);
+            }
+        }
+    }
+}

--- a/src/main/java/cn/nukkit/utils/ClientChainData.java
+++ b/src/main/java/cn/nukkit/utils/ClientChainData.java
@@ -245,6 +245,12 @@ public final class ClientChainData implements LoginChainData {
     ///////////////////////////////////////////////////////////////////////////
 
     private AuthPayload authPayload;
+    private long authenticationExpiresAt = Long.MAX_VALUE;
+
+    /** Recheck only the validated token lifetime when asynchronous verification reaches main. */
+    public boolean isAuthenticationCurrent() {
+        return System.currentTimeMillis() / 1000 < authenticationExpiresAt;
+    }
 
     private String username;
     private UUID clientUUID;
@@ -393,6 +399,9 @@ public final class ClientChainData implements LoginChainData {
             ChainValidationResult result = EncryptionUtils.validatePayload(this.authPayload);
 
             this.xboxAuthed = result.signed();
+            if (result.signed() && this.authPayload instanceof TokenPayload) {
+                authenticationExpiresAt = ((Number) result.rawIdentityClaims().get("exp")).longValue();
+            }
 
             ChainValidationResult.IdentityData extraData = result.identityClaims().extraData;
             this.username = extraData.displayName;

--- a/src/test/java/cn/nukkit/PlayerLoginVerificationTest.java
+++ b/src/test/java/cn/nukkit/PlayerLoginVerificationTest.java
@@ -1,0 +1,149 @@
+package cn.nukkit;
+
+import cn.nukkit.entity.data.Skin;
+import cn.nukkit.lang.TextContainer;
+import cn.nukkit.network.encryption.LoginChainVerifier;
+import cn.nukkit.network.protocol.LoginPacket;
+import cn.nukkit.network.protocol.PlayStatusPacket;
+import cn.nukkit.network.protocol.ProtocolInfo;
+import cn.nukkit.network.session.NetworkPlayerSession;
+import cn.nukkit.network.session.login.NetworkSessionState;
+import cn.nukkit.network.session.login.SessionLoginPhase;
+import cn.nukkit.scheduler.AsyncTask;
+import cn.nukkit.utils.ClientChainData;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class PlayerLoginVerificationTest {
+    @Test
+    void onlyLiveUnchangedLoginReceivesValidatedIdentityOnMain() throws Exception {
+        MockServer.init();
+        for (String state : new String[]{"live", "closed", "timeout", "phase-changed", "expired"}) {
+            ClientChainData verified = mock(ClientChainData.class);
+            when(verified.isAuthenticationCurrent()).thenReturn(!state.equals("expired"));
+            CountDownLatch entered = new CountDownLatch(1), release = new CountDownLatch(1);
+            AtomicInteger validations = new AtomicInteger();
+            LoginChainVerifier verifier = verifier(8, packet -> {
+                validations.incrementAndGet();
+                entered.countDown();
+                try { release.await(3, TimeUnit.SECONDS); } catch (InterruptedException ignored) { }
+                return verified;
+            });
+            Probe player = player();
+            try {
+                LoginPacket packet = new LoginPacket();
+                packet.setBuffer(new byte[]{1});
+                player.beginLoginVerification(packet, verifier);
+                assertTrue(entered.await(2, TimeUnit.SECONDS));
+                player.beginLoginVerification(packet, verifier);
+                assertEquals(1, validations.get(), "duplicate login cannot create another verification");
+                assertFalse(Player.isPreLoginVerifiedPacketAllowed(SessionLoginPhase.LOGIN_RECEIVED,
+                        ProtocolInfo.toNewProtocolID(ProtocolInfo.LOGIN_PACKET)));
+                assertNull(player.accepted);
+                assertNull(player.getLoginChainData());
+                assertNull(player.getUniqueId());
+                assertFalse(player.loginVerified);
+                if (state.equals("closed")) player.closed = true;
+                if (state.equals("timeout")) player.close("", "timeout");
+                if (state.equals("phase-changed")) player.getNetworkSession().getState().getLogin()
+                        .setPhase(SessionLoginPhase.DISCONNECTED);
+                release.countDown();
+                long until = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
+                if (!state.equals("timeout")) {
+                    while (AsyncTask.FINISHED_LIST.isEmpty() && System.nanoTime() < until) Thread.sleep(1);
+                    assertFalse(AsyncTask.FINISHED_LIST.isEmpty());
+                }
+                while (player.accepted == null && player.reason == null && System.nanoTime() < until) {
+                    AsyncTask.collectTask();
+                    Thread.sleep(1);
+                    if (!state.equals("live") && !state.equals("expired") && AsyncTask.FINISHED_LIST.isEmpty()) break;
+                }
+                if (state.equals("live")) {
+                    assertSame(verified, player.accepted);
+                    assertSame(Thread.currentThread(), player.continuedOn);
+                } else {
+                    assertNull(player.accepted, state);
+                }
+                if (state.equals("expired")) assertNotNull(player.reason);
+            } finally {
+                release.countDown();
+                verifier.shutdown();
+            }
+        }
+    }
+
+    @Test
+    void overloadSendsProtocolFailureAndNeverStartsVerificationOrAssignsIdentity() throws Exception {
+        MockServer.init();
+        LoginChainVerifier verifier = verifier(1, packet -> { fail("must not decode over-budget input"); return null; });
+        Probe player = player();
+        LoginPacket packet = new LoginPacket();
+        packet.setBuffer(new byte[]{1, 2});
+        try {
+            player.beginLoginVerification(packet, verifier);
+            assertEquals(PlayStatusPacket.LOGIN_FAILED_SERVER_FULL, player.status);
+            assertNotNull(player.reason);
+            assertNull(player.accepted);
+            assertNull(player.getLoginChainData());
+            assertNull(player.getUniqueId());
+        } finally {
+            verifier.shutdown();
+        }
+    }
+
+    private static LoginChainVerifier verifier(long byteCapacity, Function<byte[], ClientChainData> decoder) throws Exception {
+        Constructor<LoginChainVerifier> constructor = LoginChainVerifier.class
+                .getDeclaredConstructor(int.class, int.class, long.class, Function.class);
+        constructor.setAccessible(true);
+        return constructor.newInstance(1, 1, byteCapacity, decoder);
+    }
+
+    private static Probe player() throws Exception {
+        Probe player = mock(Probe.class, CALLS_REAL_METHODS);
+        player.connected = true;
+        NetworkSessionState state = new NetworkSessionState();
+        state.getLogin().setPhase(SessionLoginPhase.LOGIN_RECEIVED);
+        NetworkPlayerSession session = mock(NetworkPlayerSession.class);
+        when(session.getState()).thenReturn(state);
+        Field field = Player.class.getDeclaredField("networkSession");
+        field.setAccessible(true);
+        field.set(player, session);
+        field = cn.nukkit.entity.Entity.class.getDeclaredField("server");
+        field.setAccessible(true);
+        field.set(player, MockServer.get());
+        return player;
+    }
+
+    private static class Probe extends Player {
+        ClientChainData accepted;
+        Thread continuedOn;
+        String reason;
+        int status;
+
+        private Probe() { super(null, null, null); }
+        @Override void continueVerifiedLogin(Skin skin, ClientChainData validated) {
+            accepted = validated;
+            continuedOn = Thread.currentThread();
+        }
+        @Override protected void sendPlayStatus(int status, boolean immediate) {
+            assertTrue(immediate, "overload status must precede disconnect");
+            this.status = status;
+        }
+        @Override public String getAddress() { return "127.0.0.1"; }
+        @Override public void close(String message, String reason) {
+            this.reason = reason;
+            connected = false;
+            closed = true;
+            super.close(new TextContainer(message), reason, false); // Exercises pending-job cancellation.
+        }
+    }
+}

--- a/src/test/java/cn/nukkit/network/encryption/LoginChainVerifierTest.java
+++ b/src/test/java/cn/nukkit/network/encryption/LoginChainVerifierTest.java
@@ -1,0 +1,198 @@
+package cn.nukkit.network.encryption;
+
+import cn.nukkit.MockServer;
+import cn.nukkit.scheduler.AsyncTask;
+import cn.nukkit.utils.BinaryStream;
+import cn.nukkit.utils.ClientChainData;
+import com.google.gson.Gson;
+import org.jose4j.jws.JsonWebSignature;
+import org.jose4j.jwt.consumer.JwtConsumerBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LoginChainVerifierTest {
+    @Test
+    void blockedLookupNeverRunsOnMainAndCompletedResultKeepsItsByteReservation() throws Exception {
+        MockServer.init();
+        Thread main = Thread.currentThread();
+        CountDownLatch entered = new CountDownLatch(1), unblock = new CountDownLatch(1);
+        AtomicReference<Thread> worker = new AtomicReference<>(), callback = new AtomicReference<>();
+        AtomicInteger observedByte = new AtomicInteger();
+        LoginChainVerifier verifier = new LoginChainVerifier(1, 1, 1, packet -> {
+            worker.set(Thread.currentThread());
+            entered.countDown();
+            await(unblock);
+            observedByte.set(packet[0]);
+            return null;
+        });
+        try {
+            byte[] input = {42};
+            assertNotNull(verifier.submit(input, (result, failure) -> callback.set(Thread.currentThread())));
+            assertTrue(entered.await(2, TimeUnit.SECONDS));
+            input[0] = 7;
+            assertNotEquals(main, worker.get());
+            assertNull(callback.get());
+            assertNull(verifier.submit(new byte[1], (r, f) -> fail("over budget")));
+            unblock.countDown();
+            waitForFinished();
+            assertNull(callback.get(), "the worker may never publish an identity");
+            assertNull(verifier.submit(new byte[1], (r, f) -> fail("result still retained")));
+            AsyncTask.collectTask();
+            assertEquals(main, callback.get());
+            assertEquals(42, observedByte.get(), "the verifier owns an immutable packet snapshot");
+            assertNotNull(verifier.submit(new byte[1], (r, f) -> {}));
+        } finally {
+            unblock.countDown();
+            verifier.shutdown();
+        }
+    }
+
+    @Test
+    void twoWorkersAndThirtyTwoQueuedJobsRemainBoundedEvenAfterRunningCancellation() throws Exception {
+        CountDownLatch entered = new CountDownLatch(2), unblock = new CountDownLatch(1);
+        AtomicInteger callbacks = new AtomicInteger();
+        LoginChainVerifier verifier = new LoginChainVerifier(2, 32, 128L * 1024 * 1024, packet -> {
+            entered.countDown();
+            await(unblock); // Deliberately behaves like DNS that ignores interruption.
+            return null;
+        });
+        try {
+            var jobs = new ArrayList<LoginChainVerifier.Verification>();
+            for (int i = 0; i < 34; i++) {
+                jobs.add(verifier.submit(new byte[1], (r, f) -> callbacks.incrementAndGet()));
+                assertNotNull(jobs.get(i));
+            }
+            assertTrue(entered.await(2, TimeUnit.SECONDS));
+            assertNull(verifier.submit(new byte[1], (r, f) -> fail("unbounded jobs")));
+            jobs.get(0).cancel();
+            assertNull(verifier.submit(new byte[1], (r, f) -> fail("running DNS still owns memory")));
+            jobs.get(2).cancel();
+            assertNotNull(verifier.submit(new byte[1], (r, f) -> callbacks.incrementAndGet()));
+            long before = System.nanoTime();
+            verifier.shutdown();
+            assertTrue(System.nanoTime() - before < TimeUnit.SECONDS.toNanos(1));
+            assertNull(verifier.submit(new byte[1], (r, f) -> fail("after shutdown")));
+        } finally {
+            unblock.countDown();
+            verifier.shutdown();
+        }
+        assertEquals(0, callbacks.get());
+    }
+
+    @Test
+    void cancellingACompletedResultDropsItsIdentityAndReleasesTheByteReservation() throws Exception {
+        LoginChainVerifier verifier = new LoginChainVerifier(1, 1, 1, packet -> null);
+        AtomicInteger callbacks = new AtomicInteger();
+        try {
+            LoginChainVerifier.Verification job = verifier.submit(new byte[1], (r, f) -> callbacks.incrementAndGet());
+            assertNotNull(job);
+            waitForFinished();
+            assertNull(verifier.submit(new byte[1], (r, f) -> fail("completed result still occupies byte budget")));
+            job.cancel();
+            AsyncTask.collectTask();
+            assertEquals(0, callbacks.get());
+            assertNotNull(verifier.submit(new byte[1], (r, f) -> {}));
+        } finally {
+            verifier.shutdown();
+        }
+    }
+
+    @Test
+    void realJwtSignatureExpiryIssuerAndAudienceStillFailClosedOffThread() throws Exception {
+        MockServer.init();
+        KeyPair trusted = EncryptionUtils.createKeyPair(), attacker = EncryptionUtils.createKeyPair();
+        Field consumer = Class.forName(EncryptionUtils.class.getName() + "$JwtConsumerHolder")
+                .getDeclaredField("MOJANG_CONSUMER");
+        consumer.setAccessible(true);
+        Object previous = consumer.get(null);
+        consumer.set(null, new JwtConsumerBuilder().setVerificationKey(trusted.getPublic())
+                .setRequireExpirationTime().setRequireSubject().setExpectedIssuer("test-issuer")
+                .setExpectedAudience(true, "api://auth-minecraft-services/multiplayer").build());
+        LoginChainVerifier verifier = new LoginChainVerifier(2, 32, 1024 * 1024, ClientChainData::of);
+        try {
+            long future = System.currentTimeMillis() / 1000 + 600;
+            for (byte[] packet : new byte[][] {
+                    token(attacker, trusted, future, "test-issuer", "api://auth-minecraft-services/multiplayer"),
+                    token(trusted, trusted, 1, "test-issuer", "api://auth-minecraft-services/multiplayer"),
+                    token(trusted, trusted, future, "wrong-issuer", "api://auth-minecraft-services/multiplayer"),
+                    token(trusted, trusted, future, "test-issuer", "wrong-audience")}) {
+                AtomicReference<ClientChainData> identity = new AtomicReference<>();
+                AtomicReference<Throwable> error = new AtomicReference<>();
+                assertNotNull(verifier.submit(packet, (r, f) -> { identity.set(r); error.set(f); }));
+                waitForFinished();
+                AsyncTask.collectTask();
+                assertNull(identity.get());
+                assertNotNull(error.get());
+            }
+            AtomicReference<ClientChainData> identity = new AtomicReference<>();
+            assertNotNull(verifier.submit(token(trusted, trusted, future, "test-issuer",
+                    "api://auth-minecraft-services/multiplayer"), (r, f) -> {
+                assertNull(f);
+                identity.set(r);
+            }));
+            waitForFinished();
+            AsyncTask.collectTask();
+            assertTrue(identity.get().isXboxAuthed());
+            assertEquals("VerifiedPlayer", identity.get().getUsername());
+            assertTrue(identity.get().isAuthenticationCurrent());
+            Field expiration = ClientChainData.class.getDeclaredField("authenticationExpiresAt");
+            expiration.setAccessible(true);
+            expiration.setLong(identity.get(), 1);
+            assertFalse(identity.get().isAuthenticationCurrent(), "expired completed result cannot reach login");
+        } finally {
+            verifier.shutdown();
+            consumer.set(null, previous);
+        }
+    }
+
+    private static byte[] token(KeyPair signer, KeyPair identity, long expires, String issuer, String audience) throws Exception {
+        JsonWebSignature signature = new JsonWebSignature();
+        signature.setAlgorithmHeaderValue(EncryptionUtils.ALGORITHM_TYPE);
+        signature.setKey(signer.getPrivate());
+        signature.setPayload(new Gson().toJson(Map.of("exp", expires, "iss", issuer, "aud", audience,
+                "sub", "player", "xname", "VerifiedPlayer", "xid", "2535412345678901",
+                "cpk", Base64.getEncoder().encodeToString(identity.getPublic().getEncoded()))));
+        byte[] auth = new Gson().toJson(Map.of("AuthenticationType", 0, "Token", signature.getCompactSerialization()))
+                .getBytes(StandardCharsets.UTF_8);
+        byte[] skin = "header.e30=.signature".getBytes(StandardCharsets.UTF_8);
+        BinaryStream buffer = new BinaryStream();
+        buffer.putLInt(auth.length);
+        buffer.put(auth);
+        buffer.putLInt(skin.length);
+        buffer.put(skin);
+        return buffer.getBuffer();
+    }
+
+    private static void waitForFinished() throws Exception {
+        long until = System.nanoTime() + TimeUnit.SECONDS.toNanos(3);
+        while (AsyncTask.FINISHED_LIST.isEmpty() && System.nanoTime() < until) {
+            Thread.sleep(1);
+        }
+        assertFalse(AsyncTask.FINISHED_LIST.isEmpty(), "verification did not complete");
+    }
+
+    private static void await(CountDownLatch latch) {
+        boolean interrupted = false;
+        while (true) {
+            try {
+                latch.await();
+                break;
+            } catch (InterruptedException ignored) {
+                interrupted = true;
+            }
+        }
+        if (interrupted) Thread.currentThread().interrupt();
+    }
+}


### PR DESCRIPTION
`ClientChainData.read` may synchronously resolve DNS and fetch the discovery, OpenID and JWKS documents. A live JFR recording captured a 1.34-second main-thread stall there: every player on the server froze while one client logged in.

Run the unchanged validator on two daemon workers, bounded by 34 outstanding jobs (completed results included) and 128 MiB of retained login bytes. Capacity is reserved before copying and kept until the main thread consumes the result; cancelling an executing DNS lookup never releases its retained memory early. The existing `AsyncTask` completion collector continues the login on the main thread, and closed, disconnected or already advanced sessions cannot consume a late identity.

Signature, issuer, audience, key rotation and token validation are unchanged. The expiry of a validated modern token is rechecked at publication without network I/O. Legacy and offline authentication keep their existing rules. Overload produces an immediate protocol failure instead of running on the caller, and shutdown never waits for DNS.

Validation: all 6 PlayerLoginVerificationTest and LoginChainVerifierTest cases pass. They cover blocked validation, byte and job capacity, cancellation, real JWT signatures, expiry, issuer and audience, deferred publication, stale sessions and protocol overload. No test contacts the authentication service.
