### PR TITLE
fix(block): restore the vanilla blast resistance of shulker boxes

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockShulkerBox.java
+++ b/src/main/java/cn/nukkit/block/BlockShulkerBox.java
@@ -64,7 +64,10 @@ public class BlockShulkerBox extends BlockTransparentMeta implements BlockEntity
 
     @Override
     public double getResistance() {
-        return 30;
+        // Bedrock blast resistance of a shulker box is 2, the same as its hardness.
+        // Nukkit stores five times that value, so 30 made the box three times tougher
+        // than vanilla and let it survive TNT blasts that flattened the stone around it.
+        return 10;
     }
 
     @Override

--- a/src/test/java/cn/nukkit/block/BlockShulkerBoxBlastResistanceTest.java
+++ b/src/test/java/cn/nukkit/block/BlockShulkerBoxBlastResistanceTest.java
@@ -1,0 +1,47 @@
+package cn.nukkit.block;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A shulker box must be as fragile against explosions as vanilla Bedrock makes it.
+ *
+ * <p>Nukkit keeps five times the vanilla blast resistance, and {@link cn.nukkit.level.Explosion}
+ * divides by five again while tracing a ray. A stored 30 therefore meant a blast resistance of 6
+ * instead of the vanilla 2: TNT flattened the stone around the box and left the box itself intact.
+ */
+class BlockShulkerBoxBlastResistanceTest {
+
+    private static final double VANILLA_BLAST_RESISTANCE = 2d;
+    private static final double NUKKIT_SCALE = 5d;
+
+    @Test
+    void dyedAndUndyedBoxesKeepVanillaBlastResistance() {
+        assertEquals(VANILLA_BLAST_RESISTANCE * NUKKIT_SCALE,
+                new BlockShulkerBox().getResistance(),
+                1e-12,
+                "dyed shulker box blast resistance");
+        assertEquals(VANILLA_BLAST_RESISTANCE * NUKKIT_SCALE,
+                new BlockUndyedShulkerBox().getResistance(),
+                1e-12,
+                "undyed shulker box inherits the same value");
+    }
+
+    @Test
+    void boxIsNotTougherThanAChest() {
+        assertTrue(new BlockShulkerBox().getResistance() < new BlockChest().getResistance(),
+                "vanilla shulker boxes are weaker than chests, not stronger");
+    }
+
+    @Test
+    void primedTntRemovesTheBoxThroughTheExplosionFormula() {
+        // The ray in Explosion#explodeA starts at 0.7..1.3 times the blast size and pays
+        // (resistance / 5 + 0.3) * 0.3 for every step through a block.
+        double weakestRay = 4d * 0.7d;
+        double cost = (new BlockShulkerBox().getResistance() / NUKKIT_SCALE + 0.3d) * 0.3d;
+        assertTrue(weakestRay - cost > 0d,
+                "even the weakest TNT ray must break through a shulker box");
+    }
+}


### PR DESCRIPTION
Nukkit stores five times the vanilla blast resistance, and `Explosion` divides by five again while tracing a ray. `BlockShulkerBox` returned 30, which is a blast resistance of 6 instead of the vanilla Bedrock 2, so primed TNT flattened the stone around a box and left the box itself untouched.

Return 10 so dyed and undyed boxes match vanilla (and PocketMine-MP, where the shulker box break info is `pickaxe(2)` and the default blast resistance is five times the hardness). Hardness, tool type and drops are unchanged.

Validation: all 3 BlockShulkerBoxBlastResistanceTest cases pass. They cover both block classes, keep the box weaker than a chest, and walk the explosion formula for the weakest TNT ray.
